### PR TITLE
Bugfix cvxpy and modeltest

### DIFF
--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -60,7 +60,6 @@ jobs:
         # Cython must be pre-installed to build native extensions on pyGSTi install
         python -m pip install cython
         python -m pip install wheel
-        python -m pip install "cvxpy<=1.1.7" # TEMPORARY: 1.1.8 messed up numpy version, see https://github.com/cvxgrp/cvxpy/issues/1236
         # Installing with -e to keep installation local (for NOSE_NOPATH)
         # but still compile Cython extensions
         python -m pip install -e .[testing]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,6 @@ jobs:
         # Cython must be pre-installed to build native extensions on pyGSTi install
         python -m pip install cython
         python -m pip install wheel flake8
-        python -m pip install "cvxpy<=1.1.7" # TEMPORARY: 1.1.8 messed up numpy version, see https://github.com/cvxgrp/cvxpy/issues/1236
         python -m pip install .[testing]
         python -m pip freeze
     - name: Lint with flake8

--- a/pygsti/protocols/modeltest.py
+++ b/pygsti/protocols/modeltest.py
@@ -128,6 +128,7 @@ class ModelTest(_proto.Protocol):
         self.auxfile_types['target_model'] = 'pickle'
         self.auxfile_types['gaugeopt_suite'] = 'pickle'  # TODO - better later? - json?
         self.auxfile_types['gaugeopt_target'] = 'pickle'  # TODO - better later? - json?
+        self.auxfile_types['badfit_options'] = 'pickle' # SS: Had issues using json, unclear what was not serializable
         self.auxfile_types['objfn_builders'] = 'pickle'
 
         #Advanced options that could be changed by users who know what they're doing


### PR DESCRIPTION
Two small bugfixes:

**Unpinning cvxpy from 1.1.7**
1.1.9 fixed the versioning issues with 1.1.8,  and 1.1.10 may be needed for newer numpy versions.

**Adding badfit_options as an auxfile for ModelTest**
This matches the behavior in GateSetTomography and was needed as GSTBadFitOptions could not be JSON-serialized when testing with wildcard during SGST analysis.