### PR TITLE
Added DataSet.add_cirq_trial_result method to import Cirq.TrialResult objects

### DIFF
--- a/jupyter_notebooks/Examples/CirqIntegration.ipynb
+++ b/jupyter_notebooks/Examples/CirqIntegration.ipynb
@@ -1,0 +1,545 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "DmNaCESptyWj"
+   },
+   "source": [
+    "# Cirq Integration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook shows a simple example of how to use pyGSTi with Cirq. It has three sections:\n",
+    "\n",
+    "1. Sets up pyGSTi.\n",
+    "2. Shows how pyGSTi circuits can be converted to Cirq circuits.\n",
+    "3. Shows how the Cirq circuits can be run and the results loaded back into pyGSTi for analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "gw9bJiKmkST9"
+   },
+   "outputs": [],
+   "source": [
+    "import cirq\n",
+    "import pygsti\n",
+    "from pygsti.modelpacks import smq1Q_XYI\n",
+    "import numpy as np\n",
+    "import tqdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "uugvjGQ3vR0z"
+   },
+   "source": [
+    "## 1. Generate the GST circuits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "cWpHwZVtvejH"
+   },
+   "source": [
+    "### Make target gate set $\\{\\sqrt{X},\\sqrt{Y},I\\}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_model = smq1Q_XYI.target_model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "JVfiXBu4vqJV"
+   },
+   "source": [
+    "### Preparation and measurement fiducials, germs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "EPNxq24fvo6t"
+   },
+   "outputs": [],
+   "source": [
+    "preps = smq1Q_XYI.prep_fiducials()\n",
+    "effects = smq1Q_XYI.meas_fiducials()\n",
+    "germs = smq1Q_XYI.germs()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "u9fHRr8Hv933"
+   },
+   "source": [
+    "### Construct pyGSTi circuits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "Jptyo9F0vx5N"
+   },
+   "outputs": [],
+   "source": [
+    "max_lengths = list(np.logspace(0, 10, 11, base=2, dtype=int))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "SuvgxDpKwCul",
+    "outputId": "6654eeeb-3870-4b61-af43-0c66cb09169e"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(max_lengths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "colab": {},
+    "colab_type": "code",
+    "id": "qk-yEEWTwFJM"
+   },
+   "outputs": [],
+   "source": [
+    "pygsti_circuits = pygsti.construction.create_lsgst_circuits(target_model, preps, effects, germs, max_lengths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
+    "colab_type": "code",
+    "id": "9vD8DXOPwHSV",
+    "outputId": "06e10aec-f7ab-4b7b-d0c6-242ce225d5a2"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1624"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(pygsti_circuits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Convert to runable `cirq.Circuit`'s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we need to map the qubit names from pyGSTi (`0`, `1`, etc.) into cirq qubits. There's nothing special about `cirq.GridQubit(8, 3)`; it's just an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q0 = cirq.GridQubit(8, 3)\n",
+    "qubit_label_dict = {0: q0}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Testing examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do an example conversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pyGSTi:\n",
+      "Qubit 0 ---|Gxpi2|-|Gxpi2|-| |-| |-|Gxpi2|---\n",
+      "\n",
+      "Cirq:\n",
+      "(8, 3): ───X^0.5───X^0.5───────────X^0.5───\n"
+     ]
+    }
+   ],
+   "source": [
+    "pygsti_circuit = pygsti_circuits[111]\n",
+    "print('pyGSTi:')\n",
+    "print(pygsti_circuit)\n",
+    "print('Cirq:')\n",
+    "print(pygsti_circuit.convert_to_cirq(qubit_label_dict))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do another example conversion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pyGSTi:\n",
+      "Qubit 0 ---|Gypi2|-|Gypi2|-|Gypi2|-|Gypi2|-|Gxpi2|-|Gxpi2|-|Gxpi2|---\n",
+      "\n",
+      "Cirq:\n",
+      "(8, 3): ───Y^0.5───Y^0.5───Y^0.5───Y^0.5───X^0.5───X^0.5───X^0.5───\n"
+     ]
+    }
+   ],
+   "source": [
+    "pygsti_circuit = pygsti_circuits[90]\n",
+    "print('pyGSTi:')\n",
+    "print(pygsti_circuit)\n",
+    "print('Cirq:')\n",
+    "print(pygsti_circuit.convert_to_cirq(qubit_label_dict))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, lets try the same thing but specifing a wait duration for the idle operation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wait_duration = cirq.Duration(nanos=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pyGSTi:\n",
+      "Qubit 0 ---|Gxpi2|-|Gxpi2|-| |-| |-|Gxpi2|---\n",
+      "\n",
+      "Cirq:\n",
+      "(8, 3): ───X^0.5───X^0.5───WaitGate(100 ns)───WaitGate(100 ns)───X^0.5───\n"
+     ]
+    }
+   ],
+   "source": [
+    "pygsti_circuit = pygsti_circuits[111]\n",
+    "print('pyGSTi:')\n",
+    "print(pygsti_circuit)\n",
+    "print('Cirq:')\n",
+    "print(pygsti_circuit.convert_to_cirq(qubit_label_dict, wait_duration))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pyGSTi:\n",
+      "Qubit 0 ---|Gypi2|-|Gypi2|-|Gypi2|-|Gypi2|-|Gxpi2|-|Gxpi2|-|Gxpi2|---\n",
+      "\n",
+      "Cirq:\n",
+      "(8, 3): ───Y^0.5───Y^0.5───Y^0.5───Y^0.5───X^0.5───X^0.5───X^0.5───\n"
+     ]
+    }
+   ],
+   "source": [
+    "pygsti_circuit = pygsti_circuits[90]\n",
+    "print('pyGSTi:')\n",
+    "print(pygsti_circuit)\n",
+    "print('Cirq:')\n",
+    "print(pygsti_circuit.convert_to_cirq(qubit_label_dict, wait_duration))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The real thing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, convert all the circuits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1624/1624 [00:08<00:00, 189.73it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "cirq_circuits = [c.convert_to_cirq(qubit_label_dict, wait_duration) for c in tqdm.tqdm(pygsti_circuits)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we're missing the measurments, the idle operations don't have a time associated with them, and the first circuit is empty (it's should just be an idle). Otherwise, the results look good, and those things should be easy to fix."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run the circuits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add measurements to the circuits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for circuit in cirq_circuits:\n",
+    "    circuit.append(cirq.measure(q0, key='result'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Simulate the circuits (or run them on a real quantum computer!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1624/1624 [00:39<00:00, 41.60it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "simulator = cirq.Simulator()\n",
+    "results = [simulator.run(circuit, repetitions=1000) for circuit in tqdm.tqdm(cirq_circuits)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load everything the results into a pyGSTi dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = pygsti.objects.dataset.DataSet()\n",
+    "for pygsti_circuit, trial_result in zip(pygsti_circuits, results):\n",
+    "    dataset.add_cirq_trial_result(pygsti_circuit, trial_result, key='result')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perform GST."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Circuit Creation ---\n",
+      "-- Std Practice:  [##################################################] 100.0%  (Target) --\n"
+     ]
+    }
+   ],
+   "source": [
+    "gst_results = pygsti.run_stdpractice_gst(dataset, target_model, preps, effects, germs, max_lengths, modes=\"TP,Target\", verbosity=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See what if finds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2DeltaLogL(estimate, data):  1102.0101377779301\n",
+      "2DeltaLogL(ideal, data):  1118.865389448009\n"
+     ]
+    }
+   ],
+   "source": [
+    "mdl_estimate = gst_results.estimates['TP'].models['stdgaugeopt']\n",
+    "print(\"2DeltaLogL(estimate, data): \", pygsti.tools.two_delta_logl(mdl_estimate, dataset))\n",
+    "print(\"2DeltaLogL(ideal, data): \", pygsti.tools.two_delta_logl(target_model, dataset))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "XYI GST circuit generation with commentary 2019-10-17.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pygsti/objects/dataset.py
+++ b/pygsti/objects/dataset.py
@@ -1474,6 +1474,39 @@ class DataSet(object):
                                  aux, update_ol, unsafe=True)
         #unsafe=True OK b/c outcome_label_list contains the keys of an OutcomeLabelDict
 
