### PR TITLE
Contributor guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment (please complete the following information):**
+ - pyGSTi version [e.g. v0.9.7.4]
+ - python version [e.g. 3.7, 2.7]
+ - OS [e.g. OSX 10.14, Ubuntu 16.04 LTS]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: 'enhancement'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+# Contributing to pyGSTi
+
+Thanks for taking the time to contribute to pyGSTi! Open-source projects like
+ours couldn't exist without contributors like you.
+
+This document contains a set of guidelines for contributing to pyGSTi and
+related packages hosted under the
+[pyGSTio group](https://github.com/pyGSTio). We ask that contributors make an
+earnest effort to follow these guidelines, but no one's keeping score here --
+just use your best judgement, and by all means, feel free to propose changes to
+these guidelines in a pull request.
+
+### Reporting Bugs
+
+Found a bug in pyGSTi? We'd appreciate letting us know!
+
+* First, **see if the bug has already been reported** by searching on Github
+  under [Issues](https://github.com/pyGSTio/pyGSTi/issues).
+
+* If you can't find an open issue about the problem,
+  [open a new one](https://github.com/pyGSTio/pyGSTi/issues/new)! Be sure to
+  include a **title**, a **clear description** of what went wrong, and **as much
+  relevant information as possible.** If you can, try to include detailed steps
+  to reproduce the problem.
+
+* Once you open an issue, please **keep an eye on it** -- you may be asked to
+  provide more details.
+
+### Suggesting Features & Enhancements
+
+Want to add a new feature or change an existing one?
+
+* First, **see if the feature or enhancement has already been suggested** by
+  searching on Github under [Issues](https://github.com/pyGSTio/pyGSTi/issues).
+
+* If you can't find a similar suggestion in the issue tracker, [open a new
+  issue](https://github.com/pyGSTio/pyGSTi/issues/new) for your feature
+  suggestion.
+
+### Making a Contribution
+
+Want to fix a bug, add a feature, or change an existing feature?
+
+Because pyGSTi is a project of the Quantum Performance Lab at Sandia National
+Labs, the process of contributing to pyGSTi is different for contributors
+working at Sandia.
+
+#### For non-Sandians
+
+Unfortunately, **we can't currently accept pull requests from contributors
+outside of SNL.** We're working on setting up a contributor license agreement,
+so, someday, this may change. Check back later!
+
+#### For Sandians
+
+* **Contact the authors** at [pygsti@sandia.gov](mailto:pygsti@sandia.gov) to
+  request an invite to the [pyGSTio group](https://github.com/pyGSTio).
+
+* If there is an **open issue** in the
+  [issue tracker](https://github.com/pyGSTio/pyGSTi/issues) for the bug,
+  feature, or enhancement, **assign yourself** to it.
+
+* In your local repository, make a **feature branch** off of `develop` for your
+  contribution. The names of branches for *features* and *enhancements* should
+  begin with `feature-`. Branch names for *bug fixes* should begin with
+  `bugfix-`.
+
+* Write and commit your patch in this branch. Try and make **frequent commits
+  containing only related work.** While you should **push** your changes to
+  Github often, please try to avoid changing history on publicly-visible
+  branches.
+
+* Once you're finished, **pull** the latest refs on `develop` from Github and
+  **merge** `develop` into your feature branch. Resolve any merge conflicts that
+  arise.
+
+* On Github under [Pull Requests](https://github.com/pyGSTio/pyGSTi/pulls),
+  create a new pull request to merge your feature branch into `develop`.
+
+* If your feature passes linting and automated tests, it will be reviewed by a
+  pyGSTi core developer, who may have suggestions for changes or fixes which you
+  should make before your patch can be merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,8 +58,8 @@ back later!
 
 * **Follow the guidelines** [on the project wiki][contributing].
 
-[contributing]: /pyGSTio/pyGSTi/wiki/Contributing
+[contributing]: https://github.com/pyGSTio/pyGSTi/wiki/Contributing
 [email]: mailto:pygsti@sandia.gov
-[issues:new]: /pyGSTio/pyGSTi/issues/new
-[issues]: /pyGSTio/pyGSTi/issues
-[pygstio]: /pyGSTio
+[issues:new]: https://github.com/pyGSTio/pyGSTi/issues/new
+[issues]: https://github.com/pyGSTio/pyGSTi/issues
+[pygstio]: https://github.com/pyGSTio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,65 @@
 # Contributing to pyGSTi
 
-Thanks for taking the time to contribute to pyGSTi! Open-source projects like
-ours couldn't exist without contributors like you.
+Thanks for taking the time to contribute to pyGSTi! Open-source
+projects like ours couldn't exist without contributors like you.
 
-This document contains a set of guidelines for contributing to pyGSTi and
-related packages hosted under the
-[pyGSTio group](https://github.com/pyGSTio). We ask that contributors make an
-earnest effort to follow these guidelines, but no one's keeping score here --
-just use your best judgement, and by all means, feel free to propose changes to
-these guidelines in a pull request.
+This document contains a set of guidelines for contributing to pyGSTi
+and related packages hosted under the [pyGSTio group][pygstio]. We ask
+that contributors make an earnest effort to follow these guidelines,
+but no one's keeping score here -- just use your best judgement, and
+by all means, feel free to propose changes to these guidelines in a
+pull request.
 
 ### Reporting Bugs
 
 Found a bug in pyGSTi? We'd appreciate letting us know!
 
-* First, **see if the bug has already been reported** by searching on Github
-  under [Issues](https://github.com/pyGSTio/pyGSTi/issues).
+* First, **see if the bug has already been reported** by searching on
+  Github under [Issues][issues].
 
 * If you can't find an open issue about the problem,
-  [open a new one](https://github.com/pyGSTio/pyGSTi/issues/new)! Be sure to
-  include a **title**, a **clear description** of what went wrong, and **as much
-  relevant information as possible.** If you can, try to include detailed steps
+  [open a new one][issues:new]! Be sure to include a **title**, a
+  **clear description** of what went wrong, and **as much relevant
+  information as possible.** If you can, try to include detailed steps
   to reproduce the problem.
 
-* Once you open an issue, please **keep an eye on it** -- you may be asked to
-  provide more details.
+* Once you open an issue, please **keep an eye on it** -- you may be
+  asked to provide more details.
 
 ### Suggesting Features & Enhancements
 
 Want to add a new feature or change an existing one?
 
-* First, **see if the feature or enhancement has already been suggested** by
-  searching on Github under [Issues](https://github.com/pyGSTio/pyGSTi/issues).
+* First, **see if the feature or enhancement has already been
+  suggested** by searching on Github under [Issues][issues].
 
-* If you can't find a similar suggestion in the issue tracker, [open a new
-  issue](https://github.com/pyGSTio/pyGSTi/issues/new) for your feature
-  suggestion.
+* If you can't find a similar suggestion in the issue tracker,
+  [open a new issue][issues:new] for your feature suggestion.
 
 ### Making a Contribution
 
 Want to fix a bug, add a feature, or change an existing feature?
 
-Because pyGSTi is a project of the Quantum Performance Lab at Sandia National
-Labs, the process of contributing to pyGSTi is different for contributors
-working at Sandia.
+Because pyGSTi is a project of the Quantum Performance Lab at Sandia
+National Labs, the process of contributing to pyGSTi is different for
+contributors working at Sandia.
 
 #### For non-Sandians
 
-Unfortunately, **we can't currently accept pull requests from contributors
-outside of SNL.** We're working on setting up a contributor license agreement,
-so, someday, this may change. Check back later!
+Unfortunately, **we can't currently accept pull requests from
+contributors outside of SNL.** We're working on setting up a
+contributor license agreement, so, someday, this may change. Check
+back later!
 
 #### For Sandians
 
-* **Contact the authors** at [pygsti@sandia.gov](mailto:pygsti@sandia.gov) to
-  request an invite to the [pyGSTio group](https://github.com/pyGSTio).
+* **Contact the authors** at [pygsti@sandia.gov][email] to
+  request an invite to the [pyGSTio group][pygstio].
 
-* If there is an **open issue** in the
-  [issue tracker](https://github.com/pyGSTio/pyGSTi/issues) for the bug,
-  feature, or enhancement, **assign yourself** to it.
+* **Follow the guidelines** [on the project wiki][contributing].
 
-* In your local repository, make a **feature branch** off of `develop` for your
-  contribution. The names of branches for *features* and *enhancements* should
-  begin with `feature-`. Branch names for *bug fixes* should begin with
-  `bugfix-`.
-
-* Write and commit your patch in this branch. Try and make **frequent commits
-  containing only related work.** While you should **push** your changes to
-  Github often, please try to avoid changing history on publicly-visible
-  branches.
-
-* Once you're finished, **pull** the latest refs on `develop` from Github and
-  **merge** `develop` into your feature branch. Resolve any merge conflicts that
-  arise.
-
-* On Github under [Pull Requests](https://github.com/pyGSTio/pyGSTi/pulls),
-  create a new pull request to merge your feature branch into `develop`.
-
-* If your feature passes linting and automated tests, it will be reviewed by a
-  pyGSTi core developer, who may have suggestions for changes or fixes which you
-  should make before your patch can be merged.
+[contributing]: /pyGSTio/pyGSTi/wiki/Contributing
+[email]: mailto:pygsti@sandia.gov
+[issues:new]: /pyGSTio/pyGSTi/issues/new
+[issues]: /pyGSTio/pyGSTi/issues
+[pygstio]: /pyGSTio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Found a bug in pyGSTi? We'd appreciate letting us know!
   Github under [Issues][issues].
 
 * If you can't find an open issue about the problem,
-  [open a new one][issues:new]! Be sure to include a **title**, a
+  [open a new one][issues:bug]! Be sure to include a **title**, a
   **clear description** of what went wrong, and **as much relevant
   information as possible.** If you can, try to include detailed steps
   to reproduce the problem.
@@ -34,7 +34,7 @@ Want to add a new feature or change an existing one?
   suggested** by searching on Github under [Issues][issues].
 
 * If you can't find a similar suggestion in the issue tracker,
-  [open a new issue][issues:new] for your feature suggestion.
+  [open a new issue][issues:feature] for your feature suggestion.
 
 ### Making a Contribution
 
@@ -60,6 +60,8 @@ back later!
 
 [contributing]: https://github.com/pyGSTio/pyGSTi/wiki/Contributing
 [email]: mailto:pygsti@sandia.gov
+[issues:bug]: https://github.com/pyGSTio/pyGSTi/issues/new?labels=bug&template=bug_report.md
+[issues:feature]: https://github.com/pyGSTio/pyGSTi/issues/new?labels=enhancement&template=feature_request.md
 [issues:new]: https://github.com/pyGSTio/pyGSTi/issues/new
 [issues]: https://github.com/pyGSTio/pyGSTi/issues
 [pygstio]: https://github.com/pyGSTio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,10 @@ contributors working at Sandia.
 
 Unfortunately, **we can't currently accept pull requests from
 contributors outside of SNL.** We're working on setting up a
-contributor license agreement, so, someday, this may change. Check
-back later!
+contributor license agreement, so, someday, this may change.  If you're
+interested in making contributions please let us know by email at
+[pygsti@sandia.gov][email] so we can make a strong case to our lawyers for
+getting this done!
 
 #### For Sandians
 


### PR DESCRIPTION
Adds contributor guidelines & issue templates. Closes #60 

Github reads issue templates from `master`, so I'm requesting this be merged directly to `master` instead of `develop`. This only adds Github content, so there's no reason to wait to include in a release. But you may also want to merge it to `develop` just so the refs are there.

Also, be aware that the template links (and some links on the wiki) are broken until this is merged to master.