### PR TITLE
Adds "no-MPI" extras target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,8 @@ jobs:
       env: NOSE_WHERE="test/test_packages/" NOSETESTS="drivers objects tools iotest optimize construction extras"
     - stage: test-extra
       python: 3.5
-      env: NOSE_WHERE="test/test_packages/" NOSETESTS="mpi"
+      # MPI nose utils needs sys.path
+      env: NOSE_WHERE="test/test_packages/" NOSE_NOPATH="" NOSETESTS="mpi"
 
     - stage: push
       env: PUSH_BRANCH="beta"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ before_install:
 install:
   # see https://github.com/cvxgrp/cvxpy/issues/968
   - pip install "numpy>=1.16.0"
+  # Cython must be pre-installed to build native extensions on pyGSTi install
+  - pip install cython
+
   - pip install .[testing]
   - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - NOSE_WITH_COVERAGE=1
     - NOSE_COVER_PACKAGE="pygsti"
     - NOSE_PROCESSES=-1
+    - NOSE_NOPATH=1 # use installed package, not source tree under CWD
     - NOSE_PROCESS_TIMEOUT=2400 # timeout after 40 minutes (travis job timeout is 50 minutes)
   matrix:
     - NOSE_WHERE="test/unit/"
@@ -42,7 +43,7 @@ install:
 
 # Default `test' stage script
 script:
-  - mv "pygsti" "do-not-import-this-pygsti"
+  - python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
   - echo "nosetests $NOSETESTS"
   - nosetests $NOSETESTS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,9 @@ before_install:
   - gcc --version
 
 install:
-  # Install cython ahead of time b/c pip runs setup.py *before* installing dependencies (??)
-  - pip install cython
-  # Install base dependencies
-  - pip install .
-  # Install test dependencies
+  # see https://github.com/cvxgrp/cvxpy/issues/968
+  - pip install "numpy>=1.16.0"
   - pip install .[testing]
-  # Show pip environment, for diagnostics
   - pip freeze
 
 # Default `test' stage script

--- a/pygsti/extras/drift/driftreport.py
+++ b/pygsti/extras/drift/driftreport.py
@@ -540,7 +540,7 @@ def _create_drift_switchboard(ws, results, gss):
         drift_switchBd = ws.Switchboard(
             ["Dataset              ", "Germ                 ", "Preparation Fiducial ", "Measurement Fiducial",
              "Outcome             "],
-            [list(results.data.keys()), [c.str for c in gss.germs], [c.str for c in(gss.prepStrs)],
+            [list(results.data.keys()), [c.str for c in gss.germs], [c.str for c in gss.prepStrs],
              [c.str for c in gss.effectStrs],
              [i.str for i in results.data.get_outcome_labels()]],
             ["dropdown", "dropdown", "dropdown", "dropdown", "dropdown"], [0, 1, 0, 0, 0],
@@ -554,7 +554,7 @@ def _create_drift_switchboard(ws, results, gss):
     else:
         drift_switchBd = ws.Switchboard(
             ["Germ", "Preperation Fiducial", "Measurement Fiducial", "Outcome"],
-            [[c.str for c in gss.germs], [c.str for c in(gss.prepStrs)],
+            [[c.str for c in gss.germs], [c.str for c in gss.prepStrs],
              [c.str for c in gss.effectStrs], [str(o) for o in results.data.get_outcome_labels()]],
             ["dropdown", "dropdown", "dropdown", "dropdown"], [0, 0, 0, 0], show=[True, True, True, True])
         drift_switchBd.add("germs", (0,))

--- a/pygsti/objects/smartcache.py
+++ b/pygsti/objects/smartcache.py
@@ -388,6 +388,7 @@ def smart_cached(obj):
     function or method
     '''
     cache = obj.cache = SmartCache(decorating=(obj.__module__, obj.__name__))
+
     @_functools.wraps(obj)
     def _cacher(*args, **kwargs):
         _, v = cache.cached_compute(obj, args, kwargs)

--- a/pygsti/report/notebook.py
+++ b/pygsti/report/notebook.py
@@ -282,7 +282,7 @@ class Notebook(object):
         for serverinfo in servers:
             rel = _os.path.relpath(outputFilename, serverinfo['notebook_dir'])
             if ".." not in rel:  # notebook servers don't allow moving up directories
-                if port == 'auto'or int(serverinfo['port']) == port:
+                if port == 'auto' or int(serverinfo['port']) == port:
                     url = _os.path.join(serverinfo['url'], 'notebooks', rel)
                     _browser.open(url); break
         else:

--- a/pygsti/report/plothelpers.py
+++ b/pygsti/report/plothelpers.py
@@ -380,7 +380,7 @@ def _eformat(f, prec):
 
 
 def _num_non_nan(array):
-    ixs = _np.where(_np.isnan(_np.array(array).flatten()) == False)[0]  # noqa: E721
+    ixs = _np.where(_np.isnan(_np.array(array).flatten()) == False)[0]  # noqa: E712
     return int(len(ixs))
 
 
@@ -401,7 +401,7 @@ def _compute_num_boxes_dof(subMxs, sumUp, element_dof):
         reshape_subMxs = _np.array(_np.reshape(subMxs, (s[0] * s[1], s[2], s[3])))
 
         #Get all the boxes where the entries are not all NaN
-        non_all_NaN = reshape_subMxs[_np.where(_np.array([_np.isnan(k).all() for k in reshape_subMxs]) == False)]  # noqa: E721,E501
+        non_all_NaN = reshape_subMxs[_np.where(_np.array([_np.isnan(k).all() for k in reshape_subMxs]) == False)]  # noqa: E712,E501
         s = _np.shape(non_all_NaN)
         dof_each_box = [_num_non_nan(k) * element_dof for k in non_all_NaN]
 

--- a/pygsti/report/plotly_plot_ex.py
+++ b/pygsti/report/plotly_plot_ex.py
@@ -230,8 +230,7 @@ def plot_ex(figure_or_data, show_link=True, link_text='Export to plot.ly',
              ow=orig_width if orig_width else "null",
              oh=orig_height if orig_height else "null",
              plotlyClickJS=plotly_click_js,
-             plotlyCreateJS=plotly_create_js,
-             plotlyResizeJS=plotly_resize_js)
+             plotlyCreateJS=plotly_create_js)
 
     #Add resize handler if needed
     if resizable:

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,10 @@ extras = {
 # Add `complete' target, which will install all extras listed above
 extras['complete'] = list({pkg for req in extras.values() for pkg in req})
 
+# Add `no_mpi' target, identical to `complete' target but without mpi4py,
+# which is unavailable in some common environments.
+extras['no_mpi'] = [e for e in extras['complete'] if e != 'mpi4py']
+
 
 # Configure setuptools_scm to build the post-release version number
 def custom_version():

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ extras = {
         'cvxopt',
         'cvxpy'
     ],
-    'nose testing': ['nose'],
     'accurate memory profiling': ['psutil'],
     'multi-processor support': ['mpi4py'],
     'evolutionary optimization algorithm': ['deap'],


### PR DESCRIPTION
Closes #126 

Adds a `no_mpi` extras install target, which is equivalent to the `complete` target but without the `mpi4py` requirement.

Incidentally, also removes the redundant `nose testing` extras install target.