### PR TITLE
Extension compilation fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,60 +1,13 @@
 """A python implementation of Gate Set Tomography"""
 
+from warnings import warn
+
 try:
     from setuptools import setup
     from setuptools import Extension
 except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
-
-try:
-    import numpy as np
-    from Cython.Build import cythonize
-    ext_modules = [
-        Extension(
-            "pygsti.tools.fastcalc",
-            sources=["pygsti/tools/fastcalc.pyx"],  # , "fastcalc.c
-            # # Cython docs on NumPy usage should mention this!
-            # define_macros = [('NPY_NO_DEPRECATED_API','NPY_1_7_API_VERSION')],
-            # # leave above commented
-            # # see http://docs.cython.org/en/latest/src/reference/compilation.html#configuring-the-c-build
-            # define_macros = [('CYTHON_TRACE','1')], #for profiling
-            include_dirs=['.', np.get_include()]
-            # libraries=['m'] #math lib?
-        ),
-        Extension(
-            "pygsti.objects.opcalc.fastopcalc",
-            sources=["pygsti/objects/opcalc/fastopcalc.pyx"],
-            include_dirs=['.', np.get_include()],
-            language="c++",
-            extra_compile_args=["-std=c++11"],  # ,"-stdlib=libc++"
-            extra_link_args=["-std=c++11"]
-        ),
-        Extension(
-            "pygsti.objects.replib.fastreplib",
-            sources=[
-                "pygsti/objects/replib/fastreplib.pyx",
-                "pygsti/objects/replib/fastreps.cpp"
-            ],
-            include_dirs=['.', np.get_include()],
-            language="c++",
-            extra_compile_args=["-std=c++11"],  # ,"-stdlib=libc++"
-            extra_link_args=["-std=c++11"]
-        ),
-        Extension(
-            "pygsti.io.circuitparser.fastcircuitparser",
-            sources=["pygsti/io/circuitparser/fastcircuitparser.pyx"],
-            include_dirs=['.', np.get_include()],
-            language="c++",
-            extra_compile_args=["-std=c++11"],  # ,"-stdlib=libc++"
-            extra_link_args=["-std=c++11"]
-        )
-    ]
-    ext_modules = cythonize(ext_modules)
-except ImportError:  # if Cython isn't available (e.g. in readthedocs) just skip
-    # print warning??
-    ext_modules = []
-
 
 descriptionTxt = """\
 Gate set tomography (GST) is a quantum tomography protocol that provides full characterization of a quantum logic device
@@ -129,81 +82,139 @@ def custom_version():
     return {'version_scheme': postrelease_version}
 
 
-setup(name='pyGSTi',
-      use_scm_version=custom_version,
-      description='A python implementation of Gate Set Tomography',
-      long_description=descriptionTxt,
-      author='Erik Nielsen, Kenneth Rudinger, Timothy Proctor, John Gamble, Robin Blume-Kohout',
-      author_email='pygsti@sandia.gov',
-      packages=[
-          'pygsti',
-          'pygsti.algorithms',
-          'pygsti',
-          'pygsti.construction',
-          'pygsti.drivers',
-          'pygsti.extras',
-          'pygsti.extras.rb',
-          'pygsti.extras.rpe',
-          'pygsti.extras.drift',
-          'pygsti.extras.idletomography',
-          'pygsti.io',
-          'pygsti.objects',
-          'pygsti.optimize',
-          'pygsti.report',
-          'pygsti.tools'
-      ],
-      package_dir={'': '.'},
-      package_data={
-          'pygsti.tools': ['fastcalc.pyx'],
-          'pygsti.objects': [
-              'fastopcalc.pyx',
-              'fastreplib.pyx',
-              'fastreps.cpp',
-              'fastreps.h'
-          ],
-          'pygsti.report': [
-              'templates/*.tex',
-              'templates/*.html',
-              'templates/*.json',
-              'templates/report_notebook/*.txt',
-              'templates/standard_html_report/*.html',
-              'templates/offline/README.txt',
-              'templates/offline/*.js',
-              'templates/offline/*.css',
-              'templates/offline/fonts/*',
-              'templates/offline/images/*'
-          ]
-      },
-      setup_requires=['setuptools_scm'],
-      install_requires=[
-          'numpy>=1.15.0',
-          'scipy',
-          'plotly',
-          'ply'
-      ],
-      extras_require=extras,
-      python_requires='>=3.5',
-      platforms=["any"],
-      url='http://www.pygsti.info',
-      download_url='https://github.com/pyGSTio/pyGSTi/tarball/master',
-      keywords=[
-          'pygsti',
-          'tomography',
-          'gate set',
-          'pigsty',
-          'pig',
-          'quantum',
-          'qubit'
-      ],
-      classifiers=[
-          "Development Status :: 4 - Beta",
-          "Intended Audience :: Science/Research",
-          "License :: OSI Approved :: Apache Software License",
-          "Programming Language :: Python",
-          "Topic :: Scientific/Engineering :: Physics",
-          "Operating System :: Microsoft :: Windows",
-          "Operating System :: MacOS :: MacOS X",
-          "Operating System :: Unix"
-      ],
-      ext_modules=ext_modules,
-)
+def setup_with_extensions(extensions=None):
+    setup(
+        name='pyGSTi',
+        use_scm_version=custom_version,
+        description='A python implementation of Gate Set Tomography',
+        long_description=descriptionTxt,
+        author='Erik Nielsen, Kenneth Rudinger, Timothy Proctor, John Gamble, Robin Blume-Kohout',
+        author_email='pygsti@sandia.gov',
+        packages=[
+            'pygsti',
+            'pygsti.algorithms',
+            'pygsti',
+            'pygsti.construction',
+            'pygsti.drivers',
+            'pygsti.extras',
+            'pygsti.extras.rb',
+            'pygsti.extras.rpe',
+            'pygsti.extras.drift',
+            'pygsti.extras.idletomography',
+            'pygsti.io',
+            'pygsti.objects',
+            'pygsti.optimize',
+            'pygsti.report',
+            'pygsti.tools'
+        ],
+        package_dir={'': '.'},
+        package_data={
+            'pygsti.tools': ['fastcalc.pyx'],
+            'pygsti.objects': [
+                'fastopcalc.pyx',
+                'fastreplib.pyx',
+                'fastreps.cpp',
+                'fastreps.h'
+            ],
+            'pygsti.report': [
+                'templates/*.tex',
+                'templates/*.html',
+                'templates/*.json',
+                'templates/report_notebook/*.txt',
+                'templates/standard_html_report/*.html',
+                'templates/offline/README.txt',
+                'templates/offline/*.js',
+                'templates/offline/*.css',
+                'templates/offline/fonts/*',
+                'templates/offline/images/*'
+            ]
+        },
+        setup_requires=['setuptools_scm'],
+        install_requires=[
+            'numpy>=1.15.0',
+            'scipy',
+            'plotly',
+            'ply'
+        ],
+        extras_require=extras,
+        python_requires='>=3.5',
+        platforms=["any"],
+        url='http://www.pygsti.info',
+        download_url='https://github.com/pyGSTio/pyGSTi/tarball/master',
+        keywords=[
+            'pygsti',
+            'tomography',
+            'gate set',
+            'pigsty',
+            'pig',
+            'quantum',
+            'qubit'
+        ],
+        classifiers=[
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: Apache Software License",
+            "Programming Language :: Python",
+            "Topic :: Scientific/Engineering :: Physics",
+            "Operating System :: Microsoft :: Windows",
+            "Operating System :: MacOS :: MacOS X",
+            "Operating System :: Unix"
+        ],
+        ext_modules=extensions or [],
+    )
+
+
+try:
+    # Try to compile extensions first
+
+    import numpy as np
+    from Cython.Build import cythonize
+    ext_modules = [
+        Extension(
+            "pygsti.tools.fastcalc",
+            sources=["pygsti/tools/fastcalc.pyx"],  # , "fastcalc.c
+            # # Cython docs on NumPy usage should mention this!
+            # define_macros = [('NPY_NO_DEPRECATED_API','NPY_1_7_API_VERSION')],
+            # # leave above commented
+            # # see http://docs.cython.org/en/latest/src/reference/compilation.html#configuring-the-c-build
+            # define_macros = [('CYTHON_TRACE','1')], #for profiling
+            include_dirs=['.', np.get_include()]
+            # libraries=['m'] #math lib?
+        ),
+        Extension(
+            "pygsti.objects.opcalc.fastopcalc",
+            sources=["pygsti/objects/opcalc/fastopcalc.pyx"],
+            include_dirs=['.', np.get_include()],
+            language="c++",
+            extra_compile_args=["-std=c++11"],  # ,"-stdlib=libc++"
+            extra_link_args=["-std=c++11"]
+        ),
+        Extension(
+            "pygsti.objects.replib.fastreplib",
+            sources=[
+                "pygsti/objects/replib/fastreplib.pyx",
+                "pygsti/objects/replib/fastreps.cpp"
+            ],
+            include_dirs=['.', np.get_include()],
+            language="c++",
+            extra_compile_args=["-std=c++11"],  # ,"-stdlib=libc++"
+            extra_link_args=["-std=c++11"]
+        ),
+        Extension(
+            "pygsti.io.circuitparser.fastcircuitparser",
+            sources=["pygsti/io/circuitparser/fastcircuitparser.pyx"],
+            include_dirs=['.', np.get_include()],
+            language="c++",
+            extra_compile_args=["-std=c++11"],  # ,"-stdlib=libc++"
+            extra_link_args=["-std=c++11"]
+        )
+    ]
+    setup_with_extensions(cythonize(ext_modules))
+except ImportError:
+    # Cython or numpy is not available
+    warn("Extensions build tools are not available. Installing without Cython extensions...")
+    setup_with_extensions()
+except SystemExit:
+    # Extension compilation failed
+    warn("Error in extension compilation. Installing without Cython extensions...")
+    setup_with_extensions()

--- a/setup.py
+++ b/setup.py
@@ -209,7 +209,7 @@ try:
             extra_link_args=["-std=c++11"]
         )
     ]
-    setup_with_extensions(cythonize(ext_modules))
+    setup_with_extensions(cythonize(ext_modules, exclude_failures=True))
 except ImportError:
     # Cython or numpy is not available
     warn("Extensions build tools are not available. Installing without Cython extensions...")


### PR DESCRIPTION
Since we provide pure-python alternatives to all cython extensions, setup.py should still install pyGSTi if extension compilation fails. This patch does that, emitting a warning on compilation failure. Additionally, cythonization failures are allowed and excluded. Developers should pay special attention when developing cython extensions, as compilation errors are now less obvious.