### PR TITLE
Feature std static op

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ hooks/etc/permissions.yml
 *.cache
 /.eggs/
 .ropeproject
+.vscode
 
 # Test Metadata #
 #################

--- a/pygsti/construction/modelconstruction.py
+++ b/pygsti/construction/modelconstruction.py
@@ -1257,7 +1257,7 @@ def create_crosstalk_free_model(num_qubits, gate_names, nonstd_gate_unitaries={}
     for key in all_keys:
         # Use custom gate directly as error gate
         if key in custom_gates:
-            gatedict[name] = custom_gates[name]
+            gatedict[key] = custom_gates[key]
             continue
     
         # Skip idle, prep, and povm here, just do gates

--- a/pygsti/construction/modelconstruction.py
+++ b/pygsti/construction/modelconstruction.py
@@ -948,7 +948,8 @@ def _get_error_gate(key, ideal_gate, depolarization_strengths, stochastic_error_
                 # TODO: Make this not require dense
                 err_gate = _op.LindbladOp(ideal_gate.to_dense(), errgen, dense_rep=True)
             else:
-                raise ValueError("Unknown parameterization %s for depolarizing error specification" % parameterization[0])
+                raise ValueError("Unknown parameterization %s for depolarizing error specification" \
+                                 % depolarization_parameterization)
 
         elif key in stochastic_error_probs: # Stochastic error specification
             sto_rates = stochastic_error_probs[key]
@@ -965,7 +966,8 @@ def _get_error_gate(key, ideal_gate, depolarization_strengths, stochastic_error_
                 # TODO: Make this not require dense
                 err_gate = _op.LindbladOp(ideal_gate.to_dense(), errgen, dense_rep=True)
             else:
-                raise ValueError("Unknown parameterization %s for stochastic error specification" % parameterization[0])
+                raise ValueError("Unknown parameterization %s for stochastic error specification" \
+                                 % stochastic_parameterization)
 
         elif key in lindblad_error_coeffs: # LindbladOp with errgen coefficients
             errdict = lindblad_error_coeffs[key]

--- a/pygsti/construction/nqnoiseconstruction.py
+++ b/pygsti/construction/nqnoiseconstruction.py
@@ -49,6 +49,7 @@ from ..io import CircuitParser as _CircuitParser
 
 from . import circuitconstruction as _gsc
 from .modelconstruction import _basis_create_spam_vector as _basis_build_vector
+from .modelconstruction import _parameterization_from_errgendict
 
 RANK_TOL = 1e-9
 
@@ -654,18 +655,6 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
             if k.sslbls is not None:
                 assert(all([sslbl in qubitGraph.node_names for sslbl in k.sslbls])), \
                     "One or more invalid qubit names in the label: %s" % str(k)
-
-    def _parameterization_from_errgendict(errs):
-        paramtypes = []
-        if any([nm[0] == 'H' for nm in errs]): paramtypes.append('H')
-        if any([nm[0] == 'S' for nm in errs]): paramtypes.append('S')
-        if any([nm[0] == 'A' for nm in errs]): paramtypes.append('A')
-        if any([nm[0] == 'S' and isinstance(nm, tuple) and len(nm) == 3 for nm in errs]):
-            # parameterization must be "CPTP" if there are any ('S',b1,b2) keys
-            parameterization = "CPTP"
-        else:
-            parameterization = '+'.join(paramtypes)
-        return parameterization
 
     def _map_stencil_sslbls(stencil_sslbls, target_lbls):  # deals with graph directions
         ret = [qubitGraph.resolve_relative_nodelabel(s, target_lbls) for s in stencil_sslbls]

--- a/pygsti/construction/nqnoiseconstruction.py
+++ b/pygsti/construction/nqnoiseconstruction.py
@@ -448,8 +448,10 @@ def create_cloudnoise_model_from_hops_and_weights(
         return mdl
 
 
-def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gate_unitaries=None, custom_gates=None,
-                                 availability=None, qubit_labels=None, geometry="line", parameterization='auto',
+def create_cloud_crosstalk_model(num_qubits, gate_names, nonstd_gate_unitaries={}, custom_gates={},
+                                 depolarization_strengths={}, stochastic_error_probs={}, lindblad_error_coeffs={},
+                                 depolarization_parameterization='depolarize', stochastic_parameterization='stochastic',
+                                 lindblad_parameterization='auto', availability=None, qubit_labels=None, geometry="line",
                                  evotype="auto", simulator="auto", independent_gates=False, sparse_lindblad_basis=False,
                                  sparse_lindblad_reps=False, errcomp_type="errorgens", add_idle_noise_to_all_gates=True,
                                  verbosity=0):
@@ -512,6 +514,50 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
         be *static*, and keys of this dictionary must by strings - there's
         no way to specify the "cloudnoise" part of a gate via this dict
         yet, only the "target" part.
+    
+    depolarization_strengths : dict, optional
+        A dictionary whose keys are gate names (e.g. `"Gx"`) and whose values
+        are floats that specify the strength of uniform depolarization.
+    
+    stochastic_error_probs : dict, optional
+        A dictionary whose keys are gate names (e.g. `"Gx"`) and whose values
+        are tuples that specify Pauli-stochastic rates for each of the non-trivial
+        Paulis (so a 3-tuple would be expected for a 1Q gate and a 15-tuple for a 2Q gate).
+    
+    lindblad_error_coeffs : dict, optional
+        A dictionary whose keys are gate names (e.g. `"Gx"`) and whose values
+        are dictionaries corresponding to the `lindblad_term_dict` kwarg taken
+        by `LindbladErrorgen`. Keys are `(termType, basisLabel1, <basisLabel2>)`
+        tuples, where `termType` can be `"H"` (Hamiltonian), `"S"`
+        (Stochastic), or `"A"` (Affine).  Hamiltonian and Affine terms always
+        have a single basis label (so key is a 2-tuple) whereas Stochastic
+        tuples with 1 basis label indicate a *diagonal* term, and are the
+        only types of terms allowed when `nonham_mode != "all"`.  Otherwise,
+        Stochastic term tuples can include 2 basis labels to specify
+        "off-diagonal" non-Hamiltonian Lindblad terms.  Basis labels can be
+        strings or integers.  Values are complex coefficients.
+    
+    depolarization_parameterization : str of {"depolarize", "stochastic", or "lindblad"}
+        Determines whether a DepolarizeOp, StochasticNoiseOp, or LindbladOp
+        is used to parameterize the depolarization noise, respectively.
+        When "depolarize" (the default), a DepolarizeOp is created with the strength given
+        in `depolarization_strengths`. When "stochastic", the depolarization strength is split
+        evenly among the stochastic channels of a StochasticOp. When "lindblad", the depolarization
+        strength is split evenly among the coefficients of the stochastic error generators
+        (which are exponentiated to form a LindbladOp with the "depol" parameterization).
+    
+    stochastic_parameterization : str of {"stochastic", or "lindblad"}
+        Determines whether a StochasticNoiseOp or LindbladOp is used to parameterize the
+        stochastic noise, respectively. When "stochastic", elements of `stochastic_error_probs`
+        are used as coefficients in a linear combination of stochastic channels (the default).
+        When "lindblad", the elements of `stochastic_error_probs` are coefficients of
+        stochastic error generators (which are exponentiated to form a LindbladOp with the
+        "cptp" parameterization).
+    
+    lindblad_parameterization : "auto" or a LindbladOp paramtype
+        Determines the parameterization of the LindbladOp. When "auto" (the default), the parameterization
+        is inferred from the types of error generators specified in the `lindblad_error_coeffs` dictionaries.
+        When not "auto", the parameterization type is passed through to the LindbladOp.
 
     availability : dict, optional
         A dictionary whose keys are the same gate names as in
@@ -547,9 +593,6 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
         graph used to define neighbor relationships.  Alternatively,
         a :class:`QubitGraph` object with node labels equal to
         `qubit_labels` may be passed directly.
-
-    parameterization : "auto"
-        This argument is for future expansion and currently must be set to `"auto"`.
 
     evotype : {"auto","densitymx","statevec","stabilizer","svterm","cterm"}
         The evolution type.  If "auto" is specified, "densitymx" is used.
@@ -612,10 +655,8 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
     # the qubit graph.
     printer = _VerbosityPrinter.create_printer(verbosity)
 
-    if parameterization != "auto":
-        raise NotImplementedError(("Future versions of pyGSTi may allow you to specify a non-automatic "
-                                   "parameterization - for instance building DepolarizeOp objects "
-                                   "instead of LindbladOps for depolarization errors."))
+    if depolarization_strengths or stochastic_error_probs:
+        raise NotImplementedError("Cloud noise models can currently only be built with `lindbad_error_coeffs`")
 
     if evotype == "auto":
         evotype = "densitymx"  # FUTURE: do something more sophisticated?
@@ -640,17 +681,17 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
 
     nQubit_dim = 2**num_qubits if evotype in ('statevec', 'stabilizer') else 4**num_qubits
 
-    orig_error_rates = error_rates.copy()
+    orig_lindblad_error_coeffs = lindblad_error_coeffs.copy()
     cparser = _CircuitParser()
     cparser.lookup = None  # lookup - functionality removed as it wasn't used
-    for k, v in orig_error_rates.items():
+    for k, v in orig_lindblad_error_coeffs.items():
         if isinstance(k, str) and ":" in k:  # then parse this to get a label, allowing, e.g. "Gx:0"
             lbls, _, _ = cparser.parse(k)
             assert(len(lbls) == 1), "Only single primitive-gate labels allowed as keys! (not %s)" % str(k)
             assert(all([sslbl in qubitGraph.node_names for sslbl in lbls[0].sslbls])), \
                 "One or more invalid qubit names in: %s" % k
-            del error_rates[k]
-            error_rates[lbls[0]] = v
+            del lindblad_error_coeffs[k]
+            lindblad_error_coeffs[lbls[0]] = v
         elif isinstance(k, _Lbl):
             if k.sslbls is not None:
                 assert(all([sslbl in qubitGraph.node_names for sslbl in k.sslbls])), \
@@ -822,29 +863,29 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
             return errgen
 
     #Process "auto" simulator
-    _, evotype = _gt.split_lindblad_paramtype(parameterization)  # what about "auto" parameterization?
+    _, evotype = _gt.split_lindblad_paramtype(lindblad_parameterization)  # what about "auto" parameterization?
     assert(evotype in ("densitymx", "svterm", "cterm")), "State-vector evolution types not allowed."
     if simulator == "auto":
         if evotype in ("svterm", "cterm"): simulator = _TermFSim()
         else: simulator = _MapFSim() if num_qubits > 2 else _MatrixFSim()
 
     #Global Idle
-    if 'idle' in error_rates:
+    if 'idle' in lindblad_error_coeffs:
         printer.log("Creating Idle:")
-        global_idle_layer = create_error(qubit_labels, error_rates['idle'], return_what="errmap")
+        global_idle_layer = create_error(qubit_labels, lindblad_error_coeffs['idle'], return_what="errmap")
     else:
         global_idle_layer = None
 
     #SPAM
-    if 'prep' in error_rates:
+    if 'prep' in lindblad_error_coeffs:
         prepPure = _sv.ComputationalSPAMVec([0] * num_qubits, evotype)
-        prepNoiseMap = create_error(qubit_labels, error_rates['prep'], return_what="errmap")
+        prepNoiseMap = create_error(qubit_labels, lindblad_error_coeffs['prep'], return_what="errmap")
         prep_layers = [_sv.LindbladSPAMVec(prepPure, prepNoiseMap, "prep")]
     else:
         prep_layers = [_sv.ComputationalSPAMVec([0] * num_qubits, evotype)]
 
-    if 'povm' in error_rates:
-        povmNoiseMap = create_error(qubit_labels, error_rates['povm'], return_what="errmap")
+    if 'povm' in lindblad_error_coeffs:
+        povmNoiseMap = create_error(qubit_labels, lindblad_error_coeffs['povm'], return_what="errmap")
         povm_layers = [_povm.LindbladPOVM(povmNoiseMap, None, "pp")]
     else:
         povm_layers = [_povm.ComputationalBasisPOVM(num_qubits, evotype)]
@@ -857,12 +898,12 @@ def create_cloud_crosstalk_model(num_qubits, gate_names, error_rates, nonstd_gat
         # regardless of the value of `independent_gates`) using these rates.  Otherwise, if we have a stencil
         # for this gate, then we should use it to construct the output, using a copy when gates are independent
         # and a reference to the *same* stencil operations when `independent_gates==False`.
-        if lbl in error_rates:
-            return create_error(lbl.sslbls, errs=error_rates[lbl])  # specific instructions for this primitive layer
+        if lbl in lindblad_error_coeffs:
+            return create_error(lbl.sslbls, errs=lindblad_error_coeffs[lbl])  # specific instructions for this primitive layer
         elif lbl.name in stencils:
             return create_error(lbl.sslbls, stencil=stencils[lbl.name])  # use existing stencil
-        elif lbl.name in error_rates:
-            stencils[lbl.name] = create_error(lbl.sslbls, error_rates[lbl.name],
+        elif lbl.name in lindblad_error_coeffs:
+            stencils[lbl.name] = create_error(lbl.sslbls, lindblad_error_coeffs[lbl.name],
                                               return_what='stencil')  # create stencil
             return create_error(lbl.sslbls, stencil=stencils[lbl.name])  # and then use it
         else:

--- a/pygsti/objects/operation.py
+++ b/pygsti/objects/operation.py
@@ -2995,7 +2995,7 @@ class DepolarizeOp(StochasticNoiseOp):
         StochasticNoiseOp.__init__(self, dim, basis, evotype, initial_sto_rates)
 
         # For DepolarizeOp, set params to only first element
-        self.params = [self.params[0]]
+        self.params = _np.array([self.params[0]])
 
     def _rates_to_params(self, rates):
         """Note: requires rates to all be the same"""
@@ -3004,45 +3004,6 @@ class DepolarizeOp(StochasticNoiseOp):
 
     def _params_to_rates(self, params):
         return _np.array([params[0]**2] * (self.basis.size - 1), 'd')
-    
-    def to_vector(self):
-        """
-        Extract a vector of the underlying operation parameters from this operation.
-
-        Returns
-        -------
-        numpy array
-            a 1D numpy array with length == num_params().
-        """
-        return self.params
-
-    def from_vector(self, v, close=False, dirty_value=True):
-        """
-        Initialize the operation using a vector of parameters.
-
-        Parameters
-        ----------
-        v : numpy array
-            The 1D vector of operation parameters.  Length
-            must == num_params()
-
-        close : bool, optional
-            Whether `v` is close to this operation's current
-            set of parameters.  Under some circumstances, when this
-            is true this call can be completed more quickly.
-
-        dirty_value : bool, optional
-            The value to set this object's "dirty flag" to before exiting this
-            call.  This is passed as an argument so it can be updated *recursively*.
-            Leave this set to `True` unless you know what you're doing.
-
-        Returns
-        -------
-        None
-        """
-        self.params[:] = v
-        self._update_rep()
-        self.dirty = dirty_value
 
     def _get_rate_poly_dicts(self):
         """ Return a list of dicts, one per rate, expressing the

--- a/pygsti/objects/operation.py
+++ b/pygsti/objects/operation.py
@@ -2994,6 +2994,9 @@ class DepolarizeOp(StochasticNoiseOp):
         initial_sto_rates = [initial_rate / num_rates] * num_rates
         StochasticNoiseOp.__init__(self, dim, basis, evotype, initial_sto_rates)
 
+        # For DepolarizeOp, set params to only first element
+        self.params = [self.params[0]]
+
     def _rates_to_params(self, rates):
         """Note: requires rates to all be the same"""
         assert(all([rates[0] == r for r in rates[1:]]))
@@ -3001,6 +3004,45 @@ class DepolarizeOp(StochasticNoiseOp):
 
     def _params_to_rates(self, params):
         return _np.array([params[0]**2] * (self.basis.size - 1), 'd')
+    
+    def to_vector(self):
+        """
+        Extract a vector of the underlying operation parameters from this operation.
+
+        Returns
+        -------
+        numpy array
+            a 1D numpy array with length == num_params().
+        """
+        return self.params
+
+    def from_vector(self, v, close=False, dirty_value=True):
+        """
+        Initialize the operation using a vector of parameters.
+
+        Parameters
+        ----------
+        v : numpy array
+            The 1D vector of operation parameters.  Length
+            must == num_params()
+
+        close : bool, optional
+            Whether `v` is close to this operation's current
+            set of parameters.  Under some circumstances, when this
+            is true this call can be completed more quickly.
+
+        dirty_value : bool, optional
+            The value to set this object's "dirty flag" to before exiting this
+            call.  This is passed as an argument so it can be updated *recursively*.
+            Leave this set to `True` unless you know what you're doing.
+
+        Returns
+        -------
+        None
+        """
+        self.params[:] = v
+        self._update_rep()
+        self.dirty = dirty_value
 
     def _get_rate_poly_dicts(self):
         """ Return a list of dicts, one per rate, expressing the

--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -161,10 +161,9 @@ def standard_gatename_unitaries():
     - Clifford Gates:
 
       - 'Gi' : the 1Q idle operation.
-      - 'Gxpi2','Gypi2','Gzpi2' : 1Q pi/2 rotations around X, Y and Z.
       - 'Gxpi','Gypi','Gzpi' : 1Q pi rotations around X, Y and Z.
       - 'Gxpi2','Gypi2','Gzpi2' : 1Q pi/2 rotations around X, Y and Z.
-      - 'Gxpi2','Gypi2','Gzpi2' : 1Q pi/2 rotations around X, Y and Z.
+      - 'Gxmpi2','Gympi2','Gzmpi2' : 1Q -pi/2 rotations around X, Y and Z.
       - 'Gh' : Hadamard.
       - 'Gp', 'Gpdag' : phase and inverse phase (an alternative notation/name for Gzpi and Gzmpi2).
       - 'Gci' where i = 0, 1, ..., 23 : the 24 1-qubit Cliffor gates (all the gates above are included as one of these).

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -165,11 +165,31 @@ class ModelConstructionTester(BaseCase):
             nQubits, ('Gi',), depol_strengths={'Gi': 0.1},
             parameterization=['auto', 'auto', 'auto']
         )
-        Gi_op = mdl_depol1.operation_blks['gates']['Gi']
+        Gi_op = mdl_depol4.operation_blks['gates']['Gi']
         self.assertTrue(isinstance(Gi_op, op.ComposedOp))
         self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
         self.assertTrue(isinstance(Gi_op.factorops[1], op.DepolarizeOp))
-        self.assertEqual(mdl_depol1.num_params, 1)
+        self.assertEqual(mdl_depol4.num_params, 1)
+
+        # For prep and povm, only lindblad parameterization is allowed
+        # Test that proper warnings are raised
+        with self.assertWarns(UserWarning):
+            mc.create_crosstalk_free_model(
+                nQubits, ('Gi',), depol_strengths={'Gi': 0.1, 'prep': 0.1},
+                parameterization=['depolarize', 'auto', 'auto'])
+        with self.assertWarns(UserWarning):
+            mc.create_crosstalk_free_model(
+                nQubits, ('Gi',), depol_strengths={'Gi': 0.1, 'prep': 0.1},
+                parameterization=['stochastic', 'auto', 'auto'])
+        
+        with self.assertWarns(UserWarning):
+            mc.create_crosstalk_free_model(
+                nQubits, ('Gi',), depol_strengths={'Gi': 0.1, 'povm': 0.1},
+                parameterization=['depolarize', 'auto', 'auto'])
+        with self.assertWarns(UserWarning):
+            mc.create_crosstalk_free_model(
+                nQubits, ('Gi',), depol_strengths={'Gi': 0.1, 'povm': 0.1},
+                parameterization=['stochastic', 'auto', 'auto'])
 
     def test_build_crosstalk_free_model_stochastic_parameterizations(self):
         nQubits = 2
@@ -204,6 +224,17 @@ class ModelConstructionTester(BaseCase):
         Gi_op = mdl_sto3.operation_blks['gates']['Gi']
         self.assertTrue(isinstance(Gi_op, op.LindbladOp))
         self.assertEqual(mdl_sto3.num_params, 3)
+
+        # For prep and povm, only lindblad parameterization is allowed
+        # Test that proper warnings are raised
+        with self.assertWarns(UserWarning):
+            mc.create_crosstalk_free_model(
+                nQubits, ('Gi',), depol_strengths={'Gi': 0.1, 'prep': 0.1},
+                parameterization=['auto', 'stochastic', 'auto'])
+        with self.assertWarns(UserWarning):
+            mc.create_crosstalk_free_model(
+                nQubits, ('Gi',), depol_strengths={'Gi': 0.1, 'povm': 0.1},
+                parameterization=['auto', 'stochastic', 'auto'])
 
     def test_build_crosstalk_free_model_lindblad_parameterizations(self):
         nQubits = 2

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -91,12 +91,18 @@ class ModelConstructionTester(BaseCase):
         self.assertEqual(mdl.num_params, 24)
 
         # TODO: These are maybe not deterministic? Sometimes are swapped for me...
-        self.assertEqual(mdl.operation_blks['layers'][('Gx', 0)].gpindices, slice(0, 12))
-        self.assertEqual(mdl.operation_blks['layers'][('Gy', 0)].gpindices, slice(12, 24))
-        self.assertEqual(mdl.operation_blks['layers'][('Gi', 0)].gpindices, slice(0, 12))
-        self.assertEqual(mdl.operation_blks['gates']['Gx'].gpindices, slice(0, 12))
-        self.assertEqual(mdl.operation_blks['gates']['Gy'].gpindices, slice(12, 24))
-        self.assertEqual(mdl.operation_blks['gates']['Gi'].gpindices, slice(0, 12))
+        if mdl.operation_blks['layers'][('Gx', 0)].gpindices == slice(0, 12):
+            slice1 = slice(0, 12)
+            slice2 = slice(12, 24)
+        else:
+            slice1 = slice(12, 24)
+            slice2 = slice(0, 12)
+        self.assertEqual(mdl.operation_blks['layers'][('Gx', 0)].gpindices, slice1)
+        self.assertEqual(mdl.operation_blks['layers'][('Gy', 0)].gpindices, slice2)
+        self.assertEqual(mdl.operation_blks['layers'][('Gi', 0)].gpindices, slice1)
+        self.assertEqual(mdl.operation_blks['gates']['Gx'].gpindices, slice1)
+        self.assertEqual(mdl.operation_blks['gates']['Gy'].gpindices, slice2)
+        self.assertEqual(mdl.operation_blks['gates']['Gi'].gpindices, slice1)
 
         # Case: ensure_composed_gates=False, independent_gates=True
         cfmdl = mc.create_crosstalk_free_model(

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -5,6 +5,7 @@ from ..util import BaseCase
 
 import pygsti
 import pygsti.construction.modelconstruction as mc
+import pygsti.objects.operation as op
 
 
 class ModelConstructionTester(BaseCase):
@@ -64,7 +65,7 @@ class ModelConstructionTester(BaseCase):
 
         mdl = mc.create_crosstalk_free_model(
             nQubits, ('Gi', 'Gx', 'Gy', 'Gcnot'),
-            {}, ensure_composed_gates=True,
+            ensure_composed_gates=True,
             independent_gates=False
         )
         assert(set(mdl.operation_blks['gates'].keys()) == set(["Gi", "Gx", "Gy", "Gcnot"]))
@@ -79,6 +80,8 @@ class ModelConstructionTester(BaseCase):
         mdl.operation_blks['gates']['Gy'].append(addlErr2)
         mdl.operation_blks['gates']['Gi'].append(addlErr)
 
+        # TODO: If you call mdl.num_params between the 3 calls above, this second one has an error...
+
         self.assertEqual(mdl.num_params, 24)
 
         self.assertEqual(mdl.operation_blks['layers'][('Gx', 0)].gpindices, slice(0, 12))
@@ -91,12 +94,11 @@ class ModelConstructionTester(BaseCase):
         # Case: ensure_composed_gates=False, independent_gates=True
         cfmdl = mc.create_crosstalk_free_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx': 0.1,  # depol
-             'Gy': (0.02, 0.02, 0.02),  # pauli stochastic
-             # errgen: BUG? when SIX too large -> no coeff corresponding to rate?
-             'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
-             'idle': 0.01, 'prep': 0.01, 'povm': 0.01
-             }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
+            depol_error_rates={'Gx': 0.1, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
+            sto_error_rates={'Gy': (0.02, 0.02, 0.02)},
+            lindblad_error_rates={
+                'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
+            }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)], 
             ensure_composed_gates=False, independent_gates=True)
 
         self.assertEqual(cfmdl.num_params, 17)
@@ -104,10 +106,10 @@ class ModelConstructionTester(BaseCase):
         # Case: ensure_composed_gates=True, independent_gates=False
         cfmdl2 = mc.create_crosstalk_free_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx': 0.1,  # depol
-             'Gy': (0.02, 0.02, 0.02),  # pauli stochastic
-             'Gcnot': {'HZZ': 0.01, 'SIX': 0.01},  # errgen: BUG? when SIX too large -> no coeff corresponding to rate?
-             'idle': 0.01, 'prep': 0.01, 'povm': 0.01
+            depol_error_rates={'Gx': 0.1, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
+            sto_error_rates={'Gy': (0.02, 0.02, 0.02)},
+            lindblad_error_rates={
+                'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
             ensure_composed_gates=True, independent_gates=False)
         self.assertEqual(cfmdl2.num_params, 11)
@@ -115,14 +117,123 @@ class ModelConstructionTester(BaseCase):
         # Same as above but add ('Gx','qb0') to test giving qubit-specific error rates
         cfmdl3 = mc.create_crosstalk_free_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx': 0.1,  # depol
-             ('Gx', 'qb0'): 0.2,  # adds another independent depol param for Gx:qb0
-             'Gy': (0.02, 0.02, 0.02),  # pauli stochastic
-             'Gcnot': {'HZZ': 0.01, 'SIX': 0.01},  # errgen: BUG? when SIX too large -> no coeff corresponding to rate?
-             'idle': 0.01, 'prep': 0.01, 'povm': 0.01
+            depol_error_rates={'Gx': 0.1, ('Gx', 'qb0'): 0.2, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
+            sto_error_rates={'Gy': (0.02, 0.02, 0.02)},
+            lindblad_error_rates={
+                'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01}, # adds another independent depol param for Gx:qb0
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
             ensure_composed_gates=True, independent_gates=False)
         self.assertEqual(cfmdl3.num_params, 12)
+
+    def test_build_crosstalk_free_model_depolarize_parameterizations(self):
+        nQubits = 2
+
+        # Test depolarizing
+        mdl_depol1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            parameterization=['depolarize', 'auto', 'auto']
+        )
+        Gi_op = mdl_depol1.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.ComposedOp))
+        self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
+        self.assertTrue(isinstance(Gi_op.factorops[1], op.DepolarizeOp))
+        self.assertEqual(mdl_depol1.num_params, 3) # Currently, DepolarizeOp uses StochasticNoiseOp so 3 params
+
+        # Expand into StochasticNoiseOp
+        mdl_depol2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            parameterization=['stochastic', 'auto', 'auto']
+        )
+        Gi_op = mdl_depol2.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.ComposedOp))
+        self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
+        self.assertTrue(isinstance(Gi_op.factorops[1], op.StochasticNoiseOp))
+        self.assertEqual(mdl_depol2.num_params, 3) 
+
+        # Use LindbladOp with "depol", "diagonal" param
+        mdl_depol3 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            parameterization=['lindblad', 'auto', 'auto']
+        )
+        Gi_op = mdl_depol3.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
+        self.assertEqual(mdl_depol3.num_params, 1)
+
+        # Same as depol3
+        mdl_depol4 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            parameterization=['auto', 'auto', 'auto']
+        )
+        Gi_op = mdl_depol4.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
+        self.assertEqual(mdl_depol4.num_params, 1) # Use LindbladOp with "depol", "diagonal" param
+
+    def test_build_crosstalk_free_model_stochastic_parameterizations(self):
+        nQubits = 2
+
+        # Test stochastic
+        mdl_sto1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), sto_error_rates={'Gi': (0.1, 0.1, 0.1)},
+            parameterization=['auto', 'stochastic', 'auto']
+        )
+        Gi_op = mdl_sto1.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.ComposedOp))
+        self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
+        self.assertTrue(isinstance(Gi_op.factorops[1], op.StochasticNoiseOp))
+        self.assertEqual(mdl_sto1.num_params, 3)
+
+        # Same as sto1
+        mdl_sto2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), sto_error_rates={'Gi': (0.1, 0.1, 0.1)},
+            parameterization=['auto', 'auto', 'auto']
+        )
+        Gi_op = mdl_sto2.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.ComposedOp))
+        self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
+        self.assertTrue(isinstance(Gi_op.factorops[1], op.StochasticNoiseOp))
+        self.assertEqual(mdl_sto2.num_params, 3)
+
+        # Use LindbladOp with "cptp", "diagonal" param
+        mdl_sto3 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), sto_error_rates={'Gi': (0.1, 0.1, 0.1)},
+            parameterization=['auto', 'lindblad', 'auto']
+        )
+        Gi_op = mdl_sto3.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
+        self.assertEqual(mdl_sto3.num_params, 3)
+
+    def test_build_crosstalk_free_model_lindblad_parameterizations(self):
+        nQubits = 2
+
+        # Test Lindblad
+        mdl_lb1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_rates={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
+            parameterization=['auto', 'auto', 'auto']
+        )
+        Gi_op = mdl_lb1.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
+        self.assertEqual(Gi_op.error_rates(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
+        self.assertEqual(mdl_lb1.num_params, 2)
+    
+        # Test param passthrough
+        mdl_lb2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_rates={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
+            parameterization=['auto', 'auto', 'H+S']
+        )
+        Gi_op = mdl_lb2.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
+        self.assertEqual(Gi_op.error_rates(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
+        self.assertEqual(mdl_lb2.num_params, 2)
+
+        # Test coeff instead of rates
+        mdl_lb3 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_coeffs={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
+            parameterization=['auto', 'auto', 'auto']
+        )
+        Gi_op = mdl_lb3.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
+        self.assertEqual(Gi_op.errorgen_coefficients(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
+        self.assertEqual(mdl_lb3.num_params, 2)
 
     def test_build_crosstalk_free_model_with_nonstd_gate_unitary_factory(self):
         nQubits = 2
@@ -134,7 +245,7 @@ class ModelConstructionTester(BaseCase):
             return scipy.linalg.expm(1j * float(a) * sigmaZ)
 
         cfmdl = mc.create_crosstalk_free_model(nQubits, ('Gx', 'Gy', 'Gcnot', 'Ga'),
-                                              {}, nonstd_gate_unitaries={'Ga': fn})
+                                              nonstd_gate_unitaries={'Ga': fn})
 
         c = pygsti.obj.Circuit("Gx:1Ga;0.3:1Gx:1@(0,1)")
         p = cfmdl.probabilities(c)

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -84,6 +84,7 @@ class ModelConstructionTester(BaseCase):
 
         self.assertEqual(mdl.num_params, 24)
 
+        # TODO: These are maybe not deterministic? Sometimes are swapped for me...
         self.assertEqual(mdl.operation_blks['layers'][('Gx', 0)].gpindices, slice(0, 12))
         self.assertEqual(mdl.operation_blks['layers'][('Gy', 0)].gpindices, slice(12, 24))
         self.assertEqual(mdl.operation_blks['layers'][('Gi', 0)].gpindices, slice(0, 12))
@@ -137,7 +138,7 @@ class ModelConstructionTester(BaseCase):
         self.assertTrue(isinstance(Gi_op, op.ComposedOp))
         self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
         self.assertTrue(isinstance(Gi_op.factorops[1], op.DepolarizeOp))
-        self.assertEqual(mdl_depol1.num_params, 3) # Currently, DepolarizeOp uses StochasticNoiseOp so 3 params
+        self.assertEqual(mdl_depol1.num_params, 1)
 
         # Expand into StochasticNoiseOp
         mdl_depol2 = mc.create_crosstalk_free_model(
@@ -159,14 +160,16 @@ class ModelConstructionTester(BaseCase):
         self.assertTrue(isinstance(Gi_op, op.LindbladOp))
         self.assertEqual(mdl_depol3.num_params, 1)
 
-        # Same as depol3
+        # Same as depol1
         mdl_depol4 = mc.create_crosstalk_free_model(
             nQubits, ('Gi',), depol_strengths={'Gi': 0.1},
             parameterization=['auto', 'auto', 'auto']
         )
-        Gi_op = mdl_depol4.operation_blks['gates']['Gi']
-        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
-        self.assertEqual(mdl_depol4.num_params, 1) # Use LindbladOp with "depol", "diagonal" param
+        Gi_op = mdl_depol1.operation_blks['gates']['Gi']
+        self.assertTrue(isinstance(Gi_op, op.ComposedOp))
+        self.assertTrue(isinstance(Gi_op.factorops[0], op.StaticStandardOp))
+        self.assertTrue(isinstance(Gi_op.factorops[1], op.DepolarizeOp))
+        self.assertEqual(mdl_depol1.num_params, 1)
 
     def test_build_crosstalk_free_model_stochastic_parameterizations(self):
         nQubits = 2

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -94,9 +94,9 @@ class ModelConstructionTester(BaseCase):
         # Case: ensure_composed_gates=False, independent_gates=True
         cfmdl = mc.create_crosstalk_free_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            depol_error_rates={'Gx': 0.1, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
-            sto_error_rates={'Gy': (0.02, 0.02, 0.02)},
-            lindblad_error_rates={
+            depol_strengths={'Gx': 0.1, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
+            sto_error_probs={'Gy': (0.02, 0.02, 0.02)},
+            lindblad_error_coeffs={
                 'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
             }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)], 
             ensure_composed_gates=False, independent_gates=True)
@@ -106,9 +106,9 @@ class ModelConstructionTester(BaseCase):
         # Case: ensure_composed_gates=True, independent_gates=False
         cfmdl2 = mc.create_crosstalk_free_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            depol_error_rates={'Gx': 0.1, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
-            sto_error_rates={'Gy': (0.02, 0.02, 0.02)},
-            lindblad_error_rates={
+            depol_strengths={'Gx': 0.1, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
+            sto_error_probs={'Gy': (0.02, 0.02, 0.02)},
+            lindblad_error_coeffs={
                 'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
             ensure_composed_gates=True, independent_gates=False)
@@ -117,9 +117,9 @@ class ModelConstructionTester(BaseCase):
         # Same as above but add ('Gx','qb0') to test giving qubit-specific error rates
         cfmdl3 = mc.create_crosstalk_free_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            depol_error_rates={'Gx': 0.1, ('Gx', 'qb0'): 0.2, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
-            sto_error_rates={'Gy': (0.02, 0.02, 0.02)},
-            lindblad_error_rates={
+            depol_strengths={'Gx': 0.1, ('Gx', 'qb0'): 0.2, 'idle': 0.01, 'prep': 0.01, 'povm': 0.01},
+            sto_error_probs={'Gy': (0.02, 0.02, 0.02)},
+            lindblad_error_coeffs={
                 'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01}, # adds another independent depol param for Gx:qb0
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
             ensure_composed_gates=True, independent_gates=False)
@@ -130,7 +130,7 @@ class ModelConstructionTester(BaseCase):
 
         # Test depolarizing
         mdl_depol1 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            nQubits, ('Gi',), depol_strengths={'Gi': 0.1},
             parameterization=['depolarize', 'auto', 'auto']
         )
         Gi_op = mdl_depol1.operation_blks['gates']['Gi']
@@ -141,7 +141,7 @@ class ModelConstructionTester(BaseCase):
 
         # Expand into StochasticNoiseOp
         mdl_depol2 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            nQubits, ('Gi',), depol_strengths={'Gi': 0.1},
             parameterization=['stochastic', 'auto', 'auto']
         )
         Gi_op = mdl_depol2.operation_blks['gates']['Gi']
@@ -152,7 +152,7 @@ class ModelConstructionTester(BaseCase):
 
         # Use LindbladOp with "depol", "diagonal" param
         mdl_depol3 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            nQubits, ('Gi',), depol_strengths={'Gi': 0.1},
             parameterization=['lindblad', 'auto', 'auto']
         )
         Gi_op = mdl_depol3.operation_blks['gates']['Gi']
@@ -161,7 +161,7 @@ class ModelConstructionTester(BaseCase):
 
         # Same as depol3
         mdl_depol4 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), depol_error_rates={'Gi': 0.1},
+            nQubits, ('Gi',), depol_strengths={'Gi': 0.1},
             parameterization=['auto', 'auto', 'auto']
         )
         Gi_op = mdl_depol4.operation_blks['gates']['Gi']
@@ -173,7 +173,7 @@ class ModelConstructionTester(BaseCase):
 
         # Test stochastic
         mdl_sto1 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), sto_error_rates={'Gi': (0.1, 0.1, 0.1)},
+            nQubits, ('Gi',), sto_error_probs={'Gi': (0.1, 0.1, 0.1)},
             parameterization=['auto', 'stochastic', 'auto']
         )
         Gi_op = mdl_sto1.operation_blks['gates']['Gi']
@@ -184,7 +184,7 @@ class ModelConstructionTester(BaseCase):
 
         # Same as sto1
         mdl_sto2 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), sto_error_rates={'Gi': (0.1, 0.1, 0.1)},
+            nQubits, ('Gi',), sto_error_probs={'Gi': (0.1, 0.1, 0.1)},
             parameterization=['auto', 'auto', 'auto']
         )
         Gi_op = mdl_sto2.operation_blks['gates']['Gi']
@@ -195,7 +195,7 @@ class ModelConstructionTester(BaseCase):
 
         # Use LindbladOp with "cptp", "diagonal" param
         mdl_sto3 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), sto_error_rates={'Gi': (0.1, 0.1, 0.1)},
+            nQubits, ('Gi',), sto_error_probs={'Gi': (0.1, 0.1, 0.1)},
             parameterization=['auto', 'lindblad', 'auto']
         )
         Gi_op = mdl_sto3.operation_blks['gates']['Gi']
