### PR TITLE
Moved CI runner up to xenial, python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 dist: xenial
 language: python
 
-python:
-  - "3.7"
-  - "2.7"
-  - "3.5"
+python: 3.7
 
 branches:
   only:
@@ -57,11 +54,59 @@ cache:
 
 stages:
   - test
+  # Run tests on python 2.7 & 3.5, but only on master/beta
+  - name: test-extra
+    if: branch IN (master, beta)
   - name: deploy # only run deployment for master & develop branches
     if: branch IN (master, develop)
 
 jobs:
   include:
+    # Can't use matrix expansion for included jobs or custom stages, so we'll manually list extra jobs
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="drivers objects" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="algorithms" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="algorithmsb" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="tools iotest optimize construction extras" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="report" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="reportb" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 3.5
+      env: NOSETESTS="mpi" NOSEOPTS=$NOSEOPTS_ALL
+
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="drivers objects" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="algorithms" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="algorithmsb" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="tools iotest optimize construction extras" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="report" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="reportb" NOSEOPTS=$NOSEOPTS_ALL
+    - stage: test-extra
+      python: 2.7
+      env: NOSETESTS="mpi" NOSEOPTS=$NOSEOPTS_ALL
+
     - stage: deploy
       python: 3.7
       env: NOSETESTS=none NOSEOPTS=$NOSEOPTS_DEFAULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-dist: trusty
+dist: xenial
 language: python
 
 python:
+  - "3.7"
   - "2.7"
   - "3.5"
 
@@ -10,6 +11,7 @@ branches:
     - master
     - beta
     - develop
+    - ci-fixes
 
 # Hold off testing feature & bugfix branches in case this competes w/other testing.
 #    - /^feature-.*$/
@@ -35,8 +37,7 @@ before_install:
     sudo apt-get update -qq -y &&
     sudo apt-get install -qq -y
     gfortran libblas-dev liblapack-dev openmpi-bin openmpi-common openssh-client
-    openssh-server libopenmpi1.6 libopenmpi1.6-dbg libopenmpi-dev
-    libsuitesparse-dev
+    openssh-server libopenmpi1.10 libopenmpi-dev libsuitesparse-dev
   - cmake --version
   - gcc --version
 
@@ -62,7 +63,7 @@ stages:
 jobs:
   include:
     - stage: deploy
-      python: 3.5
+      python: 3.7
       env: NOSETESTS=none NOSEOPTS=$NOSEOPTS_DEFAULT
       install: skip
       script: python CI/deploy


### PR DESCRIPTION
Simple patch, but I want the green-light from @enielse before merging.

Supporting both 3.7 and 3.5 in CI is a ton of extra build time without a lot of payoff if we don't actually care about 3.5 support, so maybe think about dropping 3.5.