### PR TITLE
v0.9.8 CI hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ test/test_packages/cmp_chk_files/Fake_Dataset_none.txt.cache
 build/*
 dist/*
 packages/pygsti.egg-info
+packages/pyGSTi.egg-info
 packages/pygsti/baseobjs/parsetab_string.py
 packages/pygsti/objects/fastgatecalc.cpp
 packages/pygsti/objects/fastreplib.cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,8 @@ stages:
     if: branch IN (master, beta)
   - name: push
     if: (branch = develop) AND (NOT (type = pull_request))
+  - name: deploy
+    if: tag IS present
 
 jobs:
   include:
@@ -137,6 +139,14 @@ jobs:
       script:
         - CI/push.sh
 
+    - stage: deploy
+      env: PYPI_DEPLOY=1
+      install:
+        - pip install -e .[extension_modules]
+      script:
+        - echo "Pushing $TRAVIS_TAG to PyPI"
+
+
   allow_failures:
     - stage: lint
       name: "PEP8"
@@ -150,6 +160,7 @@ deploy:
   skip_existing: true
   on:
     tags: true
+    condition: $PYPI_DEPLOY = 1
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ deploy:
   user: pygsti-ci
   password:
     secure: vK9Lm939ZRMgQ/UdpCRSrbiWSN5h0e0/vKV+ZCtUL63KHMaK9AShSJhNOWZ2RUIi3c/ZKTlllCgj9O/r0MjP2qE5N3DLhm0t+QNjgMM4Iz4bsMJx4nPYTrAeiShyffPFJWSVSP9l6054mBGZow6aeZEzDGsF2Y3LzISzE47c8xFxJI2TSM1AJ+j1feRsayTDepBq5+di2z3GgBXT8qDWMS4EY+ljdgsHBQ5xRh3HmT5AcecltwRmNaWprLSukjpmTuX+HKgMazSKCsqvTXSuhKive+7OxONu0JGva14GGk9baO3mGVaYA0+9R72QIQxD2hKdLwzHzYeo1Rue1AAggKdlSUDZ5InrqXx2ASkdqyqw7p6GUyxEQGErSvbqyPqgyCs0wNkxZR9xAGeUX9SztZxhgQyFlZRdq0gahSQB6vuwlbg8NlV/hMW94n/wk+NrARf7fCSw9rglIaTECGjcxaijc4r+EAVwyiEwtoT7wsei1A2sNfxHBJaZfjy7VXPhE5oSswPQV4B5uS9pxuiEWFfFor4e+iHtwQTR/KkKDrm0OOmWSemHgO4MLubupPrTzyViGfHM7BGHNe8D9FpY+IgMV/7Je+WwbDfccY4PZgjKZq1HYHnbQIhIyO7nckU6LXh1YPC/32NxOCThB+0H484B5dvPYjprIXQ+xIDRcKc=
-  distributions: "sdist bdist_wheel"
+  distributions: "sdist"
   skip_existing: true
   on:
     tags: true


### PR DESCRIPTION
The Travis CI deploy phase was previously running for every successful job, which doesn't match our use case. Deployment now runs in a dedicated stage, only on tag builds.

Also gitignores `packages/pyGSTi.egg-info`. The same path but lower-case was already gitignored. Not sure what that was used for.

Also disabled Travis CI building wheels on deployment. PyPI unconditionally rejects `linux_x86_64` wheels, which is our build platform. Might be able to get it building using the specific environment PyPI wants on Travis, but in the meantime, we'll just have to manually push wheels.