### PR TITLE
Make `pygsti.DataSet.add_count_dict` convert all keys in `count_dict`…

### DIFF
--- a/pygsti/objects/dataset.py
+++ b/pygsti/objects/dataset.py
@@ -1400,9 +1400,10 @@ class DataSet(object):
         elif isinstance(count_dict, _OrderedDict):  # then don't sort keys
             outcomeCounts = _ld.OutcomeLabelDict(list(count_dict.items()))
         else:
-            # sort key for deterministic ordering of *new* outcome labels)
+            # sort key for deterministic ordering of *new* outcome labels). If keys are
+            # not strings, they will be converted to strings.
             outcomeCounts = _ld.OutcomeLabelDict([
-                (lbl, count_dict[lbl]) for lbl in sorted(list(count_dict.keys()))])
+                (str(lbl), count_dict[lbl]) for lbl in sorted(list(count_dict.keys()), key=str)])
 
         outcomeLabelList = list(outcomeCounts.keys())
         countList = list(outcomeCounts.values())


### PR DESCRIPTION
… to strings. This allows us to use the `collections.Counter` returned by `cirq.TrialResult.histogram` for `count_dict`. This does not affect existing behaviour because if the keys are already strings, then they won't be altered.