### PR TITLE
Updates most SPAM vecs & ops to work with pruned-path term calcs.

### DIFF
--- a/packages/pygsti/objects/polynomial.py
+++ b/packages/pygsti/objects/polynomial.py
@@ -218,12 +218,35 @@ class Polynomial(dict):
 
         Returns
         -------
+        Polynomial
+        """
+        return Polynomial({ mapfn(k): v for k,v in self.items() })
+
+        
+    def map_indices_inplace(self, mapfn):
+        """
+        Performs an in-place find & replace on this polynomial's variable indices.
+
+        This is useful when the variable indices have external significance
+        (like being the indices of a gate's parameters) and one want to convert
+        to another set of indices (like a parent model's parameters).
+
+        Parameters
+        ----------
+        mapfn : function
+            A function that takes as input an "old" variable-index-tuple 
+            (a key of this Polynomial) and returns the updated "new"
+            variable-index-tuple.
+
+        Returns
+        -------
         None
         """
         new_items = { mapfn(k): v for k,v in self.items() }
         self.clear()
         self.update(new_items)
 
+        
     def mult(self,x):
         """ 
         Multiplies this polynomial by another polynomial `x`.

--- a/packages/pygsti/objects/slowreplib.py
+++ b/packages/pygsti/objects/slowreplib.py
@@ -1051,7 +1051,7 @@ class PolyRep(dict):
         cpy.update(self) # constructor expects dict w/var-index keys, not ints like self has
         return cpy
 
-    def map_indices(self, mapfn):
+    def map_indices_inplace(self, mapfn):
         """
         Map the variable indices in this `PolyRep`.
         This allows one to change the "labels" of the variables.
@@ -1621,6 +1621,8 @@ def _prs_as_pruned_polys(calc, rholabel, elabels, circuit, repcache, comm=None, 
     mpv = calc.Np # max_poly_vars
     mpo = 1000 ## PLATFORM_BITS / _np.log2(mpv) #max_poly_order allowed for our integer storage
     distinct_gateLabels = sorted(set(circuit))
+
+    #TODO REMOVE
     #print("DB: _prs_as_pruned_polys: ", circuit, "Distinct = ",distinct_gateLabels)
     #op_term_reps = { glbl: [ t.torep(mpo,mpv,"gate") for t in calc.sos.get_operation(glbl).get_highmagnitude_terms(min_term_mag, max_taylor_order=calc.max_order)]
     #                 for glbl in distinct_gateLabels }
@@ -1637,7 +1639,7 @@ def _prs_as_pruned_polys(calc, rholabel, elabels, circuit, repcache, comm=None, 
             
     #Similar with rho_terms and E_terms, but lists
     #rho_term_reps = [ t.torep(mpo,mpv,"prep") for t in calc.sos.get_prep(rholabel).get_highmagnitude_terms(min_term_mag, max_taylor_order=calc.max_order) ]
-    #rho_num_foat = calc.sos.get_prep(rholabel).get_num_firstorder_terms()
+    #rho_num_foat = calc.sos.get_prep(rholabel).get_num_firstorder_terms() # TODO REMOVE
     if rholabel not in repcache:
         hmterms, foat_indices = calc.sos.get_prep(rholabel).get_highmagnitude_terms(
             min_term_mag, max_taylor_order=calc.max_order)

--- a/packages/pygsti/objects/term.py
+++ b/packages/pygsti/objects/term.py
@@ -388,7 +388,7 @@ class RankOneTerm(object):
         copy_of_me.post_ops = self.post_ops[:]
         return copy_of_me
 
-    def map_indices(self, mapfn):
+    def map_indices_inplace(self, mapfn):
         """
         Performs a bulk find & replace on the coefficient polynomial's variable
         indices.  This function should only be called when this term's
@@ -405,9 +405,9 @@ class RankOneTerm(object):
         -------
         None
         """
-        assert(hasattr(self.coeff, 'map_indices')), \
-            "Coefficient (type %s) must implements `map_indices`" % str(type(self.coeff))
-        self.coeff.map_indices(mapfn)
+        assert(hasattr(self.coeff, 'map_indices_inplace')), \
+            "Coefficient (type %s) must implements `map_indices_inplace`" % str(type(self.coeff))
+        self.coeff.map_indices_inplace(mapfn)
 
         
     def torep(self, max_poly_order, max_poly_vars, typ):


### PR DESCRIPTION
Adds some finishing touches onto the work of the previously merged feature-directterms branch.  Rob can decide whether/when to merge this into develop as is convenient with the reformatting work.