### PR TITLE
MLGST log-likelihood `_objective_func_probs` functions take vectorGS …

### DIFF
--- a/packages/pygsti/algorithms/core.py
+++ b/packages/pygsti/algorithms/core.py
@@ -2429,9 +2429,9 @@ def _do_mlgst_base(dataset, startModel, circuitsToUse,
             mdl.from_vector(vectorGS)
             mdl.bulk_fill_probs(probs, evTree, probClipInterval,
                                 check, comm)
-            return _objective_func_probs(tm)
-                        
-        def _objective_func_probs(tm):
+            return _objective_func_probs(vectorGS, tm)
+
+        def _objective_func_probs(vectorGS, tm):
             pos_probs = _np.where(probs < min_p, min_p, probs)
             S = minusCntVecMx / min_p + totalCntVec
             S2 = -0.5 * minusCntVecMx / (min_p**2)
@@ -2531,9 +2531,9 @@ def _do_mlgst_base(dataset, startModel, circuitsToUse,
             tm = _time.time()
             mdl.from_vector(vectorGS)
             mdl.bulk_fill_probs(probs, evTree, probClipInterval, check, comm)
-            return _objective_func_probs(tm)
+            return _objective_func_probs(vectorGS, tm)
 
-        def _objective_func_probs(tm):
+        def _objective_func_probs(vectorGS, tm):
             pos_probs = _np.where(probs < min_p, min_p, probs)
             S = minusCntVecMx / min_p
             S2 = -0.5 * minusCntVecMx / (min_p**2)


### PR DESCRIPTION
Pretty sure someone must have split up these functions without realizing they needed `vectorGS` in scope.

Was [causing `test.test_packages.algorithms.testCore.TestCoreMethods.test_MLGST` to fail](https://travis-ci.org/pyGSTio/pyGSTi/jobs/509630458#L804)