+    def add_cirq_trial_result(self, circuit, trial_result, key):
+        """
+        Add a single circuit's counts --- stored in a Cirq TrialResult --- to this DataSet
+
+        Parameters
+        ----------
+        circuit : tuple or Circuit
+            A tuple of operation labels specifying the circuit or a Circuit object.
+            Note that this must be a PyGSTi circuit --- not a Cirq circuit.
+
+        trial_result : cirq.TrialResult
+            The TrialResult to add
+
+        key : str
+            The string key of the measurement. Set by cirq.measure.
+
+        Returns
+        -------
+        None
+        """
+
+        try:
+            import cirq
+        except ImportError:
+            raise ImportError("Cirq is required for this operation, and it does not appear to be installed.")
+
+        # TrialResult.histogram returns a collections.Counter object, which is a subclass of dict.
+        histogram_counter = trial_result.histogram(key=key)
+        # The keys in histogram_counter are integers, but pyGSTi likes dictionary keys to be strings.
+        count_dict = {str(key): value for key, value in histogram_counter.items()}
+        self.add_count_dict(circuit, count_dict)
+
+
     def add_raw_series_data(self, circuit, outcome_label_list, time_stamp_list,
                             rep_count_list=None, overwrite_existing=True,
                             record_zero_counts=True, aux=None, update_ol=True,


### PR DESCRIPTION
I ended up adding the import method to DataSet because that seemed to fit well. I can move it elsewhere if you'd like. I also added a jupyter notebook showing how to run everything. Feel free to include it or discard it.