### PR TITLE
Feature modelbuilding

### DIFF
--- a/packages/pygsti/construction/modelconstruction.py
+++ b/packages/pygsti/construction/modelconstruction.py
@@ -1089,16 +1089,16 @@ def build_crosstalk_free_model(nQubits, gate_names, error_rates, nonstd_gate_uni
         else:
             U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
             if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
-            if evotype in ("densitymx", "svterm", "cterm"):
-                if callable(U):  # then assume a function: args -> unitary
-                    U0 = U(None)  # U fns must return a sample unitary when passed None to get size.
-                    gateMx = _opfactory.UnitaryOpFactory(U, U0.shape[0], evotype=evotype)
-                else:
+            if callable(U):  # then assume a function: args -> unitary
+                U0 = U(None)  # U fns must return a sample unitary when passed None to get size.
+                gateMx = _opfactory.UnitaryOpFactory(U, U0.shape[0], evotype=evotype)
+            else:
+                if evotype in ("densitymx", "svterm", "cterm"):
                     gateMx = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
-            else:  # we just store the unitaries
-                raise NotImplementedError("Setting error rates on unitaries isn't implemented yet")
-                #assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
-                #gateMx = U
+                else:  # we just store the unitaries
+                    raise NotImplementedError("Setting error rates on unitaries isn't implemented yet")
+                    #assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
+                    #gateMx = U
             gatedict[name] = create_gate(name, gateMx)
 
     #Check for any error rates specific to sslbls that we missed, e.g. ('Gx',0)

--- a/packages/pygsti/construction/modelconstruction.py
+++ b/packages/pygsti/construction/modelconstruction.py
@@ -1040,7 +1040,7 @@ def build_crosstalk_free_model(nQubits, gate_names, error_rates, nonstd_gate_uni
 
         if isinstance(gateMx, _opfactory.OpFactory):
             factory = gateMx
-            gateMx = _np.identity(factory.dim, 'd') # we'll prefix with factory
+            gateMx = _np.identity(factory.dim, 'd')  # we'll prefix with factory
         else:
             factory = None
 

--- a/packages/pygsti/construction/modelconstruction.py
+++ b/packages/pygsti/construction/modelconstruction.py
@@ -745,7 +745,12 @@ def build_localnoise_model(nQubits, gate_names, nonstd_gate_unitaries=None, cust
 
     nonstd_gate_unitaries : dict, optional
         A dictionary of numpy arrays which specifies the unitary gate action
-        of the gate names given by the dictionary's keys.
+        of the gate names given by the dictionary's keys.  As an advanced
+        behavior, a unitary-matrix-returning function which takes a single
+        argument - a tuple of label arguments - may be given instead of a
+        single matrix to create an operation *factory* which allows
+        continuously-parameterized gates.  This function must also return
+        an empty/dummy unitary when `None` is given as it's argument.
 
     custom_gates : dict, optional
         A dictionary that associates with gate labels

--- a/packages/pygsti/construction/nqnoiseconstruction.py
+++ b/packages/pygsti/construction/nqnoiseconstruction.py
@@ -189,7 +189,12 @@ def build_cloudnoise_model_from_hops_and_weights(
 
     nonstd_gate_unitaries : dict, optional
         A dictionary of numpy arrays which specifies the unitary gate action
-        of the gate names given by the dictionary's keys.
+        of the gate names given by the dictionary's keys.  As an advanced
+        behavior, a unitary-matrix-returning function which takes a single
+        argument - a tuple of label arguments - may be given instead of a
+        single matrix to create an operation *factory* which allows
+        continuously-parameterized gates.  This function must also return
+        an empty/dummy unitary when `None` is given as it's argument.
 
     custom_gates : dict
         A dictionary that associates with gate labels
@@ -414,7 +419,12 @@ def build_cloud_crosstalk_model(nQubits, gate_names, error_rates, nonstd_gate_un
 
     nonstd_gate_unitaries : dict, optional
         A dictionary of numpy arrays which specifies the unitary gate action
-        of the gate names given by the dictionary's keys.
+        of the gate names given by the dictionary's keys.  As an advanced
+        behavior, a unitary-matrix-returning function which takes a single
+        argument - a tuple of label arguments - may be given instead of a
+        single matrix to create an operation *factory* which allows
+        continuously-parameterized gates.  This function must also return
+        an empty/dummy unitary when `None` is given as it's argument.
 
     custom_gates : dict, optional
         A dictionary that associates with gate labels

--- a/packages/pygsti/construction/nqnoiseconstruction.py
+++ b/packages/pygsti/construction/nqnoiseconstruction.py
@@ -54,7 +54,7 @@ def nparams_XYCNOT_cloudnoise_model(nQubits, geometry="line", maxIdleWeight=1, m
 
     Parameters
     ----------
-    Subset of those of :function:`build_standard_cloudnoise_model_from_hops_and_weights`.
+    Subset of those of :function:`build_cloudnoise_model_from_hops_and_weights`.
 
     Returns
     -------
@@ -135,9 +135,9 @@ def nparams_XYCNOT_cloudnoise_model(nQubits, geometry="line", maxIdleWeight=1, m
     return nParams, sum(nParams.values())
 
 
-def build_standard_cloudnoise_model_from_hops_and_weights(
-        nQubits, gate_names, nonstd_gate_unitaries=None, availability=None,
-        qubit_labels=None, geometry="line",
+def build_cloudnoise_model_from_hops_and_weights(
+        nQubits, gate_names, nonstd_gate_unitaries=None, custom_gates=None,
+        availability=None, qubit_labels=None, geometry="line",
         maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
         extraWeight1Hops=0, extraGateWeight=0, sparse=False,
         roughNoise=None, sim_type="auto", parameterization="H+S",
@@ -190,21 +190,44 @@ def build_standard_cloudnoise_model_from_hops_and_weights(
         A dictionary of numpy arrays which specifies the unitary gate action
         of the gate names given by the dictionary's keys.
 
+    custom_gates : dict
+        A dictionary that associates with gate labels
+        :class:`LinearOperator`, :class:`OpFactory`, or `numpy.ndarray`
+        objects.  These objects describe the full action of the gate or
+        primitive-layer they're labeled by (so if the model represents
+        states by density matrices these objects are superoperators, not
+        unitaries), and override any standard construction based on builtin
+        gate names or `nonstd_gate_unitaries`.  Keys of this dictionary must
+        be string-type gate *names* -- they cannot include state space labels
+        -- and they must be *static* (have zero parameters) because they
+        represent only the ideal behavior of each gate -- the cloudnoise
+        operations represent the parameterized noise.  To fine-tune how this
+        noise is parameterized, call the :class:`CloudNoiseModel` constructor
+        directly.
+
     availability : dict, optional
         A dictionary whose keys are the same gate names as in
-        `gate_names` and whose values are lists of qubit-label-tuples.  Each
+        `gatedict` and whose values are lists of qubit-label-tuples.  Each
         qubit-label-tuple must have length equal to the number of qubits
-        the corresponding gate acts upon, and specifies that the named gate
-        is available to act on the specified qubits.  For example,
+        the corresponding gate acts upon, and causes that gate to be
+        embedded to act on the specified qubits.  For example,
         `{ 'Gx': [(0,),(1,),(2,)], 'Gcnot': [(0,1),(1,2)] }` would cause
-        the `1-qubit `'Gx'`-gate to be available for acting on qubits
-        0, 1, or 2, and the 2-qubit `'Gcnot'`-gate to be availalbe to
-        act on qubits 0 & 1 or 1 & 2.  Instead of a list of tuples, values of
-        `availability` may take the special values `"all-permutations"` and
-        `"all-combinations"`, which as their names imply, equate to all possible
+        the `1-qubit `'Gx'`-gate to be embedded three times, acting on qubits
+        0, 1, and 2, and the 2-qubit `'Gcnot'`-gate to be embedded twice,
+        acting on qubits 0 & 1 and 1 & 2.  Instead of a list of tuples,
+        values of `availability` may take the special values:
+
+        - `"all-permutations"` and `"all-combinations"` equate to all possible
         permutations and combinations of the appropriate number of qubit labels
-        (deterined by the gate's dimension).  The default value `"all-edges"`
-        equates to all the edges in the graph given by `geometry`.
+        (deterined by the gate's dimension).
+        - `"all-edges"` equates to all the vertices, for 1Q gates, and all the
+        edges, for 2Q gates of the graphy given by `geometry`.
+        - `"arbitrary"` or `"*"` means that the corresponding gate can be placed
+        on any target qubits via an :class:`EmbeddingOpFactory` (uses less
+        memory but slower than `"all-permutations"`.
+
+        If a gate name (a key of `gatedict`) is not present in `availability`,
+        the default is `"all-edges"`.
 
     qubit_labels : tuple, optional
         The circuit-line labels for each of the qubits, which can be integers
@@ -320,9 +343,9 @@ def build_standard_cloudnoise_model_from_hops_and_weights(
     -------
     Model
     """
-    mdl = _CloudNoiseModel.build_standard_from_hops_and_weights(
-        nQubits, gate_names, nonstd_gate_unitaries, availability,
-        qubit_labels, geometry,
+    mdl = _CloudNoiseModel.build_from_hops_and_weights(
+        nQubits, gate_names, nonstd_gate_unitaries, custom_gates,
+        availability, qubit_labels, geometry,
         maxIdleWeight, maxSpamWeight, maxhops,
         extraWeight1Hops, extraGateWeight, sparse,
         sim_type, parameterization, spamtype,
@@ -350,8 +373,8 @@ def build_standard_cloudnoise_model_from_hops_and_weights(
         return mdl
 
 
-def build_cloud_crosstalk_model(nQubits, gate_names, error_rates, nonstd_gate_unitaries=None, availability=None,
-                                qubit_labels=None, geometry="line", parameterization='auto',
+def build_cloud_crosstalk_model(nQubits, gate_names, error_rates, nonstd_gate_unitaries=None, custom_gates=None,
+                                availability=None, qubit_labels=None, geometry="line", parameterization='auto',
                                 evotype="auto", sim_type="auto", independent_gates=False, sparse=True,
                                 errcomp_type="errorgens", addIdleNoiseToAllGates=True, verbosity=0):
     """
@@ -392,21 +415,39 @@ def build_cloud_crosstalk_model(nQubits, gate_names, error_rates, nonstd_gate_un
         A dictionary of numpy arrays which specifies the unitary gate action
         of the gate names given by the dictionary's keys.
 
+    custom_gates : dict, optional
+        A dictionary that associates with gate labels
+        :class:`LinearOperator`, :class:`OpFactory`, or `numpy.ndarray`
+        objects.  These objects override any other behavior for constructing
+        their designated operations (e.g. from `error_rates` or
+        `nonstd_gate_unitaries`).  Note: currently these objects must
+        be *static*, and keys of this dictionary must by strings - there's
+        no way to specify the "cloudnoise" part of a gate via this dict
+        yet, only the "target" part.
+
     availability : dict, optional
         A dictionary whose keys are the same gate names as in
-        `gate_names` and whose values are lists of qubit-label-tuples.  Each
+        `gatedict` and whose values are lists of qubit-label-tuples.  Each
         qubit-label-tuple must have length equal to the number of qubits
-        the corresponding gate acts upon, and specifies that the named gate
-        is available to act on the specified qubits.  For example,
+        the corresponding gate acts upon, and causes that gate to be
+        embedded to act on the specified qubits.  For example,
         `{ 'Gx': [(0,),(1,),(2,)], 'Gcnot': [(0,1),(1,2)] }` would cause
-        the `1-qubit `'Gx'`-gate to be available for acting on qubits
-        0, 1, or 2, and the 2-qubit `'Gcnot'`-gate to be availalbe to
-        act on qubits 0 & 1 or 1 & 2.  Instead of a list of tuples, values of
-        `availability` may take the special values `"all-permutations"` and
-        `"all-combinations"`, which as their names imply, equate to all possible
+        the `1-qubit `'Gx'`-gate to be embedded three times, acting on qubits
+        0, 1, and 2, and the 2-qubit `'Gcnot'`-gate to be embedded twice,
+        acting on qubits 0 & 1 and 1 & 2.  Instead of a list of tuples,
+        values of `availability` may take the special values:
+
+        - `"all-permutations"` and `"all-combinations"` equate to all possible
         permutations and combinations of the appropriate number of qubit labels
-        (deterined by the gate's dimension).  The default value `"all-edges"`
-        equates to all the edges in the graph given by `geometry`.
+        (deterined by the gate's dimension).
+        - `"all-edges"` equates to all the vertices, for 1Q gates, and all the
+        edges, for 2Q gates of the graphy given by `geometry`.
+        - `"arbitrary"` or `"*"` means that the corresponding gate can be placed
+        on any target qubits via an :class:`EmbeddingOpFactory` (uses less
+        memory but slower than `"all-permutations"`.
+
+        If a gate name (a key of `gatedict`) is not present in `availability`,
+        the default is `"all-edges"`.
 
     qubit_labels : tuple, optional
         The circuit-line labels for each of the qubits, which can be integers
@@ -757,10 +798,17 @@ def build_cloud_crosstalk_model(nQubits, gate_names, error_rates, nonstd_gate_un
 
     gatedict = _collections.OrderedDict()
     for name in gate_names:
-        U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
-        if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
-        gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
-        # assume evotype is a densitymx or term type
+        if name in custom_gates:
+            gatedict[name] = custom_gates[name]
+        else:
+            U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
+            if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
+            gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
+            # assume evotype is a densitymx or term type
+
+    #Add anything from custom_gates directly if it wasn't added already
+    for lbl, gate in custom_gates.items():
+        if lbl not in gate_names: gatedict[lbl] = gate
 
     return _CloudNoiseModel(nQubits, gatedict, availability, qubit_labels, geometry,
                             global_idle_layer, prep_layers, povm_layers,
@@ -2006,8 +2054,8 @@ def create_XYCNOT_cloudnoise_sequences(nQubits, maxLengths, geometry, cnot_edges
     from pygsti.construction import std1Q_XY  # the base model for 1Q gates
     from pygsti.construction import std2Q_XYICNOT  # the base model for 2Q (CNOT) gate
 
-    tgt1Q = std1Q_XY.target_model()
-    tgt2Q = std2Q_XYICNOT.target_model()
+    tgt1Q = std1Q_XY.target_model("static")
+    tgt2Q = std2Q_XYICNOT.target_model("static")
     Gx = tgt1Q.operations['Gx']
     Gy = tgt1Q.operations['Gy']
     Gcnot = tgt2Q.operations['Gcnot']
@@ -2038,7 +2086,7 @@ def create_standard_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
     Create a set of `fiducial1+germ^power+fiducial2` sequences which amplify
     all of the parameters of a `CloudNoiseModel` created by passing the
     arguments of this function to
-    :function:`build_standard_cloudnoise_model_from_hops_and_weights`.
+    :function:`build_cloudnoise_model_from_hops_and_weights`.
 
     Note that this function essentialy performs fiducial selection, germ
     selection, and fiducial-pair reduction simultaneously.  It is used to
@@ -2076,7 +2124,7 @@ def create_standard_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
     gate_names, nonstd_gate_unitaries, availability, geometry,
     maxIdleWeight, maxhops, extraWeight1Hops, extraGateWeight, sparse : various
         Cloud-noise model parameters specifying the model to create sequences
-        for. See function:`build_standard_cloudnoise_model_from_hops_and_weights`
+        for. See function:`build_cloudnoise_model_from_hops_and_weights`
         for details.
 
     paramroot : {"CPTP", "H+S+A", "H+S", "S", "H+D+A", "D+A", "D"}
@@ -2147,7 +2195,7 @@ def create_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
     Create a set of `fiducial1+germ^power+fiducial2` sequences which amplify
     all of the parameters of a `CloudNoiseModel` created by passing the
     arguments of this function to
-    function:`build_standard_cloudnoise_model_from_hops_and_weights`.
+    function:`build_cloudnoise_model_from_hops_and_weights`.
 
     Note that this function essentialy performs fiducial selection, germ
     selection, and fiducial-pair reduction simultaneously.  It is used to
@@ -2266,7 +2314,8 @@ def create_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
     all_qubit_labels = qubitGraph.get_node_names()
 
     model = _CloudNoiseModel.build_from_hops_and_weights(
-        nQubits, gatedict, availability, None, qubitGraph,
+        nQubits, tuple(gatedict.keys()), None, gatedict,
+        availability, None, qubitGraph,
         maxIdleWeight, 0, maxhops, extraWeight1Hops,
         extraGateWeight, sparse, verbosity=printer - 5,
         sim_type="termorder:1", parameterization=ptermstype)
@@ -2283,7 +2332,8 @@ def create_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
     # ideal or error - except that which is the same as the Gi gate.
 
     ideal_model = _CloudNoiseModel.build_from_hops_and_weights(
-        nQubits, gatedict, availability, None, qubitGraph,
+        nQubits, tuple(gatedict.keys()), None, gatedict,
+        availability, None, qubitGraph,
         0, 0, 0, 0, 0, False, verbosity=printer - 5,
         sim_type="map", parameterization=paramroot)
     # for testing for synthetic idles - so no " terms"
@@ -2299,7 +2349,7 @@ def create_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
     # - actually better to pass qubitGraph here so we get the correct qubit labels (node labels of graphO
     printer.log("Creating \"idle error\" model on %d qubits" % maxIdleWeight)
     idle_model = _CloudNoiseModel.build_from_hops_and_weights(
-        maxIdleWeight, gatedict, {}, None, qubitGraph,
+        maxIdleWeight, tuple(gatedict.keys()), None, gatedict, {}, None, qubitGraph,
         maxIdleWeight, 0, maxhops, extraWeight1Hops,
         extraGateWeight, sparse, verbosity=printer - 5,
         sim_type="termorder:1", parameterization=ptermstype)
@@ -2377,7 +2427,7 @@ def create_cloudnoise_sequences(nQubits, maxLengths, singleQfiducials,
             printer.log("Getting sequences needed for max-weight=%d errors" % maxSyntheticIdleWt)
             printer.log(" on the idle gate (for %d-Q synthetic idles)" % gateWt)
             sidle_model = _CloudNoiseModel.build_from_hops_and_weights(
-                maxSyntheticIdleWt, gatedict, {}, None, 'line',
+                maxSyntheticIdleWt, tuple(gatedict.keys()), None, gatedict, {}, None, 'line',
                 maxIdleWeight, 0, maxhops, extraWeight1Hops,
                 extraGateWeight, sparse, verbosity=printer - 5,
                 sim_type="termorder:1", parameterization=ptermstype)

--- a/packages/pygsti/objects/cloudnoisemodel.py
+++ b/packages/pygsti/objects/cloudnoisemodel.py
@@ -57,14 +57,14 @@ class CloudNoiseModel(_ImplicitOpModel):
     """
 
     @classmethod
-    def build_standard_from_hops_and_weights(
-            cls, nQubits, gate_names, nonstd_gate_unitaries=None, availability=None,
-            qubit_labels=None, geometry="line",
-            maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
-            extraWeight1Hops=0, extraGateWeight=0, sparse=False,
-            sim_type="matrix", parameterization="H+S",
-            spamtype="lindblad", addIdleNoiseToAllGates=True,
-            errcomp_type="gates", independent_clouds=True, verbosity=0):
+    def build_from_hops_and_weights(cls, nQubits, gate_names, nonstd_gate_unitaries=None,
+                                    custom_gates=None, availability=None,
+                                    qubit_labels=None, geometry="line",
+                                    maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
+                                    extraWeight1Hops=0, extraGateWeight=0, sparse=False,
+                                    sim_type="auto", parameterization="H+S",
+                                    spamtype="lindblad", addIdleNoiseToAllGates=True,
+                                    errcomp_type="gates", independent_clouds=True, verbosity=0):
         """
         Create a n-qubit model using a low-weight and geometrically local
         error model with a common "global idle" operation.
@@ -74,21 +74,6 @@ class CloudNoiseModel(_ImplicitOpModel):
         the gate's target qubits.  This type of model is generally useful
         for performing GST on a multi-qubit system.
 
-        The returned model is "standard", in that the following standard gate
-        names may be specified as elements to `gate_names` without the need to
-        supply their corresponding unitaries (as one must when calling
-        the constructor directly):
-
-        - 'Gx','Gy','Gz' : 1Q pi/2 rotations
-        - 'Gxpi','Gypi','Gzpi' : 1Q pi rotations
-        - 'Gh' : Hadamard
-        - 'Gp' : phase
-        - 'Gcphase','Gcnot','Gswap' : standard 2Q gates
-
-        Furthermore, if additional "non-standard" gates are needed,
-        they are specified by their *unitary* gate action, even if
-        the final model propagates density matrices (as opposed
-        to state vectors).
 
         Parameters
         ----------
@@ -106,169 +91,20 @@ class CloudNoiseModel(_ImplicitOpModel):
             A dictionary of numpy arrays which specifies the unitary gate action
             of the gate names given by the dictionary's keys.
 
-        availability : dict, optional
-            A dictionary whose keys are the same gate names as in
-            `gate_names` and whose values are lists of qubit-label-tuples.  Each
-            qubit-label-tuple must have length equal to the number of qubits
-            the corresponding gate acts upon, and specifies that the named gate
-            is available to act on the specified qubits.  For example,
-            `{ 'Gx': [(0,),(1,),(2,)], 'Gcnot': [(0,1),(1,2)] }` would cause
-            the `1-qubit `'Gx'`-gate to be available for acting on qubits
-            0, 1, or 2, and the 2-qubit `'Gcnot'`-gate to be availalbe to
-            act on qubits 0 & 1 or 1 & 2.  Instead of a list of tuples, values of
-            `availability` may take the special values `"all-permutations"` and
-            `"all-combinations"`, which as their names imply, equate to all possible
-            permutations and combinations of the appropriate number of qubit labels
-            (deterined by the gate's dimension).  The default value `"all-edges"`
-            equates to all the edges in the graph given by `geometry`.
-
-        qubit_labels : tuple, optional
-            The circuit-line labels for each of the qubits, which can be integers
-            and/or strings.  Must be of length `nQubits`.  If None, then the
-            integers from 0 to `nQubits-1` are used.
-
-        geometry : {"line","ring","grid","torus"} or QubitGraph
-            The type of connectivity among the qubits, specifying a
-            graph used to define neighbor relationships.  Alternatively,
-            a :class:`QubitGraph` object with node labels equal to
-            `qubit_labels` may be passed directly.
-
-        maxIdleWeight : int, optional
-            The maximum-weight for errors on the global idle gate.
-
-        maxSpamWeight : int, optional
-            The maximum-weight for SPAM errors when `spamtype == "linblad"`.
-
-        maxhops : int
-            The locality constraint: for a gate, errors (of weight up to the
-            maximum weight for the gate) are allowed to occur on the gate's
-            target qubits and those reachable by hopping at most `maxhops` times
-            from a target qubit along nearest-neighbor links (defined by the
-            `geometry`).
-
-        extraWeight1Hops : int, optional
-            Additional hops (adds to `maxhops`) for weight-1 errors.  A value > 0
-            can be useful for allowing just weight-1 errors (of which there are
-            relatively few) to be dispersed farther from a gate's target qubits.
-            For example, a crosstalk-detecting model might use this.
-
-        extraGateWeight : int, optional
-            Addtional weight, beyond the number of target qubits (taken as a "base
-            weight" - i.e. weight 2 for a 2Q gate), allowed for gate errors.  If
-            this equals 1, for instance, then 1-qubit gates can have up to weight-2
-            errors and 2-qubit gates can have up to weight-3 errors.
-
-        sparse : bool, optional
-            Whether the embedded Lindblad-parameterized gates within the constructed
-            `nQubits`-qubit gates are sparse or not.  (This is determied by whether
-            they are constructed using sparse basis matrices.)  When sparse, these
-            Lindblad gates take up less memory, but their action is slightly slower.
-            Usually it's fine to leave this as the default (False), except when
-            considering particularly high-weight terms (b/c then the Lindblad gates
-            are higher dimensional and sparsity has a significant impact).
-
-        sim_type : {"auto","matrix","map","termorder:<N>"}
-            The type of forward simulation (probability computation) to use for the
-            returned :class:`Model`.  That is, how should the model compute
-            operation sequence/circuit probabilities when requested.  `"matrix"` is better
-            for small numbers of qubits, `"map"` is better for larger numbers. The
-            `"termorder"` option is designed for even larger numbers.  Usually,
-            the default of `"auto"` is what you want.
-
-        parameterization : {"P", "P terms", "P clifford terms"}
-            Where *P* can be any Lindblad parameterization base type (e.g. CPTP,
-            H+S+A, H+S, S, D, etc.) This is the type of parameterizaton to use in
-            the constructed model.  Types without any "terms" suffix perform
-            usual density-matrix evolution to compute circuit probabilities.  The
-            other "terms" options compute probabilities using a path-integral
-            approach designed for larger numbers of qubits (experts only).
-
-        spamtype : { "static", "lindblad", "tensorproduct" }
-            Specifies how the SPAM elements of the returned `Model` are formed.
-            Static elements are ideal (perfect) operations with no parameters, i.e.
-            no possibility for noise.  Lindblad SPAM operations are the "normal"
-            way to allow SPAM noise, in which case error terms up to weight
-            `maxSpamWeight` are included.  Tensor-product operations require that
-            the state prep and POVM effects have a tensor-product structure; the
-            "tensorproduct" mode exists for historical reasons and is *deprecated*
-            in favor of `"lindblad"`; use it only if you know what you're doing.
-
-        addIdleNoiseToAllGates: bool, optional
-            Whether the global idle should be added as a factor following the
-            ideal action of each of the non-idle gates.
-
-        errcomp_type : {"gates","errorgens"}
-            How errors are composed when creating layer operations in the returned
-            model.  `"gates"` means that the errors on multiple gates in a single
-            layer are composed as separate and subsequent processes.  Specifically,
-            the layer operation has the form `Composed(target,idleErr,cloudErr)`
-            where `target` is a composition of all the ideal gate operations in the
-            layer, `idleErr` is idle error (`.operation_blks['layers']['globalIdle']`),
-            and `cloudErr` is the composition (ordered as layer-label) of cloud-
-            noise contributions, i.e. a map that acts as the product of exponentiated
-            error-generator matrices.  `"errorgens"` means that layer operations
-            have the form `Composed(target, error)` where `target` is as above and
-            `error` results from composing the idle and cloud-noise error
-            *generators*, i.e. a map that acts as the exponentiated sum of error
-            generators (ordering is irrelevant in this case).
-
-        independent_clouds : bool, optional
-            Currently this must be set to True.  In a future version, setting to
-            true will allow all the clouds of a given gate name to have a similar
-            cloud-noise process, mapped to the full qubit graph via a stencil.
-
-        verbosity : int, optional
-            An integer >= 0 dictating how must output to send to stdout.
-
-        Returns
-        -------
-        CloudNoiseModel
-        """
-        if nonstd_gate_unitaries is None: nonstd_gate_unitaries = {}
-        std_unitaries = _itgs.get_standard_gatename_unitaries()
-
-        gatedict = _collections.OrderedDict()
-        for name in gate_names:
-            U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
-            if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
-            gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
-            # assume evotype is a densitymx or term type
-
-        return cls.build_from_hops_and_weights(
-            nQubits, gatedict, availability, qubit_labels, geometry,
-            maxIdleWeight, maxSpamWeight, maxhops,
-            extraWeight1Hops, extraGateWeight, sparse,
-            sim_type, parameterization, spamtype,
-            addIdleNoiseToAllGates, errcomp_type, independent_clouds, verbosity)
-
-    @classmethod
-    def build_from_hops_and_weights(cls, nQubits, gatedict, availability=None,
-                                    qubit_labels=None, geometry="line",
-                                    maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
-                                    extraWeight1Hops=0, extraGateWeight=0, sparse=False,
-                                    sim_type="auto", parameterization="H+S",
-                                    spamtype="lindblad", addIdleNoiseToAllGates=True,
-                                    errcomp_type="gates", independent_clouds=True, verbosity=0):
-        """
-        Create a n-qubit model using a low-weight and geometrically local
-        error model with a common "global idle" operation.
-
-        This type of model is referred to as a "cloud noise" model because
-        noise specific to a gate may act on a neighborhood or cloud around
-        the gate's target qubits.  This type of model is generally useful
-        for performing GST on a multi-qubit system.
-
-        Parameters
-        ----------
-        nQubits : int
-            The number of qubits
-
-        gatedict : dict
-            A dictionary (an `OrderedDict` if you care about insertion order) which
-            associates with string-type gate names (e.g. `"Gx"`) :class:`LinearOperator`,
-            `numpy.ndarray` objects. When the objects may act on fewer than the total
-            number of qubits (determined by their dimension/shape) then they are
-            repeatedly embedded into `nQubits`-qubit gates as specified by `availability`.
+        custom_gates : dict
+            A dictionary that associates with gate labels
+            :class:`LinearOperator`, :class:`OpFactory`, or `numpy.ndarray`
+            objects.  These objects describe the full action of the gate or
+            primitive-layer they're labeled by (so if the model represents
+            states by density matrices these objects are superoperators, not
+            unitaries), and override any standard construction based on builtin
+            gate names or `nonstd_gate_unitaries`.  Keys of this dictionary must
+            be string-type gate *names* -- they cannot include state space labels
+            -- and they must be *static* (have zero parameters) because they
+            represent only the ideal behavior of each gate -- the cloudnoise
+            operations represent the parameterized noise.  To fine-tune how this
+            noise is parameterized, call the :class:`CloudNoiseModel` constructor
+            directly.
 
         availability : dict, optional
             A dictionary whose keys are the same gate names as in
@@ -280,12 +116,19 @@ class CloudNoiseModel(_ImplicitOpModel):
             the `1-qubit `'Gx'`-gate to be embedded three times, acting on qubits
             0, 1, and 2, and the 2-qubit `'Gcnot'`-gate to be embedded twice,
             acting on qubits 0 & 1 and 1 & 2.  Instead of a list of tuples,
-            values of `availability` may take the special values
-            `"all-permutations"` and `"all-combinations"`, which as their names
-            imply, equate to all possible permutations and combinations of the
-            appropriate number of qubit labels (deterined by the gate's dimension).
+            values of `availability` may take the special values:
+
+            - `"all-permutations"` and `"all-combinations"` equate to all possible
+            permutations and combinations of the appropriate number of qubit labels
+            (deterined by the gate's dimension).
+            - `"all-edges"` equates to all the vertices, for 1Q gates, and all the
+            edges, for 2Q gates of the geometry.
+            - `"arbitrary"` or `"*"` means that the corresponding gate can be placed
+            on any target qubits via an :class:`EmbeddingOpFactory` (uses less
+            memory but slower than `"all-permutations"`.
+
             If a gate name (a key of `gatedict`) is not present in `availability`,
-            the default is `"all-permutations"`.
+            the default is `"all-edges"`.
 
         qubit_labels : tuple, optional
             The circuit-line labels for each of the qubits, which can be integers
@@ -386,6 +229,24 @@ class CloudNoiseModel(_ImplicitOpModel):
             An integer >= 0 dictating how must output to send to stdout.
         """
         printer = _VerbosityPrinter.build_printer(verbosity)
+
+        if custom_gates is None: custom_gates = {}
+        if nonstd_gate_unitaries is None: nonstd_gate_unitaries = {}
+        std_unitaries = _itgs.get_standard_gatename_unitaries()
+
+        gatedict = _collections.OrderedDict()
+        for name in gate_names:
+            if name in custom_gates:
+                gatedict[name] = custom_gates[name]
+            else:
+                U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
+                if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
+                gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
+                # assume evotype is a densitymx or term type
+
+        #Add anything from custom_gates directly if it wasn't added already
+        for lbl, gate in custom_gates.items():
+            if lbl not in gate_names: gatedict[lbl] = gate
 
         if qubit_labels is None:
             qubit_labels = tuple(range(nQubits))
@@ -476,6 +337,10 @@ class CloudNoiseModel(_ImplicitOpModel):
         cloud_maxhops_2Q = max([mx for wt, mx in weight_maxhops_tuples_2Q])  # max of max-hops
 
         def build_cloudnoise_fn(lbl):
+            gate_nQubits = len(lbl.sslbls)
+            if gate_nQubits not in (1, 2):
+                raise ValueError("Only 1- and 2-qubit gates are supported.  %s acts on %d qubits!"
+                                 % (str(lbl.name), gate_nQubits))
             weight_maxhops_tuples = weight_maxhops_tuples_1Q if len(lbl.sslbls) == 1 else weight_maxhops_tuples_2Q
             return _build_nqn_cloud_noise(
                 lbl.sslbls, qubitGraph, weight_maxhops_tuples,
@@ -515,11 +380,14 @@ class CloudNoiseModel(_ImplicitOpModel):
             The number of qubits
 
         gatedict : dict
-            A dictionary (an `OrderedDict` if you care about insertion order) which
+            A dictionary (an `OrderedDict` if you care about insertion order) that
             associates with string-type gate names (e.g. `"Gx"`) :class:`LinearOperator`,
-            `numpy.ndarray` objects. When the objects may act on fewer than the total
-            number of qubits (determined by their dimension/shape) then they are
-            repeatedly embedded into `nQubits`-qubit gates as specified by `availability`.
+            `numpy.ndarray`, or :class:`OpFactory` objects. When the objects may act on
+            fewer than the total number of qubits (determined by their dimension/shape) then
+            they are repeatedly embedded into `nQubits`-qubit gates as specified by their
+            `availability`.  These operations represent the ideal target operations, and
+            thus, any `LinearOperator` or `OpFactory` objects must be *static*, i.e., have
+            zero parameters.
 
         availability : dict, optional
             A dictionary whose keys are the same gate names as in
@@ -531,12 +399,19 @@ class CloudNoiseModel(_ImplicitOpModel):
             the `1-qubit `'Gx'`-gate to be embedded three times, acting on qubits
             0, 1, and 2, and the 2-qubit `'Gcnot'`-gate to be embedded twice,
             acting on qubits 0 & 1 and 1 & 2.  Instead of a list of tuples,
-            values of `availability` may take the special values
-            `"all-permutations"` and `"all-combinations"`, which as their names
-            imply, equate to all possible permutations and combinations of the
-            appropriate number of qubit labels (deterined by the gate's dimension).
+            values of `availability` may take the special values:
+
+            - `"all-permutations"` and `"all-combinations"` equate to all possible
+            permutations and combinations of the appropriate number of qubit labels
+            (deterined by the gate's dimension).
+            - `"all-edges"` equates to all the vertices, for 1Q gates, and all the
+            edges, for 2Q gates of the geometry.
+            - `"arbitrary"` or `"*"` means that the corresponding gate can be placed
+            on any target qubits via an :class:`EmbeddingOpFactory` (uses less
+            memory but slower than `"all-permutations"`.
+
             If a gate name (a key of `gatedict`) is not present in `availability`,
-            the default is `"all-permutations"`.
+            the default is `"all-edges"`.
 
         qubit_labels : tuple, optional
             The circuit-line labels for each of the qubits, which can be integers
@@ -627,10 +502,33 @@ class CloudNoiseModel(_ImplicitOpModel):
         if availability is None:
             availability = {}
 
-        #Set members
+        # Build gate dictionaries. A value of `gatedict` can be an array, a LinearOperator, or an OpFactory.
+        # For later processing, we'll create mm_gatedict to contain each item as a ModelMember.  For cloud-
+        # noise models, these gate operations should be *static* (no parameters) as they represent the target
+        # operations and all noise (and parameters) are assumed to enter through the cloudnoise members.
+        StaticDenseOp = _get_Static_factory(sim_type, evotype)  # always a *gate*
+        mm_gatedict = _collections.OrderedDict()  # static *target* ops as ModelMembers
+        #REMOVE self.gatedict = _collections.OrderedDict()  # static *target* ops (unused) as numpy arrays (so copying is clean)
+        for gn, gate in gatedict.items():
+            if isinstance(gate, _op.LinearOperator):
+                assert(gate.num_params() == 0), "Only *static* ideal operators are allowed in `gatedict`!"
+                #REMOVE self.gatedict[gn] = gate.todense()
+                if gate._evotype != evotype and isinstance(gate, _op.StaticDenseOp):
+                    # special case: we'll convert static ops to the right evotype (convenient)
+                    mm_gatedict[gn] = StaticDenseOp(gate, "pp")
+                else:
+                    mm_gatedict[gn] = gate
+            elif isinstance(gate, _opfactory.OpFactory):
+                assert(gate.num_params() == 0), "Only *static* ideal factories are allowed in `gatedict`!"
+                # don't store factories in self.gatedict for now (no good dense representation)
+                mm_gatedict[gn] = gate
+            else:  # presumably a numpy array or something like it:
+                #REMOVE self.gatedict[gn] = _np.array(gate)
+                mm_gatedict[gn] = StaticDenseOp(gate, "pp")
+            assert(mm_gatedict[gn]._evotype == evotype)
+            
+        #Set other members
         self.nQubits = nQubits
-        self.gatedict = _collections.OrderedDict(
-            [(gn, _np.array(gate)) for gn, gate in gatedict.items()])  # only hold numpy arrays (so copying is clean)
         self.availability = availability
         self.qubit_labels = qubit_labels
         self.geometry = geometry
@@ -676,7 +574,8 @@ class CloudNoiseModel(_ImplicitOpModel):
         self.operation_blks['gates'] = _ld.OrderedMemberDict(self, None, None, flags)
         self.operation_blks['cloudnoise'] = _ld.OrderedMemberDict(self, None, None, flags)
         self.instrument_blks['layers'] = _ld.OrderedMemberDict(self, None, None, flags)
-        self.factories['targetops'] = _ld.OrderedMemberDict(self, None, None, flags)
+        self.factories['layers'] = _ld.OrderedMemberDict(self, None, None, flags)
+        self.factories['gates'] = _ld.OrderedMemberDict(self, None, None, flags)
         self.factories['cloudnoise'] = _ld.OrderedMemberDict(self, None, None, flags)
 
         printer = _VerbosityPrinter.build_printer(verbosity)
@@ -704,13 +603,10 @@ class CloudNoiseModel(_ImplicitOpModel):
 
         #Get gates availability
         primitive_ops = []
-        oneQ_gates_and_avail = _collections.OrderedDict()
-        twoQ_gates_and_avail = _collections.OrderedDict()
-        for gateName, gate in self.gatedict.items():  # gate is a numpy array
-            gate_nQubits = int(round(_np.log2(gate.shape[0]) / 2))
-            if gate_nQubits not in (1, 2):
-                raise ValueError("Only 1- and 2-qubit gates are supported.  %s acts on %d qubits!"
-                                 % (str(gateName), gate_nQubits))
+        gates_and_avail = _collections.OrderedDict()
+        for gateName, gate in mm_gatedict.items():  # gate is a static ModelMember (op or factory)
+            gate_nQubits = int(round(_np.log2(gate.dim) / 2)) if (evotype in ("densitymx", "svterm", "cterm")) \
+                else int(round(_np.log2(gate.dim)))  # evotype in ("statevec","stabilizer")
 
             availList = self.availability.get(gateName, 'all-edges')
             if availList == 'all-combinations':
@@ -722,39 +618,66 @@ class CloudNoiseModel(_ImplicitOpModel):
                     availList = [(i,) for i in qubit_labels]
                 elif gate_nQubits == 2:
                     availList = qubitGraph.edges(double_for_undirected=True)
+                else:
+                    raise NotImplementedError(("I don't know how to place a %d-qubit gate "
+                                               "on graph edges yet") % gate_nQubits)
+            elif availList in ('arbitrary', '*'):
+                availList = [('*', gate_nQubits)]  # let a factory determine what's "available"
+                    
             self.availability[gateName] = tuple(availList)
-
-            if gate_nQubits == 1:
-                oneQ_gates_and_avail[gateName] = (gate, availList)
-            elif gate_nQubits == 2:
-                twoQ_gates_and_avail[gateName] = (gate, availList)
-
-        #1Q gates: e.g. X(pi/2) & Y(pi/2) on each qubit
-
-        #REMOVE
-        #weight_maxhops_tuples_1Q = [(1, maxhops + extraWeight1Hops)] + \
-        #                           [(1 + x, maxhops) for x in range(1, extraGateWeight + 1)]
-        #cloud_maxhops = max([mx for wt, mx in weight_maxhops_tuples_1Q])  # max of max-hops
+            gates_and_avail[gateName] = (gate, availList)
 
         ssAllQ = qubit_sslbls  # labls should also be node-names of qubitGraph
-
         EmbeddedDenseOp = _op.EmbeddedDenseOp if sim_type == "matrix" else _op.EmbeddedOp
-        StaticDenseOp = _get_Static_factory(sim_type, evotype)  # always a *gate*
+        
+        for gn, (gate, availList) in gates_and_avail.items():
+            #Note: gate was taken from mm_gatedict, and so is a static op or factory
+            gate_is_factory = isinstance(gate, _opfactory.OpFactory)
+            
+            if gate_is_factory:
+                self.factories['gates'][_Lbl(gn)] = gate
+            else:
+                self.operation_blks['gates'][_Lbl(gn)] = gate
 
-        for gn, (gate, availList) in oneQ_gates_and_avail.items():
-            embedded_gate = StaticDenseOp(gate, "pp")
-            self.operation_blks['gates'][_Lbl(gn)] = embedded_gate
+            for inds in availList:  # inds are target qubit labels
 
-            for (i,) in availList:  # so 'i' is target qubit label
-                #Target operations
-                printer.log("Creating 1Q %s gate on qubit %s!!" % (gn, str(i)))
-                self.operation_blks['layers'][_Lbl(gn, i)] = EmbeddedDenseOp(
-                    ssAllQ, [i], embedded_gate)
-                primitive_ops.append(_Lbl(gn, i))
+                #Target operation
+                if inds[0] == '*':
+                    printer.log("Creating %dQ %s gate on arbitrary qubits!!" % (inds[1], gn))
 
+                    self.factories['layers'][_Lbl(gn)] = _opfactory.EmbeddingOpFactory(
+                        ssAllQ, gate, dense=bool(sim_type == "matrix"), num_target_labels=inds[1])
+                    # add any primitive ops for this embedding factory?
+                else:
+                    printer.log("Creating %dQ %s gate on qubits %s!!" % (len(inds), gn, inds))
+                    assert(_Lbl(gn, inds) not in gatedict), \
+                        ("Cloudnoise models do not accept primitive-op labels, e.g. %s, in `gatedict` as this dict "
+                         "specfies the ideal target gates. Perhaps make the cloudnoise depend on the target qubits "
+                         "of the %s gate?") % (str(_Lbl(gn, inds)), gn)
+
+                    if gate_is_factory:
+                        self.factories['layers'][_Lbl(gn, inds)] = _opfactory.EmbeddedOpFactory(
+                            ssAllQ, inds, gate, dense=bool(sim_type == "matrix"))
+                        # add any primitive ops for this factory?
+                    else:
+                        self.operation_blks['layers'][_Lbl(gn, inds)] = EmbeddedDenseOp(
+                            ssAllQ, inds, gate)
+                        primitive_ops.append(_Lbl(gn, inds))
+
+                #Cloudnoise operation
                 if build_cloudnoise_fn is not None:
-                    self.operation_blks['cloudnoise'][_Lbl(gn, i)] = \
-                        build_cloudnoise_fn(_Lbl(gn, i))  # , qubitGraph, sparse, sim_type, errcomp_type, printer-1)
+                    if inds[0] == '*':
+                        cloudnoise = build_cloudnoise_fn(_Lbl(gn))
+                        assert(isinstance(cloudnoise, _opfactory.EmbeddingOpFactory)), \
+                            ("`build_cloudnoise_fn` must return an EmbeddingOpFactory for gate %s"
+                             " with arbitrary availability") % gn
+                        self.factories['cloudnoise'][_Lbl(gn)] = cloudnoise
+                    else:
+                        cloudnoise = build_cloudnoise_fn(_Lbl(gn, inds))
+                        if isinstance(cloudnoise, _opfactory.OpFactory):
+                            self.factories['cloudnoise'][_Lbl(gn, inds)] = cloudnoise
+                        else:
+                            self.operation_blks['cloudnoise'][_Lbl(gn, inds)] = cloudnoise
 
                 #REMOVE
                 #_build_nqn_cloud_noise(
@@ -764,45 +687,15 @@ class CloudNoiseModel(_ImplicitOpModel):
                 #cloud_inds = tuple(qubitGraph.radius((i,), cloud_maxhops))
                 #cloud_key = ((i,), tuple(sorted(cloud_inds)))  # (sets are unhashable)
 
-                if build_cloudkey_fn is not None:  # TODO: is there any way to get a default "key", e.g. the
+                if inds[0] != '*' and build_cloudkey_fn is not None:
+                    # TODO: is there any way to get a default "key", e.g. the
                     # qubits touched by the corresponding cloudnoise op?
                     # need a way to identify a clound (e.g. Gx and Gy gates on some qubit will have the *same* cloud)
-                    cloud_key = build_cloudkey_fn(_Lbl(gn, i))
+                    cloud_key = build_cloudkey_fn(_Lbl(gn, inds))
                     if cloud_key not in self.clouds: self.clouds[cloud_key] = []
-                    self.clouds[cloud_key].append(_Lbl(gn, i))
+                    self.clouds[cloud_key].append(_Lbl(gn, inds))
                 #keep track of the primitive-layer labels in each cloud,
                 # used to specify which gate parameters should be amplifiable by germs for a given cloud (?) TODO CHECK
-
-        #2Q gates: e.g. CNOT gates along each graph edge
-        #weight_maxhops_tuples_2Q = [(1, maxhops + extraWeight1Hops), (2, maxhops)] + \
-        #                           [(2 + x, maxhops) for x in range(1, extraGateWeight + 1)]
-        #cloud_maxhops = max([mx for wt, mx in weight_maxhops_tuples_2Q])  # max of max-hops
-        for gn, (gate, availList) in twoQ_gates_and_avail.items():
-            embedded_gate = StaticDenseOp(gate, "pp")
-            self.operation_blks['gates'][_Lbl(gn)] = embedded_gate
-
-            for (i, j) in availList:  # so 'i' and 'j' are target qubit labels
-                printer.log("Creating %s gate between qubits %s and %s!!" % (gn, str(i), str(j)))
-                self.operation_blks['layers'][_Lbl(gn, (i, j))] = EmbeddedDenseOp(
-                    ssAllQ, [i, j], embedded_gate)
-                primitive_ops.append(_Lbl(gn, (i, j)))
-
-                if build_cloudnoise_fn is not None:
-                    self.operation_blks['cloudnoise'][_Lbl(gn, (i, j))] = \
-                        build_cloudnoise_fn(_Lbl(gn, (i, j)))
-
-                #REMOVE
-                # _build_nqn_cloud_noise(
-                #    (i, j), qubitGraph, weight_maxhops_tuples_2Q,
-                #    errcomp_type=errcomp_type, sparse=sparse, sim_type=sim_type,
-                #    parameterization=parameterization, verbosity=printer - 1)
-                #cloud_inds = tuple(qubitGraph.radius((i, j), cloud_maxhops))
-                #cloud_key = (tuple(sorted([i, j])), tuple(sorted(cloud_inds)))
-
-                if build_cloudkey_fn is not None:
-                    cloud_key = build_cloudkey_fn(_Lbl(gn, (i, j)))
-                    if cloud_key not in self.clouds: self.clouds[cloud_key] = []
-                    self.clouds[cloud_key].append(_Lbl(gn, (i, j)))
 
         #SPAM (same as for local noise model)
         if prep_layers is None:
@@ -962,9 +855,9 @@ def _get_Static_factory(sim_type, evotype):
         given the simulation and parameterization """
     if evotype == "densitymx":
         if sim_type == "matrix":
-            return lambda g, b: _op.StaticDenseOp(g)
+            return lambda g, b: _op.StaticDenseOp(g, evotype)
         elif sim_type == "map":
-            return lambda g, b: _op.StaticDenseOp(g)  # TODO: create StaticGateMap?
+            return lambda g, b: _op.StaticDenseOp(g, evotype)  # TODO: create StaticGateMap?
 
     elif evotype in ("svterm", "cterm"):
         assert(sim_type.startswith("termorder"))
@@ -1316,7 +1209,7 @@ class CloudNoiseLayerLizard(_ImplicitLayerLizard):
         elif complbl in self.op_blks['layers']:
             return self.op_blks['layers'][complbl]
         else:
-            return _opfactory.op_from_factories(self.model.factories['targetops'], complbl)
+            return _opfactory.op_from_factories(self.model.factories['layers'], complbl)
 
     def get_layer_component_cloudnoise(self, complbl):
         if complbl in self.op_blks['cloudnoise']:

--- a/packages/pygsti/objects/cloudnoisemodel.py
+++ b/packages/pygsti/objects/cloudnoisemodel.py
@@ -1185,7 +1185,7 @@ class CloudNoiseLayerLizard(_ImplicitLayerLizard):
 
         if errcomp_type == "gates":
             if add_idle_noise: ops_to_compose.append(self.op_blks['layers']['globalIdle'])
-            component_cloudnoise_ops = self.get_layer_component_cloudnoises(components),
+            component_cloudnoise_ops = self.get_layer_component_cloudnoises(components)
             if len(component_cloudnoise_ops) > 0:
                 if len(component_cloudnoise_ops) > 1:
                     localErr = Composed(component_cloudnoise_ops,

--- a/packages/pygsti/objects/cloudnoisemodel.py
+++ b/packages/pygsti/objects/cloudnoisemodel.py
@@ -89,7 +89,12 @@ class CloudNoiseModel(_ImplicitOpModel):
 
         nonstd_gate_unitaries : dict, optional
             A dictionary of numpy arrays which specifies the unitary gate action
-            of the gate names given by the dictionary's keys.
+            of the gate names given by the dictionary's keys.  As an advanced
+            behavior, a unitary-matrix-returning function which takes a single
+            argument - a tuple of label arguments - may be given instead of a
+            single matrix to create an operation *factory* which allows
+            continuously-parameterized gates.  This function must also return
+            an empty/dummy unitary when `None` is given as it's argument.
 
         custom_gates : dict
             A dictionary that associates with gate labels

--- a/packages/pygsti/objects/localnoisemodel.py
+++ b/packages/pygsti/objects/localnoisemodel.py
@@ -96,7 +96,12 @@ class LocalNoiseModel(_ImplicitOpModel):
         nonstd_gate_unitaries : dict, optional
             A dictionary of numpy arrays which specifies the unitary gate action
             of the gate names given by the dictionary's keys.  This is used
-            to augment the standard unitaries built into pyGSTi.
+            to augment the standard unitaries built into pyGSTi.  As an advanced
+            behavior, a unitary-matrix-returning function which takes a single
+            argument - a tuple of label arguments - may be given instead of a
+            single matrix to create an operation *factory* which allows
+            continuously-parameterized gates.  This function must also return
+            an empty/dummy unitary when `None` is given as it's argument.
 
         custom_gates : dict, optional
             A dictionary that associates with gate labels

--- a/packages/pygsti/objects/localnoisemodel.py
+++ b/packages/pygsti/objects/localnoisemodel.py
@@ -40,38 +40,39 @@ class LocalNoiseModel(_ImplicitOpModel):
     """
 
     @classmethod
-    def build_standard_from_parameterization(
-            cls, nQubits, gate_names, nonstd_gate_unitaries=None, availability=None,
-            qubit_labels=None, geometry="line", parameterization='static',
-            evotype="auto", sim_type="auto", on_construction_error='raise',
-            independent_gates=False, ensure_composed_gates=False, globalIdle=None):
+    def build_from_parameterization(cls, nQubits, gate_names, nonstd_gate_unitaries=None,
+                                    custom_gates=None, availability=None, qubit_labels=None,
+                                    geometry="line", parameterization='static', evotype="auto",
+                                    sim_type="auto", on_construction_error='raise',
+                                    independent_gates=False, ensure_composed_gates=False,
+                                    global_idle=None):
         """
-        Creates a "standard" n-qubit model, usually of ideal gates, which
-        is capable of describing "local noise", that is, noise/error that only
-        acts on the *target qubits* of a given gate.
+        Creates a n-qubit model, usually of ideal gates, that is capable of
+        describing "local noise", that is, noise/error that only acts on the
+        *target qubits* of a given gate.  The created model typically embeds
+        the *same* gates on many different target-qubit sets, according to
+        their "availability".  It also creates a perfect 0-prep and z-basis POVM.
+
+        The gates typically specified in terms of numpy arrays that define
+        their ideal "target" actions, and this constructor method converts
+        those arrays into gates or SPAM elements with the paramterization
+        given by `parameterization`.  When `independent_gates=False`,
+        parameterization of each gate is done once, before any embedding, so
+        that just a single set of parameters will exist for each
+        low-dimensional gate. Thus, this function provides a quick
+        and easy way to setup a model where the gates are all parameterized
+        in the same way (e.g. TP-constrained).
+
+        That said, the `custom_gates` argument allows the user to add
+        almost arbitrary customization to the gates within the local-noise
+        approximation (that gates *only* act nontrivially on their target
+        qubits).
 
         For example, in a model with 4 qubits, a X(pi/2) gate on the 2nd
         qubit (which might be labelled something like `("Gx",1)`) can only
         act non-trivially on the 2nd qubit in a local noise model.  Because
         of a local noise  model's limitations, it is often used for describing
         ideal gates or very simple perturbations of them.
-
-        The returned model is "standard", in that the following standard gate
-        names may be specified as elements to `gate_names` without the need to
-        supply their corresponding unitaries (as one must when calling
-        the constructor directly):
-
-        - 'Gi' : the 1Q idle operation
-        - 'Gx','Gy','Gz' : 1Q pi/2 rotations
-        - 'Gxpi','Gypi','Gzpi' : 1Q pi rotations
-        - 'Gh' : Hadamard
-        - 'Gp' : phase
-        - 'Gcphase','Gcnot','Gswap' : standard 2Q gates
-
-        Furthermore, if additional "non-standard" gates are needed,
-        they are specified by their *unitary* gate action, even if
-        the final model propagates density matrices (as opposed
-        to state vectors).
 
         Parameters
         ----------
@@ -83,148 +84,34 @@ class LocalNoiseModel(_ImplicitOpModel):
             the list of builtin "standard" gate names given above or from the
             keys of `nonstd_gate_unitaries`.  These are the typically 1- and 2-qubit
             gates that are repeatedly embedded (based on `availability`) to form
-            the resulting model.
+            the resulting model.  These buildin names include:
+
+            - 'Gi' : the 1Q idle operation
+            - 'Gx','Gy','Gz' : 1Q pi/2 rotations
+            - 'Gxpi','Gypi','Gzpi' : 1Q pi rotations
+            - 'Gh' : Hadamard
+            - 'Gp' : phase
+            - 'Gcphase','Gcnot','Gswap' : standard 2Q gates
 
         nonstd_gate_unitaries : dict, optional
             A dictionary of numpy arrays which specifies the unitary gate action
-            of the gate names given by the dictionary's keys.
+            of the gate names given by the dictionary's keys.  This is used
+            to augment the standard unitaries built into pyGSTi.
 
-        availability : dict, optional
-            A dictionary whose keys are the same gate names as in
-            `gate_names` and whose values are lists of qubit-label-tuples.  Each
-            qubit-label-tuple must have length equal to the number of qubits
-            the corresponding gate acts upon, and specifies that the named gate
-            is available to act on the specified qubits.  For example,
-            `{ 'Gx': [(0,),(1,),(2,)], 'Gcnot': [(0,1),(1,2)] }` would cause
-            the `1-qubit `'Gx'`-gate to be available for acting on qubits
-            0, 1, or 2, and the 2-qubit `'Gcnot'`-gate to be availalbe to
-            act on qubits 0 & 1 or 1 & 2.  Instead of a list of tuples, values of
-            `availability` may take the special values `"all-permutations"` and
-            `"all-combinations"`, which as their names imply, equate to all possible
-            permutations and combinations of the appropriate number of qubit labels
-            (deterined by the gate's dimension).  The default value `"all-edges"`
-            equates to all the edges in the graph given by `geometry`.
-
-        qubit_labels : tuple, optional
-            The circuit-line labels for each of the qubits, which can be integers
-            and/or strings.  Must be of length `nQubits`.  If None, then the
-            integers from 0 to `nQubits-1` are used.
-
-        geometry : {"line","ring","grid","torus"} or QubitGraph
-            The type of connectivity among the qubits, specifying a
-            graph used to define neighbor relationships.  Alternatively,
-            a :class:`QubitGraph` object with node labels equal to
-            `qubit_labels` may be passed directly.
-
-        parameterization : {"full", "TP", "CPTP", "H+S", "S", "static", "H+S terms",
-                            "H+S clifford terms", "clifford"}
-            The type of parameterizaton to use for each gate value before it is
-            embedded. See :method:`ExplicitOpModel.set_all_parameterizations`
-            for more details.
-
-        evotype : {"auto","densitymx","statevec","stabilizer","svterm","cterm"}
-            The evolution type.  Often this is determined by the choice of
-            `parameterization` and can be left as `"auto"`, which prefers
-            `"densitymx"` (full density matrix evolution) when possible. In some
-            cases, however, you may want to specify this manually.  For instance,
-            if you give unitary maps instead of superoperators in `gatedict`
-            you'll want to set this to `"statevec"`.
-
-        sim_type : {"auto", "matrix", "map", "termorder:<N>"}
-            The simulation method used to compute predicted probabilities for the
-            resulting :class:`Model`.  Usually `"auto"` is fine, the default for
-            each `evotype` is usually what you want.  Setting this to something
-            else is expert-level tuning.
-
-        on_construction_error : {'raise','warn',ignore'}
-            What to do when the creation of a gate with the given
-            `parameterization` fails.  Usually you'll want to `"raise"` the error.
-            In some cases, for example when converting as many gates as you can
-            into `parameterization="clifford"` gates, `"warn"` or even `"ignore"`
-            may be useful.
-
-        independent_gates : bool, optional
-            Whether gates are allowed independent local noise or not.  If False,
-            then all gates with the same name (e.g. "Gx") will have the *same*
-            (local) noise (e.g. an overrotation by 1 degree), and the
-            `operation_bks['gates']` dictionary contains a single key per gate
-            name.  If True, then gates with the same name acting on different
-            qubits may have different local noise, and so the
-            `operation_bks['gates']` dictionary contains a key for each gate
-             available gate placement.
-
-        ensure_composed_gates : bool, optional
-            If True then the elements of the `operation_bks['gates']` will always
-            be either :class:`ComposedDenseOp` (if `sim_type == "matrix"`) or
-            :class:`ComposedOp` (othewise) objects.  The purpose of this is to
-            facilitate modifying the gate operations after the model is created.
-            If False, then the appropriately parameterized gate objects (often
-            dense gates) are used directly.
-
-        globalIdle : LinearOperator, optional
-            A global idle operation, which is performed once at the beginning
-            of every circuit layer.  If `None`, no such operation is performed.
-            If a 1-qubit operator is given and `nQubits > 1` the global idle
-            is the parallel application of this operator on each qubit line.
-            Otherwise the given operator must act on all `nQubits` qubits.
-
-        Returns
-        -------
-        LocalNoiseModel
-        """
-        if nonstd_gate_unitaries is None: nonstd_gate_unitaries = {}
-        std_unitaries = _itgs.get_standard_gatename_unitaries()
-
-        if evotype == "auto":  # same logic as in LocalNoiseModel
-            if parameterization == "clifford": evotype = "stabilizer"
-            elif parameterization == "static unitary": evotype = "statevec"
-            elif _gt.is_valid_lindblad_paramtype(parameterization):
-                _, evotype = _gt.split_lindblad_paramtype(parameterization)
-            else: evotype = "densitymx"  # everything else
-
-        gatedict = _collections.OrderedDict()
-        for name in gate_names:
-            U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
-            if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
-            if evotype in ("densitymx", "svterm", "cterm"):
-                gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
-            else:  # we just store the unitaries
-                assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
-                gatedict[name] = U
-
-        return cls.build_from_parameterization(
-            nQubits, gatedict, availability, qubit_labels,
-            geometry, parameterization, evotype,
-            sim_type, on_construction_error,
-            independent_gates, ensure_composed_gates, globalIdle)
-
-    @classmethod
-    def build_from_parameterization(cls, nQubits, gatedict, availability=None, qubit_labels=None,
-                                    geometry="line", parameterization='static', evotype="auto",
-                                    sim_type="auto", on_construction_error='raise',
-                                    independent_gates=False, ensure_composed_gates=False,
-                                    global_idle=None):
-        """
-        Creates a n-qubit model by embedding the *same* gates from `gatedict`
-        as requested and creating a perfect 0-prep and z-basis POVM.
-
-        The gates in `gatedict` often act on fewer (typically just 1 or 2) than
-        the total `nQubits` qubits, in which case embedded-gate objects are
-        automatically (and repeatedly) created to wrap the lower-dimensional gate.
-        Parameterization of each gate is done once, before any embedding, so that
-        just a single set of parameters will exist for each low-dimensional gate.
-
-        Parameters
-        ----------
-        nQubits : int
-            The total number of qubits.
-
-        gatedict : dict
-            A dictionary (an `OrderedDict` if you care about insertion order) which
-            associates with string-type gate names (e.g. `"Gx"`) :class:`LinearOperator`,
-            `numpy.ndarray` objects. When the objects may act on fewer than the total
-            number of qubits (determined by their dimension/shape) then they are
-            repeatedly embedded into `nQubits`-qubit gates as specified by `availability`.
+        custom_gates : dict, optional
+            A dictionary that associates with gate labels
+            :class:`LinearOperator`, :class:`OpFactory`, or `numpy.ndarray`
+            objects.  These objects describe the full action of the gate or
+            primitive-layer they're labeled by (so if the model represents
+            states by density matrices these objects are superoperators, not
+            unitaries), and override any standard construction based on builtin
+            gate names or `nonstd_gate_unitaries`.  Keys of this dictionary may
+            be string-type gate *names*, which will be embedded according to
+            `availability`, or labels that include target qubits,
+            e.g. `("Gx",0)`, which override this default embedding behavior.
+            Furthermore, :class:`OpFactory` objects may be used in place of
+            `LinearOperator` objects to allow the evaluation of labels with
+            arguments.
 
         availability : dict, optional
             A dictionary whose keys are the same gate names as in
@@ -236,12 +123,19 @@ class LocalNoiseModel(_ImplicitOpModel):
             the `1-qubit `'Gx'`-gate to be embedded three times, acting on qubits
             0, 1, and 2, and the 2-qubit `'Gcnot'`-gate to be embedded twice,
             acting on qubits 0 & 1 and 1 & 2.  Instead of a list of tuples,
-            values of `availability` may take the special values
-            `"all-permutations"` and `"all-combinations"`, which as their names
-            imply, equate to all possible permutations and combinations of the
-            appropriate number of qubit labels (deterined by the gate's dimension).
+            values of `availability` may take the special values:
+
+            - `"all-permutations"` and `"all-combinations"` equate to all possible
+            permutations and combinations of the appropriate number of qubit labels
+            (deterined by the gate's dimension).
+            - `"all-edges"` equates to all the vertices, for 1Q gates, and all the
+            edges, for 2Q gates of the geometry.
+            - `"arbitrary"` or `"*"` means that the corresponding gate can be placed
+            on any target qubits via an :class:`EmbeddingOpFactory` (uses less
+            memory but slower than `"all-permutations"`.
+
             If a gate name (a key of `gatedict`) is not present in `availability`,
-            the default is `"all-permutations"`.
+            the default is `"all-edges"`.
 
         qubit_labels : tuple, optional
             The circuit-line labels for each of the qubits, which can be integers
@@ -312,12 +206,33 @@ class LocalNoiseModel(_ImplicitOpModel):
         -------
         LocalNoiseModel
         """
-        if evotype == "auto":  # Note: this same logic is repeated in build_standard above
+        if custom_gates is None: custom_gates = {}
+        if nonstd_gate_unitaries is None: nonstd_gate_unitaries = {}
+        std_unitaries = _itgs.get_standard_gatename_unitaries()
+
+        if evotype == "auto":  # same logic as in LocalNoiseModel
             if parameterization == "clifford": evotype = "stabilizer"
             elif parameterization == "static unitary": evotype = "statevec"
             elif _gt.is_valid_lindblad_paramtype(parameterization):
                 _, evotype = _gt.split_lindblad_paramtype(parameterization)
             else: evotype = "densitymx"  # everything else
+
+        gatedict = _collections.OrderedDict()
+        for name in gate_names:
+            if name in custom_gates:
+                gatedict[name] = custom_gates[name]
+            else:
+                U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
+                if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
+                if evotype in ("densitymx", "svterm", "cterm"):
+                    gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
+                else:  # we just store the unitaries
+                    assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
+                    gatedict[name] = U
+
+        #Add anything from custom_gates directly if it wasn't added already
+        for lbl, gate in custom_gates.items():
+            if lbl not in gate_names: gatedict[lbl] = gate
 
         if evotype in ("densitymx", "svterm", "cterm"):
             from ..construction import basis_build_vector as _basis_build_vector
@@ -404,7 +319,7 @@ class LocalNoiseModel(_ImplicitOpModel):
         #Convert elements of gatedict to given parameterization if needed
         for gateName in gatedict.keys():
             gate = gatedict[gateName]
-            if not isinstance(gate, _op.LinearOperator):
+            if not isinstance(gate, (_op.LinearOperator, _opfactory.OpFactory)):
                 try:
                     if parameterization == "static unitary":  # assume gate dict is already unitary gates?
                         gate = _op.StaticDenseOp(gate, "statevec")
@@ -458,11 +373,18 @@ class LocalNoiseModel(_ImplicitOpModel):
             The total number of qubits.
 
         gatedict : dict
-            A dictionary (an `OrderedDict` if you care about insertion order) which
-            associates with string-type gate names (e.g. `"Gx"`) :class:`LinearOperator`,
+            A dictionary (an `OrderedDict` if you care about insertion order) that
+            associates with gate names (e.g. `"Gx"`) :class:`LinearOperator`,
             `numpy.ndarray` objects. When the objects may act on fewer than the total
             number of qubits (determined by their dimension/shape) then they are
             repeatedly embedded into `nQubits`-qubit gates as specified by `availability`.
+            While the keys of this dictionary are usually string-type gate *names*,
+            labels that include target qubits, e.g. `("Gx",0)`, may be used to
+            override the default behavior of embedding a reference or a copy of
+            the gate associated with the same label minus the target qubits
+            (e.g. `"Gx"`).  Furthermore, :class:`OpFactory` objects may be used
+            in place of `LinearOperator` objects to allow the evaluation of labels
+            with arguments.
 
         prep_layers, povm_layers : None or operator or dict or list
             The SPAM operations as n-qubit layer operations.  If `None`, then
@@ -483,12 +405,19 @@ class LocalNoiseModel(_ImplicitOpModel):
             the `1-qubit `'Gx'`-gate to be embedded three times, acting on qubits
             0, 1, and 2, and the 2-qubit `'Gcnot'`-gate to be embedded twice,
             acting on qubits 0 & 1 and 1 & 2.  Instead of a list of tuples,
-            values of `availability` may take the special values
-            `"all-permutations"` and `"all-combinations"`, which as their names
-            imply, equate to all possible permutations and combinations of the
-            appropriate number of qubit labels (deterined by the gate's dimension).
+            values of `availability` may take the special values:
+
+            - `"all-permutations"` and `"all-combinations"` equate to all possible
+            permutations and combinations of the appropriate number of qubit labels
+            (deterined by the gate's dimension).
+            - `"all-edges"` equates to all the vertices, for 1Q gates, and all the
+            edges, for 2Q gates of the geometry.
+            - `"arbitrary"` or `"*"` means that the corresponding gate can be placed
+            on any target qubits via an :class:`EmbeddingOpFactory` (uses less
+            memory but slower than `"all-permutations"`.
+
             If a gate name (a key of `gatedict`) is not present in `availability`,
-            the default is `"all-permutations"`.
+            the default is `"all-edges"`.
 
         evotype : {"densitymx","statevec","stabilizer","svterm","cterm"}
             The evolution type.
@@ -543,9 +472,24 @@ class LocalNoiseModel(_ImplicitOpModel):
             qubitGraph = _qgraph.QubitGraph.common_graph(nQubits, geometry, directed=False,
                                                          qubit_labels=qubit_labels)
 
+        # Build gate dictionaries. A value of `gatedict` can be an array, a LinearOperator, or an OpFactory.
+        # For later processing, we'll create mm_gatedict to contain each item as a ModelMember.  In local noise
+        # models, these gates can be parameterized however the user desires - the LocalNoiseModel just embeds these
+        # operators appropriately.
+        mm_gatedict = _collections.OrderedDict()  # ops as ModelMembers
+        #REMOVE self.gatedict = _collections.OrderedDict()  # ops (unused) as numpy arrays (so copying is clean)
+        for gn, gate in gatedict.items():
+            if isinstance(gate, _op.LinearOperator):
+                #REMOVE self.gatedict[gn] = gate.todense()
+                mm_gatedict[gn] = gate
+            elif isinstance(gate, _opfactory.OpFactory):
+                # don't store factories in self.gatedict for now (no good dense representation)
+                mm_gatedict[gn] = gate
+            else:  # presumably a numpy array or something like it:
+                #REMOVE self.gatedict[gn] = _np.array(gate)
+                mm_gatedict[gn] = _op.StaticDenseOp(gate, evotype) # static gates by default
+
         self.nQubits = nQubits
-        self.gatedict = _collections.OrderedDict(
-            [(gn, _np.array(gate)) for gn, gate in gatedict.items()])  # only hold numpy arrays (so copying is clean)
         self.availability = availability
         self.qubit_labels = qubit_labels
         self.geometry = geometry
@@ -596,7 +540,8 @@ class LocalNoiseModel(_ImplicitOpModel):
         self.operation_blks['layers'] = _ld.OrderedMemberDict(self, None, None, flags)
         self.operation_blks['gates'] = _ld.OrderedMemberDict(self, None, None, flags)
         self.instrument_blks['layers'] = _ld.OrderedMemberDict(self, None, None, flags)
-        self.factories['ops'] = _ld.OrderedMemberDict(self, None, None, flags)
+        self.factories['gates'] = _ld.OrderedMemberDict(self, None, None, flags)
+        self.factories['layers'] = _ld.OrderedMemberDict(self, None, None, flags)
 
         #SPAM (same as for cloud noise model)
         if prep_layers is None:
@@ -624,17 +569,11 @@ class LocalNoiseModel(_ImplicitOpModel):
         Composed = _op.ComposedDenseOp if sim_type == "matrix" else _op.ComposedOp
         primitive_ops = []
 
-        for gateName, gate in gatedict.items():
-            if not isinstance(gate, _op.LinearOperator):
-                gate = _op.StaticDenseOp(gate, evotype)  # static gates by default
-
-            if not independent_gates:
-                if ensure_composed_gates and not isinstance(gate, Composed):
-                    #Make a single ComposedDenseOp *here*, which is used
-                    # in all the embeddings for different target qubits
-                    gate = Composed([gate])  # to make adding more factors easy
-                self.operation_blks['gates'][_Lbl(gateName)] = gate
-
+        for gateName, gate in mm_gatedict.items():  # gate is a ModelMember - either LinearOperator, or an OpFactory
+            if _Lbl(gateName).sslbls is not None: continue
+            # only process gate labels w/out sslbls (e.g. "Gx", not "Gx:0") - we'll check for the
+            # latter when we process the corresponding "name-only" gate's availability
+            
             gate_nQubits = int(round(_np.log2(gate.dim) / 2)) if (evotype in ("densitymx", "svterm", "cterm")) \
                 else int(round(_np.log2(gate.dim)))  # evotype in ("statevec","stabilizer")
 
@@ -651,11 +590,45 @@ class LocalNoiseModel(_ImplicitOpModel):
                 else:
                     raise NotImplementedError(("I don't know how to place a %d-qubit gate "
                                                "on graph edges yet") % gate_nQubits)
+            elif availList in ('arbitrary', '*'):
+                availList = [('*', gate_nQubits)]  # let a factory determine what's "available"
+
             self.availability[gateName] = tuple(availList)
 
+            gate_is_factory = isinstance(gate, _opfactory.OpFactory)
+            if not independent_gates:  # then get our "template" gate ready
+                if ensure_composed_gates and not isinstance(gate, Composed) and not gate_is_factory:
+                    #Make a single ComposedDenseOp *here*, which is used
+                    # in all the embeddings for different target qubits
+                    gate = Composed([gate])  # to make adding more factors easy
+                    
+                if gate_is_factory:
+                    self.factories['gates'][_Lbl(gateName)] = gate
+                else:
+                    self.operation_blks['gates'][_Lbl(gateName)] = gate
+
             for inds in availList:
-                if independent_gates:
-                    if ensure_composed_gates:
+
+                if inds[0] == '*':
+                    # then `gate` has arbitrary availability, and we just need to
+                    # put it in an EmbeddingOpFactory - no need to copy it or look
+                    # for overrides in `gatedict` - there's always just *one* instance
+                    # of an arbitrarily available gate or factory.
+                    base_gate = gate
+                    
+                elif _Lbl(gateName, inds) in mm_gatedict:
+                    #Allow elements of `gatedict` that *have* sslbls override the
+                    # default copy/reference of the "name-only" gate:
+                    base_gate = mm_gatedict[_Lbl(gateName, inds)]
+                    gate_is_factory = isinstance(base_gate, _opfactory.OpFactory)
+
+                    if gate_is_factory:
+                        self.factories['gates'][_Lbl(gateName, inds)] = base_gate
+                    else:
+                        self.operation_blks['gates'][_Lbl(gateName, inds)] = base_gate
+                        
+                elif independent_gates:  # then we need to ~copy `gate` so it has indep params
+                    if ensure_composed_gates and not gate_is_factory:
                         #Make a single ComposedDenseOp *here*, for *only this* embedding
                         # Don't copy gate here, as we assume it's ok to be shared when we
                         #  have independent composed gates
@@ -663,23 +636,43 @@ class LocalNoiseModel(_ImplicitOpModel):
                     else:  # want independent params but not a composed gate, so .copy()
                         base_gate = gate.copy()  # so independent parameters
 
-                    self.operation_blks['gates'][_Lbl(gateName, inds)] = base_gate
+                    if gate_is_factory:
+                        self.factories['gates'][_Lbl(gateName, inds)] = base_gate
+                    else:
+                        self.operation_blks['gates'][_Lbl(gateName, inds)] = base_gate
                 else:
                     base_gate = gate  # already a Composed operator (for easy addition
-                    # of factors) if ensure_composed_gates == True
+                    # of factors) if ensure_composed_gates == True and not gate_is_factory
 
+                #At this point, `base_gate` is the operator or factory that we want to embed
+                # into inds (except in the special case inds[0] == '*' where we make an EmbeddingOpFactory)
                 try:
                     # Note: can't use automatic-embedding b/c we need to force embedding
                     # when just ordering doesn't align (e.g. Gcnot:1:0 on 2-qubits needs to embed)
-                    if inds == tuple(qubit_labels):
-                        embedded_op = base_gate
-                    elif sim_type == "matrix":
-                        embedded_op = _op.EmbeddedDenseOp(self.state_space_labels, inds, base_gate)
-                    else:  # sim_type == "map" or sim_type.startswidth("termorder"):
-                        embedded_op = _op.EmbeddedOp(self.state_space_labels, inds, base_gate)
-                    self.operation_blks['layers'][_Lbl(gateName, inds)] = embedded_op
-                    primitive_ops.append(_Lbl(gateName, inds))
-
+                    if inds[0] == '*':
+                        embedded_op = _opfactory.EmbeddingOpFactory(self.state_space_labels, base_gate,
+                                                                    dense=bool(sim_type == "matrix"),
+                                                                    num_target_labels=inds[1])
+                        self.factories['layers'][_Lbl(gateName)] = embedded_op
+                        #Add any primitive ops for this factory?
+                        
+                    elif gate_is_factory:
+                        if inds == tuple(qubit_labels):  # then no need to embed
+                            embedded_op = base_gate
+                        else:
+                            embedded_op = _opfactory.EmbeddedOpFactory(self.state_space_labels, inds, base_gate,
+                                                                       dense=bool(sim_type == "matrix"))
+                        self.factories['layers'][_Lbl(gateName, inds)] = embedded_op
+                        #Add any primitive ops for this factory?
+                    else:
+                        if inds == tuple(qubit_labels):  # then no need to embed
+                            embedded_op = base_gate
+                        else:
+                            EmbeddedOp = _op.EmbeddedDenseOp if sim_type == "matrix" else _op.EmbeddedOp
+                            embedded_op = EmbeddedOp(self.state_space_labels, inds, base_gate)
+                        self.operation_blks['layers'][_Lbl(gateName, inds)] = embedded_op
+                        primitive_ops.append(_Lbl(gateName, inds))
+    
                 except Exception as e:
                     if on_construction_error == 'warn':
                         _warnings.warn("Failed to embed %s gate. Dropping it." % str(_Lbl(gateName, inds)))
@@ -756,4 +749,4 @@ class SimpleCompLayerLizard(_ImplicitLayerLizard):
         elif complbl in self.op_blks['layers']:
             return self.op_blks['layers'][complbl]
         else:
-            return _opfactory.op_from_factories(self.model.factories['ops'], complbl)
+            return _opfactory.op_from_factories(self.model.factories['layers'], complbl)

--- a/packages/pygsti/objects/localnoisemodel.py
+++ b/packages/pygsti/objects/localnoisemodel.py
@@ -223,9 +223,14 @@ class LocalNoiseModel(_ImplicitOpModel):
                 gatedict[name] = custom_gates[name]
             else:
                 U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
-                if U is None: raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
+                if U is None:
+                    raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
                 if evotype in ("densitymx", "svterm", "cterm"):
-                    gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
+                    if callable(U):  # then assume a function: args -> unitary
+                        U0 = U(None)  # U fns must return a sample unitary when passed None to get size.
+                        gatedict[name] = _opfactory.UnitaryOpFactory(U, U0.shape[0], evotype=evotype)
+                    else:
+                        gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
                 else:  # we just store the unitaries
                     assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
                     gatedict[name] = U

--- a/packages/pygsti/objects/localnoisemodel.py
+++ b/packages/pygsti/objects/localnoisemodel.py
@@ -497,7 +497,7 @@ class LocalNoiseModel(_ImplicitOpModel):
                 mm_gatedict[gn] = gate
             else:  # presumably a numpy array or something like it:
                 #REMOVE self.gatedict[gn] = _np.array(gate)
-                mm_gatedict[gn] = _op.StaticDenseOp(gate, evotype) # static gates by default
+                mm_gatedict[gn] = _op.StaticDenseOp(gate, evotype)  # static gates by default
 
         self.nQubits = nQubits
         self.availability = availability
@@ -583,7 +583,7 @@ class LocalNoiseModel(_ImplicitOpModel):
             if _Lbl(gateName).sslbls is not None: continue
             # only process gate labels w/out sslbls (e.g. "Gx", not "Gx:0") - we'll check for the
             # latter when we process the corresponding "name-only" gate's availability
-            
+
             gate_nQubits = int(round(_np.log2(gate.dim) / 2)) if (evotype in ("densitymx", "svterm", "cterm")) \
                 else int(round(_np.log2(gate.dim)))  # evotype in ("statevec","stabilizer")
 
@@ -611,7 +611,7 @@ class LocalNoiseModel(_ImplicitOpModel):
                     #Make a single ComposedDenseOp *here*, which is used
                     # in all the embeddings for different target qubits
                     gate = Composed([gate])  # to make adding more factors easy
-                    
+
                 if gate_is_factory:
                     self.factories['gates'][_Lbl(gateName)] = gate
                 else:
@@ -625,7 +625,7 @@ class LocalNoiseModel(_ImplicitOpModel):
                     # for overrides in `gatedict` - there's always just *one* instance
                     # of an arbitrarily available gate or factory.
                     base_gate = gate
-                    
+
                 elif _Lbl(gateName, inds) in mm_gatedict:
                     #Allow elements of `gatedict` that *have* sslbls override the
                     # default copy/reference of the "name-only" gate:
@@ -636,7 +636,7 @@ class LocalNoiseModel(_ImplicitOpModel):
                         self.factories['gates'][_Lbl(gateName, inds)] = base_gate
                     else:
                         self.operation_blks['gates'][_Lbl(gateName, inds)] = base_gate
-                        
+
                 elif independent_gates:  # then we need to ~copy `gate` so it has indep params
                     if ensure_composed_gates and not gate_is_factory:
                         #Make a single ComposedDenseOp *here*, for *only this* embedding
@@ -665,7 +665,7 @@ class LocalNoiseModel(_ImplicitOpModel):
                                                                     num_target_labels=inds[1])
                         self.factories['layers'][_Lbl(gateName)] = embedded_op
                         #Add any primitive ops for this factory?
-                        
+
                     elif gate_is_factory:
                         if inds == tuple(qubit_labels):  # then no need to embed
                             embedded_op = base_gate
@@ -682,7 +682,7 @@ class LocalNoiseModel(_ImplicitOpModel):
                             embedded_op = EmbeddedOp(self.state_space_labels, inds, base_gate)
                         self.operation_blks['layers'][_Lbl(gateName, inds)] = embedded_op
                         primitive_ops.append(_Lbl(gateName, inds))
-    
+
                 except Exception as e:
                     if on_construction_error == 'warn':
                         _warnings.warn("Failed to embed %s gate. Dropping it." % str(_Lbl(gateName, inds)))

--- a/packages/pygsti/objects/localnoisemodel.py
+++ b/packages/pygsti/objects/localnoisemodel.py
@@ -225,15 +225,15 @@ class LocalNoiseModel(_ImplicitOpModel):
                 U = nonstd_gate_unitaries.get(name, std_unitaries.get(name, None))
                 if U is None:
                     raise KeyError("'%s' gate unitary needs to be provided by `nonstd_gate_unitaries` arg" % name)
-                if evotype in ("densitymx", "svterm", "cterm"):
-                    if callable(U):  # then assume a function: args -> unitary
-                        U0 = U(None)  # U fns must return a sample unitary when passed None to get size.
-                        gatedict[name] = _opfactory.UnitaryOpFactory(U, U0.shape[0], evotype=evotype)
-                    else:
+                if callable(U):  # then assume a function: args -> unitary
+                    U0 = U(None)  # U fns must return a sample unitary when passed None to get size.
+                    gatedict[name] = _opfactory.UnitaryOpFactory(U, U0.shape[0], evotype=evotype)
+                else:
+                    if evotype in ("densitymx", "svterm", "cterm"):
                         gatedict[name] = _bt.change_basis(_gt.unitary_to_process_mx(U), "std", "pp")
-                else:  # we just store the unitaries
-                    assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
-                    gatedict[name] = U
+                    else:  # we just store the unitaries
+                        assert(evotype in ("statevec", "stabilizer")), "Invalid evotype: %s" % evotype
+                        gatedict[name] = U
 
         #Add anything from custom_gates directly if it wasn't added already
         for lbl, gate in custom_gates.items():

--- a/packages/pygsti/objects/operation.py
+++ b/packages/pygsti/objects/operation.py
@@ -5515,6 +5515,8 @@ class ComposedErrorgen(LinearOperator):
 
     def todense(self):
         """ Return this error generator as a dense matrix """
+        if len(self.factors) == 0:
+            return _np.zeros((self.dim, self.dim), 'd')
         mx = self.factors[0].todense()
         for eg in self.factors[1:]:
             mx += eg.todense()

--- a/packages/pygsti/objects/opfactory.py
+++ b/packages/pygsti/objects/opfactory.py
@@ -596,6 +596,8 @@ class ComposedOpFactory(OpFactory):
         self.dirty = True
 
 
+#Note: to pickle these Factories we'll probably need to some work
+# because they include functions.
 class UnitaryOpFactory(OpFactory):
     """
     Converts a function, f(arg_tuple), that outputs a unitary matrix (operation)

--- a/packages/pygsti/objects/opfactory.py
+++ b/packages/pygsti/objects/opfactory.py
@@ -393,7 +393,7 @@ class EmbeddingOpFactory(OpFactory):
         assert(self.num_target_labels is None or len(sslbls) == self.num_target_labels), \
             ("EmbeddingFactory.create_op called with the wrong number (%s) of target labels!"
              " (expected %d)") % (len(sslbls), self.num_target_labels)
-        
+
         Embedded = _op.EmbeddedDenseOp if self.dense else _op.EmbeddedOp
         if self.embeds_factory:
             op = self.embedded_factory_or_op.create_op(args, None)  # Note: will have its gpindices set already

--- a/packages/pygsti/objects/processorspec.py
+++ b/packages/pygsti/objects/processorspec.py
@@ -243,10 +243,10 @@ class ProcessorSpec(object):
         if model_name == 'clifford':
             assert(parameterization in ('auto', 'clifford')), "Clifford model must use 'clifford' parameterizations"
             assert(sim_type in ('auto', 'map')), "Clifford model must use 'map' simulation type"
-            model = _LocalNoiseModel.build_standard_from_parameterization(
+            model = _LocalNoiseModel.build_from_parameterization(
                 self.number_of_qubits,
                 self.root_gate_names,
-                self.nonstd_gate_unitaries,
+                self.nonstd_gate_unitaries, None,
                 self.availability,
                 self.qubit_labels,
                 parameterization='clifford',
@@ -260,9 +260,9 @@ class ProcessorSpec(object):
                 else parameterization
             if param in ('target', 'Target'): param = 'static'  # special case for 'target' model
 
-            model = _LocalNoiseModel.build_standard_from_parameterization(
+            model = _LocalNoiseModel.build_from_parameterization(
                 self.number_of_qubits, self.root_gate_names,
-                self.nonstd_gate_unitaries, self.availability,
+                self.nonstd_gate_unitaries, None, self.availability,
                 self.qubit_labels, parameterization=param, sim_type=sim_type,
                 independent_gates=False, ensure_composed_gates=False)  # change these? add `geometry`?
 
@@ -270,9 +270,9 @@ class ProcessorSpec(object):
             if parameterization == 'auto':
                 raise ValueError(
                     "Non-std model name '%s' means you must specify `parameterization` argument!" % model_name)
-            model = _LocalNoiseModel.build_standard_from_parameterization(
+            model = _LocalNoiseModel.build_from_parameterization(
                 self.number_of_qubits, self.root_gate_names,
-                self.nonstd_gate_unitaries, self.availability,
+                self.nonstd_gate_unitaries, None, self.availability,
                 self.qubit_labels, parameterization=parameterization, sim_type=sim_type,
                 independent_gates=False, ensure_composed_gates=False)  # change these? add `geometry`?
 

--- a/packages/pygsti/objects/processorspec.py
+++ b/packages/pygsti/objects/processorspec.py
@@ -469,7 +469,7 @@ class ProcessorSpec(object):
         nontrivial_gname_pauligate_pairs = []
         for gname in self.root_gate_names:
             if callable(self.root_gate_unitaries[gname]): continue  # can't pre-process factories
-            
+
             # We convert to process matrices, to avoid global phase problems.
             u = _gt.unitary_to_pauligate(self.root_gate_unitaries[gname])
             if u.shape == (4, 4):

--- a/packages/pygsti/objects/processorspec.py
+++ b/packages/pygsti/objects/processorspec.py
@@ -51,8 +51,10 @@ class ProcessorSpec(object):
             The number of qubits in the device.
 
         gate_names : list of strings
-            The names of gates in the device that correspond to standard gates known by pyGSTi.
-            The set of standard gates includes, but is not limited to:
+            The names of gates in the device.  This may include standard gate
+            names known by pyGSTi (see below) or names which appear in the
+            `nonstd_gate_unitaries` argument. The set of standard gate names
+            includes, but is not limited to:
 
             - 'Gi' : the 1Q idle operation
             - 'Gx','Gy','Gz' : 1-qubit pi/2 rotations
@@ -61,17 +63,23 @@ class ProcessorSpec(object):
             - 'Gp' : phase or S-gate (i.e., ((1,0),(0,i)))
             - 'Gcphase','Gcnot','Gswap' : standard 2-qubit gates
 
-            Alternative names can be used for all or any of these gates, but then they must be explicitly defined
-            in the `nonstd_gate_unitaries` dictionary.
+            Alternative names can be used for all or any of these gates, but
+            then they must be explicitly defined in the `nonstd_gate_unitaries`
+            dictionary.  Including any standard names in `nonstd_gate_unitaries`
+            overrides the default (builtin) unitary with the one supplied.
 
         nonstd_gate_unitaries: dictionary of numpy arrays
             A dictionary with keys that are gate names (strings) and values that are numpy arrays specifying
-            quantum gates in terms of unitary matrices. Together with the gates specified in the `gate_names`
-            list, these matrices specify the set of all (target) native gates that can be implemented in the device.
+            quantum gates in terms of unitary matrices. This is an additional "lookup" database of unitaries -
+            to add a gate to this `ProcessorSpec` its names still needs to appear in the `gate_names` list.
+            This dictionary's values specify additional (target) native gates that can be implemented in the device
             as unitaries acting on ordinary pure-state-vectors, in the standard computationl basis. These unitaries
             need not, and often should not, be unitaries acting on all of the qubits. E.g., a CNOT gate is specified
             by a key that is the desired name for CNOT, and a value that is the standard 4 x 4 complex matrix for CNOT.
-            All gate names must start with 'G'.
+            All gate names must start with 'G'.  As an advanced behavior, a unitary-matrix-returning function which
+            takes a single argument - a tuple of label arguments - may be given instead of a single matrix to create
+            an operation *factory* which allows continuously-parameterized gates.  This function must also return
+            an empty/dummy unitary when `None` is given as it's argument.
 
         availability : dict, optional
             A dictionary whose keys are some subset of the keys (which are gate names) `nonstd_gate_unitaries` and the
@@ -109,18 +117,20 @@ class ProcessorSpec(object):
         self.number_of_qubits = nQubits
         self.root_gate_names = gate_names[:]  # copy this list
         self.nonstd_gate_unitaries = nonstd_gate_unitaries.copy()
-        self.root_gate_names += list(self.nonstd_gate_unitaries.keys())
+        #self.root_gate_names += list(self.nonstd_gate_unitaries.keys())  # must specify all names in `gate_names`
         self.availability = availability.copy()
 
         # Stores the basic unitary matrices defining the gates, as it is convenient to have these easily accessable.
-        self.root_gate_unitaries = nonstd_gate_unitaries.copy()
+        self.root_gate_unitaries = _collections.OrderedDict()
         std_gate_unitaries = _itgs.get_standard_gatename_unitaries()
         for gname in gate_names:
-            try:
+            if gname in nonstd_gate_unitaries:
+                self.root_gate_unitaries[gname] = nonstd_gate_unitaries[gname]
+            elif gname in std_gate_unitaries:
                 self.root_gate_unitaries[gname] = std_gate_unitaries[gname]
-            except:
+            else:
                 raise ValueError(
-                    str(gname) + " is not a valid 'standard' gate name, so should not be an element of `gate_names`!")
+                    str(gname) + " is not a valid 'standard' gate name, it must be given in `nonstd_gate_unitaries`")
 
         # If no qubit labels are provided it defaults to integers from 0 to nQubits-1.
         if qubit_labels is None:
@@ -356,12 +366,14 @@ class ProcessorSpec(object):
             # Look to see if we have a CNOT gate in the model (with any name).
             cnot_name = None
             for gn in self.root_gate_names:
+                if callable(self.root_gate_unitaries[gn]): continue  # can't pre-process factories
                 if _itgs.is_gate_this_standard_unitary(self.root_gate_unitaries[gn], 'CNOT'):
                     cnot_name = gn
                     break
 
             H_name = None
             for gn in self.root_gate_names:
+                if callable(self.root_gate_unitaries[gn]): continue  # can't pre-process factories
                 if _itgs.is_gate_this_standard_unitary(self.root_gate_unitaries[gn], 'H'):
                     H_name = gn
                     break
@@ -370,6 +382,7 @@ class ProcessorSpec(object):
             # to find a gate that is Pauli-equivalent to Hadamard.
             if H_name is None and compile_type == 'paulieq':
                 for gn in self.root_gate_names:
+                    if callable(self.root_gate_unitaries[gn]): continue  # can't pre-process factories
                     if _symp.unitary_is_a_clifford(self.root_gate_unitaries[gn]):
                         if _itgs.is_gate_pauli_equivalent_to_this_standard_unitary(self.root_gate_unitaries[gn], 'H'):
                             H_name = gn
@@ -387,6 +400,7 @@ class ProcessorSpec(object):
             else:
                 cphase_name = None
                 for gn in self.root_gate_names:
+                    if callable(self.root_gate_unitaries[gn]): continue  # can't pre-process factories
                     if _itgs.is_gate_this_standard_unitary(self.root_gate_unitaries[gn], 'CPHASE'):
                         cphase_name = gn
                         break
@@ -454,6 +468,8 @@ class ProcessorSpec(object):
         Id = _np.identity(4, float)
         nontrivial_gname_pauligate_pairs = []
         for gname in self.root_gate_names:
+            if callable(self.root_gate_unitaries[gname]): continue  # can't pre-process factories
+            
             # We convert to process matrices, to avoid global phase problems.
             u = _gt.unitary_to_pauligate(self.root_gate_unitaries[gname])
             if u.shape == (4, 4):
@@ -494,10 +510,13 @@ class ProcessorSpec(object):
         None
         """
         for gname1 in self.root_gate_names:
+            if callable(self.root_gate_unitaries[gname1]): continue  # can't pre-process factories
+
             # We convert to process matrices, to avoid global phase problems.
             u1 = _gt.unitary_to_pauligate(self.root_gate_unitaries[gname1])
             if _np.shape(u1) != (4, 4):
                 for gname2 in self.root_gate_names:
+                    if callable(self.root_gate_unitaries[gname2]): continue  # can't pre-process factories
                     u2 = _gt.unitary_to_pauligate(self.root_gate_unitaries[gname2])
                     if _np.shape(u2) == _np.shape(u1):
                         ucombined = _np.dot(u2, u1)

--- a/test/test_packages/drivers/testCalcMethods1Q.py
+++ b/test/test_packages/drivers/testCalcMethods1Q.py
@@ -19,7 +19,7 @@ import sys, os
 
 from ..testutils import BaseTestCase, compare_files, temp_files
 
-#Mimics a function that used to be in pyGSTi, replaced with build_standard_cloudnoise_model
+#Mimics a function that used to be in pyGSTi, replaced with build_cloudnoise_model_from_hops_and_weights
 def build_XYCNOT_cloudnoise_model(nQubits, geometry="line", cnot_edges=None,
                                       maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
                                       extraWeight1Hops=0, extraGateWeight=0, sparse=False,
@@ -39,8 +39,8 @@ def build_XYCNOT_cloudnoise_model(nQubits, geometry="line", cnot_edges=None,
     
     availability = {}; nonstd_gate_unitaries = {}
     if cnot_edges is not None: availability['Gcnot'] = cnot_edges
-    return pc.build_standard_cloudnoise_model_from_hops_and_weights(
-        nQubits, ['Gx','Gy','Gcnot'], nonstd_gate_unitaries, availability,
+    return pc.build_cloudnoise_model_from_hops_and_weights(
+        nQubits, ['Gx','Gy','Gcnot'], nonstd_gate_unitaries, None, availability,
         None, geometry, maxIdleWeight, maxSpamWeight, maxhops,
         extraWeight1Hops, extraGateWeight, sparse,
         roughNoise, sim_type, parameterization,
@@ -419,11 +419,11 @@ class CalcMethods1QTestCase(BaseTestCase):
         self.assert_outcomes(probs1, {('0',): 0.5,  ('1',): 0.5} )
 
         #Using n-qubit models
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             self.csim_nQubits, ['Gi','Gxpi','Gypi','Gcnot'], sim_type="matrix", ensure_composed_gates=False)
         probs1 = mdl.probs(self.circuit3)
 
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             self.csim_nQubits, ['Gi','Gxpi','Gypi','Gcnot'], sim_type="map", ensure_composed_gates=False)
         probs2 = mdl.probs(self.circuit3)
 
@@ -475,10 +475,10 @@ class CalcMethods1QTestCase(BaseTestCase):
         #self.circuit1.simulate(gs2) # calls probs - same as above line
 
         #Using n-qubit models
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             self.csim_nQubits, ['Gi','Gxpi','Gypi','Gcnot'], evotype="statevec", sim_type="matrix", ensure_composed_gates=False)
         probs1 = mdl.probs(self.circuit3)
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             self.csim_nQubits, ['Gi','Gxpi','Gypi','Gcnot'],  evotype="statevec", sim_type="map", ensure_composed_gates=False)
         probs2 = mdl.probs(self.circuit3)
 
@@ -511,7 +511,7 @@ class CalcMethods1QTestCase(BaseTestCase):
         self.assert_outcomes(probs1, {('0',): 0.5,  ('1',): 0.5} )
 
         #Using n-qubit models ("H+S terms" parameterization constructs embedded/composed gates containing LindbladTermGates, etc.)
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             self.csim_nQubits, ['Gi','Gxpi','Gypi','Gcnot'], sim_type="termorder:1",
             parameterization="H+S terms", ensure_composed_gates=False)
         probs1 = mdl.probs(self.circuit3)
@@ -537,7 +537,7 @@ class CalcMethods1QTestCase(BaseTestCase):
         c2 = pygsti.obj.Circuit(layer_labels=(('Gx',0),('Gx',0)), num_lines=1)
         c3 = pygsti.obj.Circuit(layer_labels=(('Gx',0),('Gx',0),('Gx',0),('Gx',0)), num_lines=1)
 
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             1, ['Gi','Gx','Gy'], parameterization="clifford", ensure_composed_gates=False)
 
         probs0 = mdl.probs(c0)
@@ -587,7 +587,7 @@ class CalcMethods1QTestCase(BaseTestCase):
         c2 = pygsti.obj.Circuit(layer_labels=(('Gx',0),('Gx',0)), num_lines=1)
         c3 = pygsti.obj.Circuit(layer_labels=(('Gx',0),('Gx',0),('Gx',0),('Gx',0)), num_lines=1)
         
-        mdl = pygsti.construction.build_standard_localnoise_model(
+        mdl = pygsti.construction.build_localnoise_model(
             1, ['Gi','Gx','Gy'], sim_type="termorder:1", parameterization="H+S clifford terms", ensure_composed_gates=False)
 
         probs0 = mdl.probs(c0)

--- a/test/test_packages/drivers/testNQubit.py
+++ b/test/test_packages/drivers/testNQubit.py
@@ -15,7 +15,7 @@ from ..testutils import BaseTestCase, compare_files, temp_files
 
 #from .nqubitconstruction import *
 
-#Mimics a function that used to be in pyGSTi, replaced with build_standard_cloudnoise_model
+#Mimics a function that used to be in pyGSTi, replaced with build_cloudnoise_model_from_hops_and_weights
 def build_XYCNOT_cloudnoise_model(nQubits, geometry="line", cnot_edges=None,
                                       maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
                                       extraWeight1Hops=0, extraGateWeight=0, sparse=False,
@@ -24,8 +24,8 @@ def build_XYCNOT_cloudnoise_model(nQubits, geometry="line", cnot_edges=None,
                                       errcomp_type="gates", return_clouds=False, verbosity=0):
     availability = {}; nonstd_gate_unitaries = {}
     if cnot_edges is not None: availability['Gcnot'] = cnot_edges
-    return pc.build_standard_cloudnoise_model_from_hops_and_weights(
-        nQubits, ['Gx','Gy','Gcnot'], nonstd_gate_unitaries, availability,
+    return pc.build_cloudnoise_model_from_hops_and_weights(
+        nQubits, ['Gx','Gy','Gcnot'], nonstd_gate_unitaries, None, availability,
         None, geometry, maxIdleWeight, maxSpamWeight, maxhops,
         extraWeight1Hops, extraGateWeight, sparse,
         roughNoise, sim_type, parameterization,

--- a/test/test_packages/extras/test_idt.py
+++ b/test/test_packages/extras/test_idt.py
@@ -20,7 +20,7 @@ hamiltonian=True
 stochastic=True
 affine=True
 
-#Mimics a function that used to be in pyGSTi, replaced with build_standard_cloudnoise_model
+#Mimics a function that used to be in pyGSTi, replaced with build_cloudnoise_model_from_hops_and_weights
 def build_XYCNOT_cloudnoise_model(nQubits, geometry="line", cnot_edges=None,
                                       maxIdleWeight=1, maxSpamWeight=1, maxhops=0,
                                       extraWeight1Hops=0, extraGateWeight=0, sparse=False,
@@ -29,8 +29,8 @@ def build_XYCNOT_cloudnoise_model(nQubits, geometry="line", cnot_edges=None,
                                       errcomp_type="gates", return_clouds=False, verbosity=0):
     availability = {}; nonstd_gate_unitaries = {}
     if cnot_edges is not None: availability['Gcnot'] = cnot_edges
-    return pygsti.construction.build_standard_cloudnoise_model_from_hops_and_weights(
-        nQubits, ['Gx','Gy','Gcnot'], nonstd_gate_unitaries, availability,
+    return pygsti.construction.build_cloudnoise_model_from_hops_and_weights(
+        nQubits, ['Gx','Gy','Gcnot'], nonstd_gate_unitaries, None, availability,
         None, geometry, maxIdleWeight, maxSpamWeight, maxhops,
         extraWeight1Hops, extraGateWeight, sparse,
         roughNoise, sim_type, parameterization,

--- a/test/test_packages/objects/testLabels.py
+++ b/test/test_packages/objects/testLabels.py
@@ -68,8 +68,8 @@ class LabelTestCase(BaseTestCase):
     def test_layerlizzard(self):
         #Test this here b/c auto-gators are associated with parallel operation labels
         availability = {'Gcnot': [(0,1)]}
-        mdl = pc.build_standard_cloudnoise_model_from_hops_and_weights(
-            2, ['Gx','Gy','Gcnot'], {}, availability,
+        mdl = pc.build_cloudnoise_model_from_hops_and_weights(
+            2, ['Gx','Gy','Gcnot'], {}, None, availability,
             None, "line", maxIdleWeight=1, maxhops=1,
             extraWeight1Hops=0, extraGateWeight=1, sparse=True,
             sim_type="map", parameterization="H+S")


### PR DESCRIPTION
A second installment of functionality to ease model-building, this PR adds a number of new factory types an more integration of these factories (e.g. into ProcessorSpec and allowing unitary-returning-functions to be passed in `nonstd_gate_unitaries` arguments). 