### PR TITLE
Adds a new Model.num_modeltest_params property

### DIFF
--- a/pygsti/algorithms/core.py
+++ b/pygsti/algorithms/core.py
@@ -850,22 +850,7 @@ def _do_runopt(objective, optimizer, printer):
     profiler.add_time("run_gst_fit: optimize", tm)
 
     if printer.verbosity > 0:
-        #Don't compute num gauge params if it's expensive (>10% of mem limit) or unavailable
-        if hasattr(mdl, 'num_elements'):
-            memForNumGaugeParams = mdl.num_elements * (mdl.num_params + mdl.dim**2) \
-                * _np.dtype('d').itemsize  # see Model._buildup_dpg (this is mem for dPG)
-
-            if resource_alloc.mem_limit is None or 0.1 * resource_alloc.mem_limit < memForNumGaugeParams:
-                try:
-                    nModelParams = mdl.num_nongauge_params  # len(x0)
-                except:  # numpy can throw a LinAlgError or sparse cases can throw a NotImplementedError
-                    printer.warning("Could not obtain number of *non-gauge* parameters - using total params instead")
-                    nModelParams = mdl.num_params
-            else:
-                printer.log("Finding num_nongauge_params is too expensive: using total params.")
-                nModelParams = mdl.num_params  # just use total number of params
-        else:
-            nModelParams = mdl.num_params  # just use total number of params
+        nModelParams = mdl.num_modeltest_params
 
         #Get number of maximal-model parameter ("dataset params") if needed for print messages
         # -> number of independent parameters in dataset (max. model # of params)

--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -537,7 +537,7 @@ class Estimate(object):
             else:
                 return p.dataset
 