@@ -207,33 +207,23 @@ class ModelConstructionTester(BaseCase):
 
         # Test Lindblad
         mdl_lb1 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), lindblad_error_rates={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
+            nQubits, ('Gi',), lindblad_error_coeffs={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
             parameterization=['auto', 'auto', 'auto']
         )
         Gi_op = mdl_lb1.operation_blks['gates']['Gi']
         self.assertTrue(isinstance(Gi_op, op.LindbladOp))
-        self.assertEqual(Gi_op.error_rates(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
+        self.assertEqual(Gi_op.errorgen_coefficients(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
         self.assertEqual(mdl_lb1.num_params, 2)
     
         # Test param passthrough
         mdl_lb2 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), lindblad_error_rates={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
+            nQubits, ('Gi',), lindblad_error_coeffs={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
             parameterization=['auto', 'auto', 'H+S']
         )
         Gi_op = mdl_lb2.operation_blks['gates']['Gi']
         self.assertTrue(isinstance(Gi_op, op.LindbladOp))
-        self.assertEqual(Gi_op.error_rates(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
-        self.assertEqual(mdl_lb2.num_params, 2)
-
-        # Test coeff instead of rates
-        mdl_lb3 = mc.create_crosstalk_free_model(
-            nQubits, ('Gi',), lindblad_error_coeffs={'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1}},
-            parameterization=['auto', 'auto', 'auto']
-        )
-        Gi_op = mdl_lb3.operation_blks['gates']['Gi']
-        self.assertTrue(isinstance(Gi_op, op.LindbladOp))
         self.assertEqual(Gi_op.errorgen_coefficients(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
-        self.assertEqual(mdl_lb3.num_params, 2)
+        self.assertEqual(mdl_lb2.num_params, 2)
 
     def test_build_crosstalk_free_model_with_nonstd_gate_unitary_factory(self):
         nQubits = 2
@@ -252,6 +242,39 @@ class ModelConstructionTester(BaseCase):
 
         self.assertAlmostEqual(p['00'], 0.08733219254516078)
         self.assertAlmostEqual(p['01'], 0.9126678074548386)
+    
+    def test_build_crosstalk_free_model_with_custom_gates(self):
+        nQubits = 2
+
+        class XRotationOpFactory(pygsti.obj.OpFactory):
+            def __init__(self):
+                pygsti.obj.OpFactory.__init__(self, dim=4, evotype="densitymx")
+                
+            def create_object(self, args=None, sslbls=None):
+                theta = float(args[0])/2.0
+                b = 2*np.cos(theta)*np.sin(theta)
+                c = np.cos(theta)**2 - np.sin(theta)**2
+                superop = np.array([[1,   0,   0,   0],
+                                    [0,   1,   0,   0],
+                                    [0,   0,   c,  -b],
+                                    [0,   0,   b,   c]],'d')
+                return pygsti.obj.StaticDenseOp(superop)
+
+        xrot_fact = XRotationOpFactory()
+    
+        cfmdl = mc.create_crosstalk_free_model(nQubits, ('Gi', 'Gxr'),
+                                              custom_gates={'Gxr': xrot_fact})
+
+        c = pygsti.obj.Circuit("Gxr;3.1415926536:1@(0,1)")
+        p = cfmdl.probabilities(c)
+
+        self.assertAlmostEqual(p['01'], 1.0)
+
+        c = pygsti.obj.Circuit("Gxr;1.5707963268:1@(0,1)")
+        p = cfmdl.probabilities(c)
+        
+        self.assertAlmostEqual(p['00'], 0.5)
+        self.assertAlmostEqual(p['01'], 0.5)
 
     def test_build_operation_raises_on_bad_parameterization(self):
         with self.assertRaises(ValueError):

--- a/test/unit/construction/test_nqnoiseconstruction.py
+++ b/test/unit/construction/test_nqnoiseconstruction.py
@@ -69,7 +69,7 @@ class NQNoiseConstructionTester(BaseCase):
         nQubits = 2
         ccmdl1 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {('Gx', 'qb0'): {('H', 'X'): 0.01, ('S', 'XY:qb0,qb1'): 0.01},
+            lindblad_error_coeffs={('Gx', 'qb0'): {('H', 'X'): 0.01, ('S', 'XY:qb0,qb1'): 0.01},
              ('Gcnot', 'qb0', 'qb1'): {('H', 'ZZ'): 0.02, ('S', 'XX:qb0,qb1'): 0.02},
              'idle': {('S', 'XX:qb0,qb1'): 0.01},
              'prep': {('S', 'XX:qb0,qb1'): 0.01},
@@ -80,7 +80,7 @@ class NQNoiseConstructionTester(BaseCase):
         #Using sparse=True and a map-based simulator
         ccmdl1 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {('Gx', 'qb0'): {('H', 'X'): 0.01, ('S', 'XY:qb0,qb1'): 0.01},
+            lindblad_error_coeffs={('Gx', 'qb0'): {('H', 'X'): 0.01, ('S', 'XY:qb0,qb1'): 0.01},
              ('Gcnot', 'qb0', 'qb1'): {('H', 'ZZ'): 0.02, ('S', 'XX:qb0,qb1'): 0.02},
              'idle': {('S', 'XX:qb0,qb1'): 0.01},
              'prep': {('S', 'XX:qb0,qb1'): 0.01},
@@ -93,7 +93,7 @@ class NQNoiseConstructionTester(BaseCase):
         #Using compact notation:
         ccmdl2 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx:0': {('HX'): 0.01, 'SXY:0,1': 0.01},
+            lindblad_error_coeffs={'Gx:0': {('HX'): 0.01, 'SXY:0,1': 0.01},
              'Gcnot:0:1': {'HZZ': 0.02, 'SXX:0,1': 0.02},
              'idle': {'SXX:0,1': 0.01},
              'prep': {'SXX:0,1': 0.01},
@@ -104,7 +104,7 @@ class NQNoiseConstructionTester(BaseCase):
         #also using qubit_labels
         ccmdl3 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx:qb0': {('HX'): 0.01, 'SXY:qb0,qb1': 0.01},
+            lindblad_error_coeffs={'Gx:qb0': {('HX'): 0.01, 'SXY:qb0,qb1': 0.01},
              'Gcnot:qb0:qb1': {'HZZ': 0.02, 'SXX:qb0,qb1': 0.02},
              'idle': {'SXX:qb0,qb1': 0.01},
              'prep': {'SXX:qb0,qb1': 0.01},
@@ -112,11 +112,24 @@ class NQNoiseConstructionTester(BaseCase):
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)])
         self.assertEqual(ccmdl3.num_params, 7)
 
+        # Assert if try to use non-lindblad error specification (will be removed in the future when implemented)
+        with self.assertRaises(NotImplementedError):
+            nc.create_cloud_crosstalk_model(
+                nQubits, ('Gx', 'Gy', 'Gcnot'),
+                depolarization_strengths={'Gx': 0.15}
+            )
+        with self.assertRaises(NotImplementedError):
+            nc.create_cloud_crosstalk_model(
+                nQubits, ('Gx', 'Gy', 'Gcnot'),
+                stochastic_error_probs={'Gx': (0.01,)*15}
+            )
+
+
     def test_build_cloud_crosstalk_model_stencils(self):
         nQubits = 2
         ccmdl1 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx': {('H', 'X'): 0.01, ('S', 'X:@0+left'): 0.01},  # ('S','XX:@1+right,@0+left'): 0.02
+            lindblad_error_coeffs={'Gx': {('H', 'X'): 0.01, ('S', 'X:@0+left'): 0.01},  # ('S','XX:@1+right,@0+left'): 0.02
              'Gcnot': {('H', 'ZZ'): 0.02, ('S', 'XX:@1+right,@0+left'): 0.02},
              'idle': {('S', 'XX:qb0,qb1'): 0.01}
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)])
@@ -125,7 +138,7 @@ class NQNoiseConstructionTester(BaseCase):
         #Using compact notation:
         ccmdl2 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx': {'HX': 0.01, 'SX:@0+left': 0.01},  # ('S','XX:@1+right,@0+left'): 0.02
+            lindblad_error_coeffs={'Gx': {'HX': 0.01, 'SX:@0+left': 0.01},  # ('S','XX:@1+right,@0+left'): 0.02
              'Gcnot': {'HZZ': 0.02, 'SXX:@1+right,@0+left': 0.02},
              'idle': {'SXX:qb0,qb1': 0.01}
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)])
@@ -136,7 +149,7 @@ class NQNoiseConstructionTester(BaseCase):
         nQubits = 2
         ccmdl1 = nc.create_cloud_crosstalk_model(
             nQubits, ('Gx', 'Gy', 'Gcnot'),
-            {'Gx': {('H', 'X'): 0.01, ('S', 'X:@0+left'): 0.01},  # ('S','XX:@1+right,@0+left'): 0.02
+            lindblad_error_coeffs={'Gx': {('H', 'X'): 0.01, ('S', 'X:@0+left'): 0.01},  # ('S','XX:@1+right,@0+left'): 0.02
              'Gcnot': {('H', 'ZZ'): 0.02, ('S', 'XX:@1+right,@0+left'): 0.02},
              'idle': {('S', 'XX:qb0,qb1'): 0.01}
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)], independent_gates=True)
@@ -152,7 +165,7 @@ class NQNoiseConstructionTester(BaseCase):
             return scipy.linalg.expm(1j * float(a) * sigmaZ)
 
         ccmdl = nc.create_cloud_crosstalk_model(nQubits, ('Gx', 'Gy', 'Gcnot', 'Ga'),
-                                                {}, nonstd_gate_unitaries={'Ga': fn})
+                                                nonstd_gate_unitaries={'Ga': fn})
         c = Circuit("Gx:1Ga;0.3:1Gx:1@(0,1)")
         p1 = ccmdl.probabilities(c)
 

--- a/test/unit/objects/test_operation.py
+++ b/test/unit/objects/test_operation.py
@@ -263,20 +263,20 @@ class StaticStdOpTester(BaseCase):
             svop = op.StaticStandardOp(name, 'statevec')
             self.assertArraysAlmostEqual(svop._rep.base, U)
 
-    def test_densitymx(self):
+    def test_densitymx_svterm_cterm(self):
         std_unitaries = itgs.standard_gatename_unitaries()
 
-        for name, U in std_unitaries.items():
-            dmop = op.StaticStandardOp(name, 'densitymx')
-            self.assertArraysAlmostEqual(dmop._rep.base, gt.unitary_to_pauligate(U))
+        for evotype in ['densitymx', 'svterm', 'cterm']:
+            for name, U in std_unitaries.items():
+                dmop = op.StaticStandardOp(name, evotype)
+                self.assertArraysAlmostEqual(dmop._rep.base, gt.unitary_to_pauligate(U))
         
-    def test_raises_on_bad_name(self):
+    def test_raises_on_bad_values(self):
         with self.assertRaises(ValueError):
             op.StaticStandardOp('BadGate', 'statevec')
         with self.assertRaises(ValueError):
             op.StaticStandardOp('BadGate', 'densitymx')
-    
-    def test_raises_on_bad_evotype(self):
+
         with self.assertRaises(ValueError):
             op.StaticStandardOp('Gi', 'not_an_evotype')
 

--- a/test/unit/objects/test_operation.py
+++ b/test/unit/objects/test_operation.py
@@ -10,6 +10,8 @@ from pygsti.tools import basisconstructors as bc
 import pygsti.construction as pc
 from pygsti.construction.modelconstruction import _create_spam_vector, _create_operation
 import pygsti.objects.operation as op
+import pygsti.tools.internalgates as itgs
+import pygsti.tools.optools as gt
 
 
 class OpBase(object):
@@ -251,6 +253,32 @@ class DenseOpTester(ImmutableDenseOpBase, BaseCase):
         for bad_mx in bad_mxs:
             with self.assertRaises(ValueError):
                 op.DenseOperator.convert_to_matrix(bad_mx)
+
+
+class StaticStdOpTester(BaseCase):
+    def test_statevec(self):
+        std_unitaries = itgs.standard_gatename_unitaries()
+
+        for name, U in std_unitaries.items():
+            svop = op.StaticStandardOp(name, 'statevec')
+            self.assertArraysAlmostEqual(svop._rep.base, U)
+
+    def test_densitymx(self):
+        std_unitaries = itgs.standard_gatename_unitaries()
+
+        for name, U in std_unitaries.items():
+            dmop = op.StaticStandardOp(name, 'densitymx')
+            self.assertArraysAlmostEqual(dmop._rep.base, gt.unitary_to_pauligate(U))
+        
+    def test_raises_on_bad_name(self):
+        with self.assertRaises(ValueError):
+            op.StaticStandardOp('BadGate', 'statevec')
+        with self.assertRaises(ValueError):
+            op.StaticStandardOp('BadGate', 'densitymx')
+    
+    def test_raises_on_bad_evotype(self):
+        with self.assertRaises(ValueError):
+            op.StaticStandardOp('Gi', 'not_an_evotype')
 
 
 class FullOpTester(MutableDenseOpBase, BaseCase):


### PR DESCRIPTION
Added the StaticStandardOp class and reworked the crosstalk-free model construction for more explicit error specification.

Probably more work could be done on extending new error specification API to the cloud noise model construction, but that seems less clear since that construction relies heavily on LindbladOps. In the meantime, this PR could already be useful in the feature-chp-revive branch.