### PR TITLE
Feature distributed report

### DIFF
--- a/packages/pygsti/report/factory.py
+++ b/packages/pygsti/report/factory.py
@@ -705,6 +705,9 @@ def create_standard_report(results, filename, title="auto",
             i.e. just upon first rendering (`"initial"`) -- or whenever
             the browser window is resized (`"continual"`).
 
+        - embed_figures: bool, optional
+            Whether figures should be embedded in the generated report.
+
         - combine_robust : bool, optional
             Whether robust estimates should automatically be combined with
             their non-robust counterpart when displayed in reports. (default
@@ -750,6 +753,7 @@ def create_standard_report(results, filename, title="auto",
     connected = advancedOptions.get('connected', False)
     resizable = advancedOptions.get('resizable', True)
     autosize = advancedOptions.get('autosize', 'initial')
+    embed_figures = advancedOptions.get('embed_figures', True)
     combine_robust = advancedOptions.get('combine_robust', True)
     ci_brevity = advancedOptions.get('confidence_interval_brevity', 1)
     idtPauliDicts = advancedOptions.get('idt_basis_dicts', 'auto')
@@ -1218,7 +1222,8 @@ def create_standard_report(results, filename, title="auto",
                         qtys, filename, templateDir='~standard_html_report',
                         auto_open=auto_open, precision=precision, link_to=link_to,
                         connected=connected, toggles=toggles, renderMath=renderMath,
-                        resizable=resizable, autosize=autosize, verbosity=printer
+                        resizable=resizable, autosize=autosize,
+                        embed_figures=embed_figures, verbosity=printer
                     )
 
             elif fmt == "latex":

--- a/packages/pygsti/report/merge_helpers.py
+++ b/packages/pygsti/report/merge_helpers.py
@@ -467,7 +467,7 @@ def merge_jinja_template(qtys, outputFilename, templateDir=None, templateName='m
     env = _make_jinja_env(static_path.relative_to(out_path), templateDir=templateDir,
                           render_options=dict(switched_item_mode="inline",
                                               global_requirejs=False,
-                                              within_report=True,
+                                              use_loadable_items=True,
                                               resizable=resizable, autosize=autosize,
                                               output_dir=figDir, link_to=link_to,
                                               precision=precision),
@@ -573,7 +573,7 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
     if not connected:
         rsync_offline_dir(outputDir)
 
-    if embed_figures or link_to is not None:
+    if embed_figures is False or link_to is not None:
         figDir = out_path / 'figures'
         figDir.mkdir(exist_ok=True)
     else:
@@ -583,7 +583,7 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
     env = _make_jinja_env(static_path.relative_to(out_path), templateDir=templateDir,
                           render_options=dict(switched_item_mode=switched_item_mode,
                                               global_requirejs=False,
-                                              within_report=True,
+                                              use_loadable_items=embed_figures,
                                               resizable=resizable, autosize=autosize,
                                               output_dir=figDir, link_to=link_to,
                                               precision=precision),

--- a/packages/pygsti/report/merge_helpers.py
+++ b/packages/pygsti/report/merge_helpers.py
@@ -395,7 +395,6 @@ def _make_jinja_env(static_path, templateDir=None, render_options=None, link_to=
         # Assume path after ~ is relative to root packaged template directory
         relpath = templateDir[1:]
         loader = jinja2.PackageLoader('pygsti', _os.path.join('report/templates', relpath))
-
     else:
         # Use path as is.
         loader = jinja2.FileSystemLoader(templateDir)
@@ -479,7 +478,7 @@ def merge_jinja_template(qtys, outputFilename, templateDir=None, templateName='m
     render_params = {
         **qtys,
         'config': {
-            **(toggles or {})
+            **(toggles or {}),
             # TODO whatever should be in config namespace
         }
     }
@@ -492,7 +491,7 @@ def merge_jinja_template(qtys, outputFilename, templateDir=None, templateName='m
 
 def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='main.html',
                              auto_open=False, precision=None, link_to=None, connected=False, toggles=None,
-                             renderMath=True, resizable=True, autosize='none', verbosity=0):
+                             renderMath=True, resizable=True, autosize='none', embed_figures=True, verbosity=0):
     """
     Renders `qtys` and merges them into the HTML files under `templateDir`,
     saving the output under `outputDir`.
@@ -518,6 +517,7 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
         everything else, respectively.  If an integer is given, it this
         same value is taken for all precision types.  If None, then
         a default is used.
+
     link_to : list, optional
         If not None, a list of one or more items from the set
         {"tex", "pdf", "pkl"} indicating whether or not to
@@ -543,6 +543,19 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
         i.e. just upon first rendering (`"initial"`) -- or whenever
         the browser window is resized (`"continual"`).
 
+    embed_figures : bool, optional
+        Whether figures should be embedded in the generated report. If
+        False, figures will be written to a 'figures' directory in the
+        output directory, and will be loaded dynamically via
+        AJAX. This may be useful for reducing the size of the
+        generated report if the report includes relatively many
+        figures.
+        Note that all major web browsers will block AJAX requests from
+        an HTML document loaded from the filesystem. If this option is
+        set to False, the generated report will fail to load from the
+        filesystem, and must be served up by a webserver. Python's
+        `http.server` module works fine.
+
     verbosity : int, optional
         Amount of detail to print to stdout.
 
@@ -560,14 +573,15 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
     if not connected:
         rsync_offline_dir(outputDir)
 
-    if link_to is not None:
+    if embed_figures or link_to is not None:
         figDir = out_path / 'figures'
         figDir.mkdir(exist_ok=True)
     else:
         figDir = None
 
+    switched_item_mode = "inline" if embed_figures else "separate files"
     env = _make_jinja_env(static_path.relative_to(out_path), templateDir=templateDir,
-                          render_options=dict(switched_item_mode="inline",
+                          render_options=dict(switched_item_mode=switched_item_mode,
                                               global_requirejs=False,
                                               within_report=True,
                                               resizable=resizable, autosize=autosize,
@@ -580,7 +594,7 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
     render_params = {
         **qtys,
         'config': {
-            **(toggles or {})
+            **(toggles or {}),
             # TODO whatever should be in config namespace
         }
     }

--- a/packages/pygsti/report/merge_helpers.py
+++ b/packages/pygsti/report/merge_helpers.py
@@ -576,6 +576,10 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
     if embed_figures is False or link_to is not None:
         figDir = out_path / 'figures'
         figDir.mkdir(exist_ok=True)
+
+        if embed_figures is False:
+            with open(figDir / 'test.html', 'w') as f:
+                f.write("<div>Dummy to test ajax loading</div>")
     else:
         figDir = None
 
@@ -598,6 +602,9 @@ def merge_jinja_template_dir(qtys, outputDir, templateDir=None, templateName='ma
             # TODO whatever should be in config namespace
         }
     }
+
+    #Additional configuration needed in jinja templates
+    render_params['config']['embed_figures'] = embed_figures  # to know when to test for AJAX errors
 
     # Render main page template to output path
     template = env.get_template(templateName)

--- a/packages/pygsti/report/templates/drift_html_report/main.html
+++ b/packages/pygsti/report/templates/drift_html_report/main.html
@@ -94,6 +94,9 @@
             {% include 'tabs/Drift.html' %}
           </div>
 
+          {% if not config['embed_figures'] %}
+          {% include 'tabs/AjaxError.html' %}
+          {% endif %}
         </div>
         <div id="status">
           No message

--- a/packages/pygsti/report/templates/drift_html_report/tabs/AjaxError.html
+++ b/packages/pygsti/report/templates/drift_html_report/tabs/AjaxError.html
@@ -1,0 +1,21 @@
+<div id="AjaxError" style="display: none">
+  <p><b>Report loading failed!</b><p>
+  <p>You're probably seeing this because this report was created <i>without</i> embedded figures and your browser does not allow locally-loaded html files to load other local files (i.e. the figures).  This is a security restriction present in many common browsers.  There are several things you can do to fix this problem:
+  	<ul>
+  	  <li> <b>Switch to Firefox and cross your fingers</b>: some versions of Firefox allow files to load other files by default, so if you're not using Firefox right now just switching to Firefox may cause this report to load properly.</li>
+      <li> <b>Run a local web server</b>: Running a local web server and loading this page (main.html) through the web server instead of by opening the file directly (so the address bar begins with <q>http://</q> instead of <q>file://</q> will almost certainly fix any problems.  A couple fairly simple ways of doing this are:
+  	    <ol>
+  		  <li><b>If you have Python installed</b>, running <pre>python3 -m http.server</pre> from a command line will start a local web server rooted in the current directory.  Access this server from a browser by typing <pre>localhost:8000</pre> in the address bar.  Navigate from there to main.html and you should be all set.</li>
+  		  <li><b>If you have the Google Chrome browser</b> (even if you're not using it), then download the <b>Web Server for Chrome</b> app (do a web search to find the app on Google's web store) and follow the instructions to start a local web server running out of a given local directory.</li> 
+  	    </ol>
+  	  </li>
+    </ul>		  
+  </p>
+</div>
+<script type="text/javascript">
+  testLocalAjax("figures/test.html", function(errstatus) {
+      console.log("AJAX ERROR: " + errstatus);
+      $('#main').find('.tabcontent').remove()
+      $('#AjaxError').show()
+  });
+</script>

--- a/packages/pygsti/report/templates/idletomography_html_report/main.html
+++ b/packages/pygsti/report/templates/idletomography_html_report/main.html
@@ -104,6 +104,10 @@
             {% include 'tabs/DataComparison.html' %}
           </div>
           {% endif %}
+
+          {% if not config['embed_figures'] %}
+          {% include 'tabs/AjaxError.html' %}
+          {% endif %}
         </div>
         <div id="status">
           No message

--- a/packages/pygsti/report/templates/idletomography_html_report/tabs/AjaxError.html
+++ b/packages/pygsti/report/templates/idletomography_html_report/tabs/AjaxError.html
@@ -1,0 +1,21 @@
+<div id="AjaxError" style="display: none">
+  <p><b>Report loading failed!</b><p>
+  <p>You're probably seeing this because this report was created <i>without</i> embedded figures and your browser does not allow locally-loaded html files to load other local files (i.e. the figures).  This is a security restriction present in many common browsers.  There are several things you can do to fix this problem:
+  	<ul>
+  	  <li> <b>Switch to Firefox and cross your fingers</b>: some versions of Firefox allow files to load other files by default, so if you're not using Firefox right now just switching to Firefox may cause this report to load properly.</li>
+      <li> <b>Run a local web server</b>: Running a local web server and loading this page (main.html) through the web server instead of by opening the file directly (so the address bar begins with <q>http://</q> instead of <q>file://</q> will almost certainly fix any problems.  A couple fairly simple ways of doing this are:
+  	    <ol>
+  		  <li><b>If you have Python installed</b>, running <pre>python3 -m http.server</pre> from a command line will start a local web server rooted in the current directory.  Access this server from a browser by typing <pre>localhost:8000</pre> in the address bar.  Navigate from there to main.html and you should be all set.</li>
+  		  <li><b>If you have the Google Chrome browser</b> (even if you're not using it), then download the <b>Web Server for Chrome</b> app (do a web search to find the app on Google's web store) and follow the instructions to start a local web server running out of a given local directory.</li> 
+  	    </ol>
+  	  </li>
+    </ul>		  
+  </p>
+</div>
+<script type="text/javascript">
+  testLocalAjax("figures/test.html", function(errstatus) {
+      console.log("AJAX ERROR: " + errstatus);
+      $('#main').find('.tabcontent').remove()
+      $('#AjaxError').show()
+  });
+</script>

--- a/packages/pygsti/report/templates/offline/pygsti_dashboard.js
+++ b/packages/pygsti/report/templates/offline/pygsti_dashboard.js
@@ -164,3 +164,25 @@ $(document).ready(function() {
         $(this).children('.captiondetail').toggleClass('showcaption')
     });
 });
+
+
+function testLocalAjax(url, onerror) {
+   var request = new XMLHttpRequest();
+    request.responseType = 'text';
+    request.withCredentials = true; //b/c jupyter notebooks use user authentication
+    request.open('GET', url, true);
+    request.onload = function() {
+	var is_safari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+	var is_chrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+	if (request.status == 200 || ((is_safari || is_chrome) && request.status == 0)) {
+	    console.log('testLocalAjax success!');
+	}
+	else {
+	    onerror(request.status);
+	}
+    };
+    request.onerror = function() {
+	onerror("connection error");
+    };
+    request.send();
+}

--- a/packages/pygsti/report/templates/standard_html_report/main.html
+++ b/packages/pygsti/report/templates/standard_html_report/main.html
@@ -229,6 +229,10 @@
                         {% include 'tabs/Help.html' %}
                     </div>
                     {% endif %}
+
+                    {% if not config['embed_figures'] %}
+                    {% include 'tabs/AjaxError.html' %}
+                    {% endif %}
                 </div>
                 <div id="status">
                     No message
@@ -236,7 +240,7 @@
             </div>
         </div>
     </body>
-
+    
     <script>
       $(document).ready(function() {
           initNav(); // so sidebar is loaded and can hide/show

--- a/packages/pygsti/report/templates/standard_html_report/tabs/AjaxError.html
+++ b/packages/pygsti/report/templates/standard_html_report/tabs/AjaxError.html
@@ -1,0 +1,21 @@
+<div id="AjaxError" style="display: none">
+  <p><b>Report loading failed!</b><p>
+  <p>You're probably seeing this because this report was created <i>without</i> embedded figures and your browser does not allow locally-loaded html files to load other local files (i.e. the figures).  This is a security restriction present in many common browsers.  There are several things you can do to fix this problem:
+  	<ul>
+  	  <li> <b>Switch to Firefox and cross your fingers</b>: some versions of Firefox allow files to load other files by default, so if you're not using Firefox right now just switching to Firefox may cause this report to load properly.</li>
+      <li> <b>Run a local web server</b>: Running a local web server and loading this page (main.html) through the web server instead of by opening the file directly (so the address bar begins with <q>http://</q> instead of <q>file://</q> will almost certainly fix any problems.  A couple fairly simple ways of doing this are:
+  	    <ol>
+  		  <li><b>If you have Python installed</b>, running <pre>python3 -m http.server</pre> from a command line will start a local web server rooted in the current directory.  Access this server from a browser by typing <pre>localhost:8000</pre> in the address bar.  Navigate from there to main.html and you should be all set.</li>
+  		  <li><b>If you have the Google Chrome browser</b> (even if you're not using it), then download the <b>Web Server for Chrome</b> app (do a web search to find the app on Google's web store) and follow the instructions to start a local web server running out of a given local directory.</li> 
+  	    </ol>
+  	  </li>
+    </ul>		  
+  </p>
+</div>
+<script type="text/javascript">
+  testLocalAjax("figures/test.html", function(errstatus) {
+      console.log("AJAX ERROR: " + errstatus);
+      $('#main').find('.tabcontent').remove()
+      $('#AjaxError').show()
+  });
+</script>

--- a/packages/pygsti/report/workspace.py
+++ b/packages/pygsti/report/workspace.py
@@ -696,7 +696,7 @@ class Switchboard(_collections.OrderedDict):
     """
 
     def __init__(self, ws, switches, positions, types, initial_pos=None,
-                 descriptions=None, show="all", ID=None, within_report=False):
+                 descriptions=None, show="all", ID=None, use_loadable_items=False):
         """
         Create a new Switchboard.
 
@@ -748,7 +748,7 @@ class Switchboard(_collections.OrderedDict):
         self.switchIDs = ["switchbd%s_%d" % (self.ID, i)
                           for i in range(len(switches))]
         self.positionLabels = positions
-        self.within_report = within_report
+        self.use_loadable_items = use_loadable_items
         if initial_pos is None:
             self.initialPositions = _np.array([0] * len(switches), _np.int64)
         else:
@@ -1047,7 +1047,7 @@ class Switchboard(_collections.OrderedDict):
             switch_js.append(js)
 
         html = "\n".join(switch_html)
-        if not self.within_report:  # run JS as soon as the document is ready
+        if not self.use_loadable_items:  # run JS as soon as the document is ready
             js = "$(document).ready(function() {\n" + \
                 "\n".join(switch_js) + "\n});"
         else:  # in a report, where we have a 'loadable' parent and might not want to load right away
@@ -1348,7 +1348,7 @@ class WorkspaceOutput(object):
 
         #HTML specific
         'global_requirejs': False,
-        'within_report': False,
+        'use_loadable_items': False,
         'click_to_display': False,
         'render_math': True,
         'resizable': True,
@@ -1579,19 +1579,19 @@ class WorkspaceOutput(object):
 
     def _create_onready_handler(self, content, ID):
         global_requirejs = self.options.get('global_requirejs', False)
-        within_report = self.options.get('within_report', False)
+        use_loadable_items = self.options.get('use_loadable_items', False)
         ret = ""
 
         if global_requirejs:
             ret += "require(['jquery','jquery-UI','plotly','autorender'],function($,ui,Plotly,renderMathInElement) {\n"
 
         ret += '  $(document).ready(function() {\n'
-        if within_report:
+        if use_loadable_items:
             ret += "  $('#%s').closest('.loadable').on('load_loadable_item', function(){\n" % ID
 
         ret += content
 
-        if within_report:
+        if use_loadable_items:
             ret += "  });"  # end load_loadable_item handler
 
         ret += '}); //end on-ready or on-load handler\n'


### PR DESCRIPTION
Adds 'embed_figures' advanced option to report generation functions (e.g. create_standard_report) that defaults to `True`.  When `False`, separate figure files are created in a figures/ subdirectory, allowing very large reports to be displayed efficiently (with the help of a web browser so the Ajax calls work).