### PR TITLE
gitignored fastopcalc.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ packages/pygsti.egg-info
 packages/pygsti/baseobjs/parsetab_string.py
 packages/pygsti/objects/fastgatecalc.cpp
 packages/pygsti/objects/fastreplib.cpp
+packages/pygsti/objects/fastopcalc.cpp
 packages/pygsti/tools/fastcalc.c
 
 


### PR DESCRIPTION
This seems to be a C extension artifact that didn't get ignored.

(It's a small change, but I made a PR because I don't know if things like this are actually bugs or intentional)