### PR TITLE
Colorbars added to ColorBoxPlot, and text size for the text on boxes …

### DIFF
--- a/packages/pygsti/report/mpl_colormaps.py
+++ b/packages/pygsti/report/mpl_colormaps.py
@@ -160,7 +160,8 @@ def mpl_color(plotly_color):
         return plotly_color  # hope this is a color name matplotlib understands
 
 
-def plotly_to_matplotlib(pygsti_fig, save_to=None, fontsize=12, prec='compacthp'):
+def plotly_to_matplotlib(pygsti_fig, save_to=None, fontsize=12, prec='compacthp',
+                        boxLabels_fontsize=6):
     """
     Convert a pygsti (plotly) figure to a matplotlib figure.
 
@@ -173,11 +174,15 @@ def plotly_to_matplotlib(pygsti_fig, save_to=None, fontsize=12, prec='compacthp'
         Output filename.  Extension determines type.  If None, then the
         matplotlib figure is returned instead of saved.
 
-    fontsize : int
+    fontsize : int, optional
         Base fontsize to use for converted figure.
 
     prec : int or {"compact","compacth"}
         Digits of precision to include in labels.
+       
+    boxLabels_fontsize : int, optional
+        The size for labels on the boxes. If 0 then no labels are
+        put on the boxes
 
     Returns
     -------
@@ -344,8 +349,8 @@ def plotly_to_matplotlib(pygsti_fig, save_to=None, fontsize=12, prec='compacthp'
 
             #print("DB ann = ", len(annotations))
             #boxLabels = bool( len(annotations) >= 1 ) #TODO: why not plt_data.size instead of 1?
-            boxLabels = True  # maybe should always be true?
-            if boxLabels:
+            #boxLabels = True  # maybe should always be true?
+            if boxLabels_fontsize > 0:
                 # Write values on colored squares
                 for y in range(plt_data.shape[0]):
                     for x in range(plt_data.shape[1]):
@@ -355,10 +360,11 @@ def plotly_to_matplotlib(pygsti_fig, save_to=None, fontsize=12, prec='compacthp'
                                   horizontalalignment='center',
                                   verticalalignment='center',
                                   color=mpl_besttxtcolor(plt_data[y, x], cmap, norm),
-                                  fontsize=(fontsize - 6))
+                                  fontsize=boxLabels_fontsize)
 
             if show_colorscale:
-                _plt.colorbar(heatmap)
+                cbar = _plt.colorbar(heatmap)
+                cbar.ax.tick_params(labelsize=(fontsize-2)) 
 
         elif typ == "scatter":
             mode = get(traceDict, 'mode', 'lines')

--- a/packages/pygsti/report/workspaceplots.py
+++ b/packages/pygsti/report/workspaceplots.py
@@ -1421,7 +1421,7 @@ class ColorBoxPlot(WorkspacePlot):
                  prec='compact', linlg_pcntle=.05, minProbClipForWeighting=1e-4,
                  directGSTmodels=None, dscomparator=None, driftresults=None,
                  submatrices=None, typ="boxes", scale=1.0, comm=None,
-                 wildcard=None):
+                 wildcard=None, colorbar=False):
         """
         Create a plot displaying the value of per-circuit quantities.
 
@@ -1511,19 +1511,22 @@ class ColorBoxPlot(WorkspacePlot):
             across multiple processors.
 
         wildcard : TODO: docstring
+
+        colorbar : bool, optional
+            Whether to include a colorbar.
         """
         # separate in rendering/saving: save_to=None, ticSize=20, scale=1.0 (?)
         super(ColorBoxPlot, self).__init__(ws, self._create, plottype, gss, dataset, model,
                                            prec, sumUp, boxLabels, hoverInfo,
                                            invert, linlg_pcntle, minProbClipForWeighting,
                                            directGSTmodels, dscomparator, driftresults,
-                                           submatrices, typ, scale, comm, wildcard)
+                                           submatrices, typ, scale, comm, wildcard, colorbar)
 
     def _create(self, plottypes, gss, dataset, model,
                 prec, sumUp, boxLabels, hoverInfo,
                 invert, linlg_pcntle, minProbClipForWeighting,
                 directGSTmodels, dscomparator, driftresults, submatrices,
-                typ, scale, comm, wildcard):
+                typ, scale, comm, wildcard, colorbar):
 
         probs_precomp_dict = None
         fig = None
@@ -1735,13 +1738,13 @@ class ColorBoxPlot(WorkspacePlot):
 
             if typ == "boxes":
                 newfig = circuit_color_boxplot(gss, subMxs, colormap,
-                                               False, boxLabels, prec,
+                                               colorbar, boxLabels, prec,
                                                hoverInfo, sumUp, invert,
                                                scale, addl_hover_info)
 
             elif typ == "scatter":
                 newfig = circuit_color_scatterplot(gss, subMxs, colormap,
-                                                   False, hoverInfo, sumUp, ytitle,
+                                                   colorbar, hoverInfo, sumUp, ytitle,
                                                    scale, addl_hover_info)
             elif typ == "histogram":
                 newfig = circuit_color_histogram(gss, subMxs, colormap,


### PR DESCRIPTION
…now settable in plotly_to_mpl function. The scale on the colobars of the plotly versions of the ColorBoxPlot is currently incorrect. It is correct in the Matplotlib output