### PR TITLE
Deprecate `opttools.cache_by_hashed_args`

### DIFF
--- a/packages/pygsti/baseobjs/basis.py
+++ b/packages/pygsti/baseobjs/basis.py
@@ -9,8 +9,7 @@ from __future__ import division, print_function, absolute_import, unicode_litera
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
-from functools import partial
-from functools import wraps
+from functools import partial, wraps, lru_cache
 from itertools import product, chain
 
 import copy as _copy
@@ -27,7 +26,6 @@ import scipy.sparse.linalg as _spsl
 import math
 
 from .basisconstructors import _basisConstructorDict
-from .basisconstructors import cache_by_hashed_args
 
 #Helper functions
 try: basestring
@@ -424,7 +422,7 @@ class Basis(object):
         else:
             return _np.dot(self.get_from_std(), from_basis.get_to_std())
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def is_normalized(self):
         '''
         Check if a basis is normalized, meaning that Tr(Bi Bi) = 1.0.
@@ -446,7 +444,7 @@ class Basis(object):
         else:
             raise ValueError("I don't know what normalized means for elndim == %d!" % self.elndim)
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def get_to_std(self):
         '''
         Retrieve the matrix that transforms a vector from this basis to the
@@ -468,7 +466,7 @@ class Basis(object):
             toStd[:, i] = vel
         return toStd
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def get_from_std(self):
         '''
         Retrieve the matrix that transforms vectors from the standard basis
@@ -503,7 +501,7 @@ class Basis(object):
                 Adag = A.transpose().conjugate()  # shape (size, dim)
                 return _np.dot(_inv(_np.dot(Adag, A)), Adag)
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def get_to_element_std(self):
         '''
         Get the matrix that transforms vectors in this basis (with length equal
@@ -526,7 +524,7 @@ class Basis(object):
         assert(self.is_simple()), "Incorrectly using a simple-assuming implementation of get_to_element_std"
         return self.get_to_std()
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def get_from_element_std(self):  # OLD: get_expand_mx(self):
         '''
         Get the matrix that transforms vectors in the "element space" - that
@@ -928,7 +926,7 @@ class DirectSumBasis(LazyBasis):
             self._lazy_build_vector_elements()
         return self._vector_elements
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def get_to_std(self):
         '''
         Retrieve the matrix that transforms a vector from this basis to the
@@ -952,7 +950,7 @@ class DirectSumBasis(LazyBasis):
             toStd[:, i] = vel
         return toStd
 
-    @cache_by_hashed_args
+    @lru_cache(maxsize=128)
     def get_to_element_std(self):
         '''
         Get the matrix that transforms vectors in this basis (with length equal

--- a/packages/pygsti/baseobjs/basisconstructors.py
+++ b/packages/pygsti/baseobjs/basisconstructors.py
@@ -19,21 +19,6 @@ from collections import namedtuple as _namedtuple
 import functools as _functools
 
 from .parameterized import parameterized as _parameterized
-from .opttools import cache_by_hashed_args
-
-#OLD TODO REMOVE
-#DefaultBasisInfo = _namedtuple('BuiltinBasisInfo', ['constructor', 'longname', 'real', 'sizesfn', 'labeler'])
-#@_parameterized # this decorator takes additional arguments (other than just f)
-#def basis_constructor(f, name, longname, sizesfn, real=True):
-#    """ This decorator saves f to a dictionary for constructing default bases,
-#        as well as enabling caching on the basis creation function: (Important
-#        to CP/TP cases of gauge opt) """
-#    @cache_by_hashed_args
-#    @_functools.wraps(f)
-#    def _cached(*args, **kwargs):
-#        return f(*args, **kwargs)
-#    _basisConstructorDict[name] = DefaultBasisInfo(_cached, longname, real, sizesfn)
-#    return _cached
 
 ## Pauli basis matrices
 sqrt2 = _np.sqrt(2)

--- a/packages/pygsti/baseobjs/opttools.py
+++ b/packages/pygsti/baseobjs/opttools.py
@@ -14,30 +14,22 @@ from time import time
 from contextlib import contextmanager
 from collections import defaultdict
 from datetime import datetime
-from functools import wraps
+from functools import lru_cache
+from ..tools.legacytools import deprecated_fn
 import warnings
 
 # note that this decorator ignores **kwargs
 
 
+@deprecated_fn('functools.lru_cache')
 def cache_by_hashed_args(obj):
-    """ Decorator for caching a function values """
-    cache = obj.cache = {}
+    """ Decorator for caching a function values
 
-    @wraps(obj)
-    def _memoizer(*args, **kwargs):
-        if len(kwargs) > 0:
-            #instead of an error, just don't cache in this case
-            warnings.warn('Cannot currently memoize on kwargs')
-            return obj(*args, **kwargs)
-        try:
-            if args not in cache:
-                cache[args] = obj(*args, **kwargs)
-            return cache[args]
-        except TypeError:
-            print('Warning: arguments for cached function could not be cached')
-            return obj(*args, **kwargs)
-    return _memoizer
+    .. deprecated:: v0.9.8.3
+       :func:`cache_by_hashed_args` will be removed in pyGSTi
+       v0.9.9. Use :func:`functools.lru_cache` instead.
+    """
+    return lru_cache(maxsize=128)(obj)
 
 
 @contextmanager

--- a/test/unit/baseobjs/test_opttools.py
+++ b/test/unit/baseobjs/test_opttools.py
@@ -7,62 +7,6 @@ from ..util import BaseCase, mock
 from pygsti.baseobjs import opttools as opt
 
 
-class CacheByHashedArgsTester(BaseCase):
-    def test_args_are_cached(self):
-        mock_call = mock.MagicMock(return_value=42)
-
-        @opt.cache_by_hashed_args
-        def cached_call(*args):
-            return mock_call(*args)
-
-        value = cached_call(8, 6, 7, 5)
-        self.assertEqual(value, mock_call.return_value, "function returns unexpected value")
-        self.assertEqual(cached_call(8, 6, 7, 5), mock_call.return_value, "invalid value fetched from cache")
-        mock_call.assert_called_once_with(8, 6, 7, 5)
-
-        mock_call.return_value = 777
-        value = cached_call(3, 0, 9)
-        self.assertEqual(value, mock_call.return_value, "function returns unexpected value on subsequent call")
-        self.assertEqual(cached_call(3, 0, 9), mock_call.return_value,
-                         "invalid value fetched from cache on subsequent call")
-        self.assertEqual(cached_call(8, 6, 7, 5), 42, "invalid value fetched from cache on subsequent call")
-        self.assertEqual(mock_call.call_count, 2, "return value was not cached on subsequent call")
-        mock_call.assert_any_call(3, 0, 9)
-
-    def test_kwargs_not_cached(self):
-        mock_call = mock.MagicMock(return_value=42)
-
-        @opt.cache_by_hashed_args
-        def cached_call(a, b=1):
-            return mock_call(a, b)
-
-        value = cached_call(2, b=2)
-        self.assertEqual(value, mock_call.return_value, "function returns unexpected value with kwargs")
-        mock_call.assert_called_once_with(2, 2)
-        mock_call.return_value = 777
-        value = cached_call(2, b=2)
-        self.assertEqual(value, mock_call.return_value,
-                         "function returns unexpected value on subsequent call with kwargs")
-        self.assertEqual(mock_call.call_count, 2, "function with kwargs was cached")
-
-    def test_unhashable_args_not_cached(self):
-        mock_call = mock.MagicMock(return_value=42)
-
-        @opt.cache_by_hashed_args
-        def cached_call(lst):
-            return mock_call(lst)
-
-        arg = [2, 2]
-        value = cached_call(arg)
-        self.assertEqual(value, mock_call.return_value, "function returns unexpected value with unhashable args")
-        mock_call.assert_called_once_with(arg)
-        mock_call.return_value = 777
-        value = cached_call(arg)
-        self.assertEqual(value, mock_call.return_value,
-                         "function returns unexpected value on subsequent call with unhashable args")
-        self.assertEqual(mock_call.call_count, 2, "function with unhashable args was cached")
-
-
 class TestTimedBlock(BaseCase):
     def test_stdout_output(self):
         with mock.patch('sys.stdout') as mock_out:


### PR DESCRIPTION
`opttools.cache_by_hashed_args` should be deprecated in favor of the standard `functools.lru_cache` which performs effectively the same functionality, with the added advantage of adjustable cache size and low-level optimization.

Usages of `cache_by_hashed_args` have been replaced with `lru_cache(maxsize=128)`. The value of `maxsize` should be adjusted based on use case, but I can't say for sure. See [the documentation](https://docs.python.org/3.7/library/functools.html#functools.lru_cache) for more about `maxsize`

This patch sets `cache_by_hashed_args` to be deprecated by v0.9.9.