### PR TITLE
Fix headline formatting in Tutorial 13 [nfc]

### DIFF
--- a/ipython_notebooks/Tutorials/13 GST on 2 qubits.ipynb
+++ b/ipython_notebooks/Tutorials/13 GST on 2 qubits.ipynb
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Step 1: construct the desired 2-qubit gateset\n",
+    "### Step 1: Construct the desired 2-qubit gateset\n",
     "There are several ways to do this, as outlined by the comments in the cell below."
    ]
   },
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Step 2: obtain lists of fiducial and germ gate sequences\n",
+    "### Step 2: Obtain lists of fiducial and germ gate sequences\n",
     "These are the building blocks of the gate sequences performed in the experiment. Typically, these lists are either given to you by the folks at Sandia National Labs (email pygsti@sandia.gov), provided by pyGSTi because you're using a \"standard\" gate set, or computed using \"fiducial selection\" and \"germ selection\" algorithms (which are a part of pyGSTi, but not covered in this tutorial)."
    ]
   },


### PR DESCRIPTION
(Without the space, the formatting is not recognized by whatever
Markdown parser a current Jupyter 4.1.0 installation uses.)