### PR TITLE
Bugfix marginalized povm

### DIFF
--- a/pygsti/objects/implicitmodel.py
+++ b/pygsti/objects/implicitmodel.py
@@ -281,7 +281,7 @@ class ImplicitOpModel(_mdl.OpModel):
 
         return s
 
-    def _default_privitive_povm_layer_lbl(self, sslbls):
+    def _default_primitive_povm_layer_lbl(self, sslbls):
         """
         Gets the default POVM label.
 
@@ -298,12 +298,12 @@ class ImplicitOpModel(_mdl.OpModel):
         Label or None
         """
         if len(self.primitive_povm_labels) == 1:
-            povmName = next(iter(self._primitive_povm_labels)).name
+            povm_name = next(iter(self.primitive_povm_labels)).name
             if len(self.state_space_labels.labels) == 1 and (self.state_space_labels.labels[0] == sslbls
                                                              or sslbls == ('*',)):
-                return _Label(povmName)  # because sslbls == all of model's sslbls
+                return _Label(povm_name)  # because sslbls == all of model's sslbls
             else:
-                return _Label(povmName, sslbls)
+                return _Label(povm_name, sslbls)
         else:
             return None
 

--- a/pygsti/objects/model.py
+++ b/pygsti/objects/model.py
@@ -943,7 +943,9 @@ class OpModel(Model):
                 #raise ValueError(f"Missing state prep in {circuit.str} and there's no default!")
                 raise ValueError("Missing state prep in %s and there's no default!" % circuit.str)
         if len(circuit) == 0 or not self._is_primitive_povm_layer_lbl(circuit[-1]):
-            povm_lbl_to_append = self._default_primitive_povm_layer_lbl(None)
+            sslbls = circuit.line_labels if circuit.line_labels != ("*",) else None
+            povm_lbl_to_append = self._default_primitive_povm_layer_lbl(sslbls)
+
             if povm_lbl_to_append is None:
                 #raise ValueError(f"Missing POVM in {circuit.str} and there's no default!")
                 raise ValueError("Missing POVM in %s and there's no default!" % circuit.str)

--- a/pygsti/objects/model.py
+++ b/pygsti/objects/model.py
@@ -1033,8 +1033,7 @@ class OpModel(Model):
         -------
         bool
         """
-        # Have to check name since want a marginalized POVM to count
-        return lbl.name in self._primitive_povm_label_dict
+        return lbl in self._primitive_povm_label_dict or lbl.name in self._primitive_povm_label_dict
 
     def _is_primitive_op_layer_lbl(self, lbl):
         """

--- a/pygsti/objects/model.py
+++ b/pygsti/objects/model.py
@@ -1033,7 +1033,8 @@ class OpModel(Model):
         -------
         bool
         """
-        return lbl in self._primitive_povm_label_dict
+        # Have to check name since want a marginalized POVM to count
+        return lbl.name in self._primitive_povm_label_dict
 
     def _is_primitive_op_layer_lbl(self, lbl):
         """

--- a/test/unit/objects/test_localnoisemodel.py
+++ b/test/unit/objects/test_localnoisemodel.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from ..util import BaseCase
 
+from pygsti.objects.circuit import Circuit
 from pygsti.objects.localnoisemodel import LocalNoiseModel
 
 
@@ -76,3 +77,27 @@ class LocalNoiseModelInstanceTester(BaseCase):
         self.assertAlmostEqual(sum(mdl_local.probabilities(test_circuit).values()), 1.0)
         self.assertAlmostEqual(mdl_local.probabilities(test_circuit)['00'], 0.414025)
         self.assertEqual(mdl_local.num_params, 144)
+
+    def test_marginalized_povm(self):
+        nQubits = 4
+        # TODO: This fails if custom qubit labels are used (as in above tests)
+        # Somehow the marginalization code doesn't handle custom sslbls well?
+        mdl_local = LocalNoiseModel.from_parameterization(
+            nQubits, ('Gx', 'Gy', 'Gcnot'), geometry="line",
+            parameterization='H+S', independent_gates=True,
+            ensure_composed_gates=False, global_idle=None)
+
+        c = Circuit( [('Gx',0),('Gx',1),('Gx',2),('Gx',3)], num_lines=4)
+        prob = mdl_local.probabilities(c)
+        self.assertEqual(len(prob), 16) # Full 4 qubit space
+
+        c2 = Circuit( [('Gx',0),('Gx',1)], num_lines=2)
+        prob2 = mdl_local.probabilities(c2)
+        self.assertEqual(len(prob2), 4) # Full 4 qubit space
+
+        c3 = Circuit( [('Gx',0),('Gx',1)], num_lines=4)
+        prob3 = mdl_local.probabilities(c3)
+        self.assertEqual(len(prob3), 16) # Full 16 qubit space
+
+
+

--- a/test/unit/objects/test_localnoisemodel.py
+++ b/test/unit/objects/test_localnoisemodel.py
@@ -80,22 +80,22 @@ class LocalNoiseModelInstanceTester(BaseCase):
 
     def test_marginalized_povm(self):
         nQubits = 4
-        # TODO: This fails if custom qubit labels are used (as in above tests)
-        # Somehow the marginalization code doesn't handle custom sslbls well?
         mdl_local = LocalNoiseModel.from_parameterization(
             nQubits, ('Gx', 'Gy', 'Gcnot'), geometry="line",
+            qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
             parameterization='H+S', independent_gates=True,
             ensure_composed_gates=False, global_idle=None)
 
-        c = Circuit( [('Gx',0),('Gx',1),('Gx',2),('Gx',3)], num_lines=4)
+        c = Circuit( [('Gx','qb0'),('Gx','qb1'),('Gx','qb2'),('Gx','qb3')], num_lines=4)
         prob = mdl_local.probabilities(c)
         self.assertEqual(len(prob), 16) # Full 4 qubit space
 
-        c2 = Circuit( [('Gx',0),('Gx',1)], num_lines=2)
+        c2 = Circuit( [('Gx','qb0'),('Gx','qb1')], num_lines=2)
         prob2 = mdl_local.probabilities(c2)
         self.assertEqual(len(prob2), 4) # Full 4 qubit space
 
-        c3 = Circuit( [('Gx',0),('Gx',1)], num_lines=4)
+        c3 = Circuit( [('Gx','qb0'),('Gx','qb1')])
+        c3.insert_idling_lines_inplace(None, ['qb2', 'qb3'])
         prob3 = mdl_local.probabilities(c3)
         self.assertEqual(len(prob3), 16) # Full 16 qubit space
 


### PR DESCRIPTION
This includes Erik's suggested fixes + a modification to _is_primitive_povm_circuit_lbl to allow marginalized primitive POVM labels to be detected as primitive as well.

The new test (`test_marginalized_povm`) fails if custom `qubit_labels` are used, as in other `LocalNoiseModel` tests. I think this is a related but separate marginalization bug to what I'm trying to fix in this PR. The relevant portion of error message:
```
  File "/Users/sserita/Documents/repos/pyGSTi/pygsti/objects/povm.py", line 1468, in <listcomp>
    indices_to_keep = set([list(all_sslbls).index(l) for l in sslbls_after_marginalizing])
ValueError: 0 is not in list
```
This can be reproduced by adding `qubit_labels=['qb{}'.format(i) for i in range(nQubits)],` into the constructor call of `mdl_local` in the new test.