### PR TITLE
paths: fix open() syntax for python 3.5

### DIFF
--- a/install_locally.py
+++ b/install_locally.py
@@ -17,7 +17,7 @@ print("Adding path:", myPackagePath)
 usp = Path(site.getusersitepackages())
 usp.mkdir(parents=True, exist_ok=True)
 uspfile = usp / 'GST.pth'
-with open(uspfile, 'w') as f:
+with uspfile.open('w') as f:
     f.write(pathspec)
     print('Wrote to {}'.format(uspfile))
 

--- a/pygsti/io/metadir.py
+++ b/pygsti/io/metadir.py
@@ -117,7 +117,7 @@ def load_meta_based_dir(root_dir, auxfile_types_member='auxfile_types',
     """
     root_dir = _pathlib.Path(root_dir)
     ret = {}
-    with open(root_dir / 'meta.json', 'r') as f:
+    with (root_dir / 'meta.json').open('r') as f:
         meta = _json.load(f)
 
     for key, val in meta.items():
@@ -165,10 +165,10 @@ def load_meta_based_dir(root_dir, auxfile_types_member='auxfile_types',
             elif typ == 'text-circuit-list':
                 val = _load.load_circuit_list(pth)
             elif typ == 'json':
-                with open(pth, 'r') as f:
+                with pth.open('r') as f:
                     val = _json.load(f)
             elif typ == 'pickle':
-                with open(pth, 'rb') as f:
+                with pth.open('rb') as f:
                     val = _pickle.load(f)
             else:
                 raise ValueError("Invalid aux-file type: %s" % typ)
@@ -263,17 +263,17 @@ def write_meta_based_dir(root_dir, valuedict, auxfile_types=None, init_meta=None
             elif typ == 'text-circuit-list':
                 _write.write_circuit_list(pth, val)
             elif typ == 'json':
-                with open(pth, 'w') as f:
+                with pth.open('w') as f:
                     _json.dump(val, f)
             elif typ == 'pickle':
-                with open(pth, 'wb') as f:
+                with pth.open('wb') as f:
                     _pickle.dump(val, f)
             elif typ in ('none', 'reset'):
                 pass
             else:
                 raise ValueError("Invalid aux-file type: %s" % typ)
 
-    with open(root_dir / 'meta.json', 'w') as f:
+    with (root_dir / 'meta.json').open('w') as f:
         _json.dump(meta, f)
 
 
@@ -290,7 +290,7 @@ def cls_from_meta_json(dirname):
     -------
     class
     """
-    with open(_pathlib.Path(dirname) / 'meta.json', 'r') as f:
+    with (_pathlib.Path(dirname) / 'meta.json').open('r') as f:
         meta = _json.load(f)
     return class_for_name(meta['type'])  # class of object to create
 
@@ -316,7 +316,7 @@ def obj_to_meta_json(obj, dirname):
     None
     """
     meta = {'type': full_class_name(obj)}
-    with open(_pathlib.Path(dirname) / 'meta.json', 'w') as f:
+    with (_pathlib.Path(dirname) / 'meta.json').open('w') as f:
         _json.dump(meta, f)
 
 
@@ -367,10 +367,10 @@ def read_json_or_pkl_files_to_dict(dirname):
     ret = {}
     for pth in dirname.iterdir():
         if pth.suffix == '.json':
-            with open(pth, 'r') as f:
+            with pth.open('r') as f:
                 val = _json.load(f)
         elif pth.suffix == '.pkl':
-            with open(pth, 'rb') as f:
+            with pth.open('rb') as f:
                 val = _pickle.load(f)
         else:
             continue  # ignore cache file times we don't understand
@@ -409,5 +409,5 @@ def write_dict_to_json_or_pkl_files(d, dirname):
         #        _json.dump(val, f)
         #except:
         #try to remove partial json file??
-        with open(dirname / (key + '.pkl'), 'wb') as f:
+        with (dirname / (key + '.pkl')).open('wb') as f:
             _pickle.dump(val, f)

--- a/pygsti/protocols/treenode.py
+++ b/pygsti/protocols/treenode.py
@@ -44,7 +44,7 @@ class TreeNode(object):
     def _init_children(self, dirname, meta_subdir=None):
         dirname = _pathlib.Path(dirname)
         edesign_dir = dirname / 'edesign'  # because subdirs.json is always & only in 'edesign'
-        with open(edesign_dir / 'subdirs.json', 'r') as f:
+        with (edesign_dir / 'subdirs.json').open('r') as f:
             meta = _json.load(f)
 
         child_dirs = {}
@@ -143,7 +143,7 @@ class TreeNode(object):
             subdirs['directories'] = {dirname: subname for subname, dirname in self._dirs.items()}
             if self._childcategory: subdirs['category'] = self._childcategory
             # write self._dirs "backwards" b/c json doesn't allow tuple-like keys (sometimes keys are tuples)
-            with open(dirname / 'edesign' / 'subdirs.json', 'w') as f:
+            with (dirname / 'edesign' / 'subdirs.json').open('w') as f:
                 _json.dump(subdirs, f)
 
         for nm, val in self._vals.items():  # only write *existing* values


### PR DESCRIPTION
The following syntax doesn't work in python 3.5 (tried looking for a doc for a few minutes, but couldn't find the link I found a few days ago). [python3.8 pathlib docs](https://docs.python.org/3/library/pathlib.html#pathlib.Path.open)
```python
with open(pathlib.Path()) as f:
    ...
``` 
Instead, the following syntax should be used
```python
with pathlib.Path().open() as f:
    ...
```
This "bug" was remedied in python 3.6+, but not in 3.5. Since pygsti nominally supports python3.5, this change should be made.
(I haven't changed this everywhere, just where I ran into it).

Also just an FYI, didn't convert to it here, but pathlib has nice ``[read,write]_text()`` and ``[read,write]_bytes()`` methods.