-    def misfit_sigma(self, use_accurate_np=False, comm=None):
+    def misfit_sigma(self, comm=None):
         """
         Returns the number of standard deviations (sigma) of model violation.
 
@@ -568,10 +568,8 @@ class Estimate(object):
 
         ds_allstrs = _tools.apply_aliases_to_circuits(circuit_list, aliases)
         ds_dof = ds.degrees_of_freedom(ds_allstrs)  # number of independent parameters in dataset
-        if hasattr(mdl, 'num_nongauge_params'):
-            mdl_dof = mdl.num_nongauge_params if use_accurate_np else mdl.num_params
-        else:
-            mdl_dof = mdl.num_params
+        mdl_dof = mdl.num_modeltest_params
+
         k = max(ds_dof - mdl_dof, 1)  # expected chi^2 or 2*(logL_ub-logl) mean
         if ds_dof <= mdl_dof: _warnings.warn("Max-model params (%d) <= model params (%d)!  Using k == 1."
                                              % (ds_dof, mdl_dof))

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1620,7 +1620,7 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
     printer = _objs.VerbosityPrinter.create_printer(verbosity, comm)
 
     if badfit_options.threshold is not None and \
-       base_estimate.misfit_sigma(use_accurate_np=True, comm=comm) <= badfit_options.threshold:
+       base_estimate.misfit_sigma(comm=comm) <= badfit_options.threshold:
         return  # fit is good enough - no need to add any estimates
 
     assert(parameters.get('weights', None) is None), \
@@ -1831,7 +1831,7 @@ def _compute_wildcard_budget(mdc_store, parameters, badfit_options, verbosity):
 
     ds_dof = ds.degrees_of_freedom(circuits_to_use)  # number of independent parameters
     # in dataset (max. model # of params)
-    nparams = model.num_params  # just use total number of params
+    nparams = model.num_modeltest_params  # just use total number of params
     percentile = 0.05; nboxes = len(circuits_to_use)
     two_dlogl_threshold = _chi2.ppf(1 - percentile, ds_dof - nparams)
     redbox_threshold = _chi2.ppf(1 - percentile / nboxes, 1)

--- a/pygsti/report/factory.py
+++ b/pygsti/report/factory.py
@@ -415,7 +415,7 @@ def _create_master_switchboard(ws, results_dict, confidence_level,
             switchBd.mdl_all_modvi[d, i] = est_modvi.models['iteration estimates']
 
             if confidence_level is not None:
-                misfit_sigma = est.misfit_sigma(use_accurate_np=True)
+                misfit_sigma = est.misfit_sigma()
 
                 for il, l in enumerate(gauge_opt_labels):
                     if l in est.models:

--- a/pygsti/report/plothelpers.py
+++ b/pygsti/report/plothelpers.py
@@ -821,11 +821,8 @@ def rated_n_sigma(dataset, model, circuits, objfn_builder, np=None, wildcard=Non
 
     aliases = circuits.op_label_aliases if isinstance(circuits, _CircuitList) else None
     ds_gstrs = _tools.apply_aliases_to_circuits(circuits, aliases)
+    np = model.num_modeltest_params
 
-    if hasattr(model, 'num_nongauge_params'):
-        np = model.num_nongauge_params
-    else:
-        np = model.num_params
     Ns = dataset.degrees_of_freedom(ds_gstrs)  # number of independent parameters in dataset
     k = max(Ns - np, 1)  # expected chi^2 or 2*(logL_ub-logl) mean
     Nsig = (fitqty - k) / _np.sqrt(2 * k)

--- a/pygsti/report/workspaceplots.py
+++ b/pygsti/report/workspaceplots.py
@@ -3005,14 +3005,8 @@ class FitComparisonBarPlot(WorkspacePlot):
         xtics = []; ys = []; colors = []; texts = []
 
         if np_by_x is None:
-            try:
-                np_by_x = [mdl.num_nongauge_params if (mdl is not None) else 0
-                           for mdl in model_by_x]  # Note: models can be None => N/A
-            except:  # numpy can throw a LinAlgError
-                _warnings.warn(("FigComparisonBarPlot could not obtain number of"
-                                " *non-gauge* parameters - using total params instead"))
-                np_by_x = [mdl.num_params if (mdl is not None) else 0
-                           for mdl in model_by_x]
+            np_by_x = [mdl.num_modeltest_params if (mdl is not None) else 0
+                       for mdl in model_by_x]  # Note: models can be None => N/A
 
         if isinstance(dataset_by_x, _objs.DataSet):
             dataset_by_x = [dataset_by_x] * len(model_by_x)

--- a/pygsti/report/workspacetables.py
+++ b/pygsti/report/workspacetables.py
@@ -2867,17 +2867,7 @@ class FitComparisonTable(WorkspaceTable):
             raise ValueError("Invalid `objfn_builder` argument: %s" % str(objfn_builder))
 
         if np_by_x is None:
-            try:
-                np_by_x = [mdl.num_nongauge_params for mdl in model_by_x]
-            except _np.linalg.LinAlgError:
-                _warnings.warn(("LinAlgError when trying to compute the number"
-                                " of non-gauge parameters.  Using total"
-                                " parameters instead."))
-                np_by_x = [mdl.num_params for mdl in model_by_x]
-            except (NotImplementedError, AttributeError):
-                _warnings.warn(("FitComparisonTable could not obtain number of"
-                                "*non-gauge* parameters - using total params instead"))
-                np_by_x = [mdl.num_params for mdl in model_by_x]
+            np_by_x = [mdl.num_modeltest_params for mdl in model_by_x]
 
         tooltips = ('', 'Difference in logL', 'number of degrees of freedom',
                     'difference between observed logl and expected mean',

--- a/pygsti/tools/likelihoodfns.py
+++ b/pygsti/tools/likelihoodfns.py
@@ -717,7 +717,7 @@ def two_delta_logl(model, dataset, circuits=None,
         the dataset. Defaults to the empty dictionary (no aliases defined)
         e.g. op_label_aliases['Gx^3'] = ('Gx','Gx','Gx')
 
-    dof_calc_method : {None, "all", "nongauge"}
+    dof_calc_method : {None, "all", "modeltest"}
         How `model`'s number of degrees of freedom (parameters) are obtained
         when computing the number of standard deviations and p-value relative to
         a chi2_k distribution, where `k` is additional degrees of freedom
@@ -762,11 +762,8 @@ def two_delta_logl(model, dataset, circuits=None,
 
     if dof_calc_method is None:
         return two_delta_logl
-    elif dof_calc_method == "nongauge":
-        if hasattr(model, 'num_nongauge_params'):
-            mdl_dof = model.num_nongauge_params
-        else:
-            mdl_dof = model.num_params
+    elif dof_calc_method == "modeltest":
+        mdl_dof = model.num_modeltest_params
     elif dof_calc_method == "all":
         mdl_dof = model.num_params
     else: raise ValueError("Invalid `dof_calc_method` arg: %s" % dof_calc_method)
@@ -836,7 +833,7 @@ def two_delta_logl_per_circuit(model, dataset, circuits=None,
         the dataset. Defaults to the empty dictionary (no aliases defined)
         e.g. op_label_aliases['Gx^3'] = ('Gx','Gx','Gx')
 
-    dof_calc_method : {"all", "nongauge"}
+    dof_calc_method : {"all", "modeltest"}
         How `model`'s number of degrees of freedom (parameters) are obtained
         when computing the number of standard deviations and p-value relative to
         a chi2_k distribution, where `k` is additional degrees of freedom
@@ -878,7 +875,7 @@ def two_delta_logl_per_circuit(model, dataset, circuits=None,
 
     if dof_calc_method is None: return two_dlogl_percircuit
     elif dof_calc_method == "all": mdl_dof = model.num_params
-    elif dof_calc_method == "nongauge": mdl_dof = model.num_nongauge_params
+    elif dof_calc_method == "modeltest": mdl_dof = model.num_modeltest_params
     else: raise ValueError("Invalid `dof_calc_method` arg: %s" % dof_calc_method)
 
     if circuits is not None:


### PR DESCRIPTION
This new property defaults to the usual .num_params, but can be set
independently to allow more flexibility in tuning the model tests
within reports and other functions.  This commit moves the logic
involved in testing whether to use the number of non-gauge parameters
instead of the total parameters to the default .num_modeltest_params
property function, simplifying other functions.  It also adds a
memory limit that can be set to avoid computing the number of nongauge
parameters when it would require too much memory.