### PR TITLE
feature noisy spamvec: manually merged updates from feature-noiseop-spamvec

### DIFF
--- a/jupyter_notebooks/Tutorials/algorithms/advanced/CircuitSimulation-CHP.ipynb
+++ b/jupyter_notebooks/Tutorials/algorithms/advanced/CircuitSimulation-CHP.ipynb
@@ -17,7 +17,7 @@
     {
      "data": {
       "text/plain": [
-       "'0.9.9.2.post917+g98710b31.d20210505'"
+       "'0.9.9.2.post849+gd0926235'"
       ]
      },
      "execution_count": 1,
@@ -96,7 +96,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<pygsti.objects.operation.LinearOperator object at 0x136044610>\n",
+      "<pygsti.objects.operation.LinearOperator object at 0x10658a850>\n",
       "h 0\n",
       "c 1 2\n",
       "\n",
@@ -398,7 +398,7 @@
    "outputs": [],
    "source": [
     "chpexe = '/Users/sserita/Documents/notebooks/pyGSTi/2021-CHP/chp'\n",
-    "sim = pygsti.obj.CHPForwardSimulator(chpexe, shots=100)"
+    "sim = pygsti.obj.CHPForwardSimulator(chpexe, shots=1)"
    ]
   },
   {
@@ -410,18 +410,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "rho0 = Composed operation of 2 factors:\n",
-      "Factor 0:\n",
-      "Embedded operation with full dimension 4 and state space Q0(2)*Q1(2)\n",
-      " that embeds the following 2-dimensional operation into acting on the ['Q0'] space\n",
-      "StaticStandardOp with name Gi and evotype chp\n",
-      "CHP operations: \n",
-      "Factor 1:\n",
-      "Embedded operation with full dimension 4 and state space Q0(2)*Q1(2)\n",
-      " that embeds the following 2-dimensional operation into acting on the ['Q1'] space\n",
-      "StaticStandardOp with name Gi and evotype chp\n",
-      "CHP operations: \n",
-      "\n",
+      "rho0 = Computational Z-basis SPAM vec for 2 qubits w/z-values: [0 0]\n",
       "\n",
       "Mdefault = Computational(Z)-basis POVM on 2 qubits and filter None\n",
       "\n",
@@ -539,8 +528,10 @@
     "        EmbeddedOp(['Q0', 'Q1'], ['Q1'], StaticStandardOp(name1, 'chp')),\n",
     "    ])\n",
     "\n",
-    "#Populate the Model object with states, effects, gates,\n",
-    "model['rho0'] = make_2Q_op('Gi', 'Gi')\n",
+    "#Populate the Model object with states, effects, gates\n",
+    "# For CHP, prep must be all-zero ComputationalSPAMVec\n",
+    "# and povm must be ComputationalBasisPOVM\n",
+    "model['rho0'] = pygsti.obj.ComputationalSPAMVec([0, 0], 'chp')\n",
     "model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
     "\n",
     "model['Gii'] = make_2Q_op('Gi', 'Gi')\n",
@@ -562,7 +553,7 @@
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('01',), 1.0000000000000007)])"
+       "OutcomeLabelDict([(('01',), 1.0)])"
       ]
      },
      "execution_count": 14,
@@ -583,10 +574,30 @@
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('11',), 1.0000000000000007)])"
+       "StateSpaceLabels[Q0(2)*Q1(2)]"
       ]
      },
      "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.state_space_labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('11',), 1.0)])"
+      ]
+     },
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -598,16 +609,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('11',), 1.0000000000000007)])"
+       "OutcomeLabelDict([(('11',), 1.0)])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -621,12 +632,270 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Advanced State Prep and Measurement\n",
+    "### State Prep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('01',), 1.0)])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Initialize an empty Model object\n",
+    "prep01_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "\n",
+    "# Make a ComputationalSPAMVec with one bit in 1 state\n",
+    "prep01_model['rho0'] = pygsti.obj.ComputationalSPAMVec([0, 1], 'chp')\n",
+    "prep01_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "\n",
+    "circ = pygsti.obj.Circuit([])\n",
+    "prep01_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('01',), 1.0)])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Initialize an empty Model object\n",
+    "prep00noise_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "\n",
+    "# Make a ComposedSPAMVec where second qubit has X error\n",
+    "rho0 = pygsti.obj.ComposedSPAMVec(\n",
+    "    pygsti.obj.ComputationalSPAMVec([0, 0], 'chp', 'prep'), # Pure SPAM vec is 00 state\n",
+    "    make_2Q_op('Gi', 'Gxpi'), 'prep') # Second qubit has X error (flipping up to 1)\n",
+    "\n",
+    "prep00noise_model['rho0'] = rho0\n",
+    "prep00noise_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "\n",
+    "circ = pygsti.obj.Circuit([])\n",
+    "prep00noise_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('10',), 1.0)])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Initialize an empty Model object\n",
+    "prep11noise_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "\n",
+    "# Make a ComposedSPAMVec where second qubit has X error AND is initialized to 1 state\n",
+    "rho0 = pygsti.obj.ComposedSPAMVec(\n",
+    "    pygsti.obj.ComputationalSPAMVec([1, 1], 'chp', 'prep'), # Pure SPAM vec is 11 state\n",
+    "    make_2Q_op('Gi', 'Gxpi'), 'prep') # Second qubit has X error (flipping back to 0)\n",
+    "\n",
+    "prep11noise_model['rho0'] = rho0\n",
+    "prep11noise_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "\n",
+    "circ = pygsti.obj.Circuit([])\n",
+    "prep11noise_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Have gpindices:  slice(0, 0, None)  v:  []\n",
+      "Have gpindices:  slice(0, 0, None)  v:  []\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('10',), 1.0)])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Initialize an empty Model object\n",
+    "tensorprep_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "\n",
+    "# Make a TensorProdSPAMVec equivalent of prep11noise_model\n",
+    "rho0 = pygsti.obj.TensorProdSPAMVec('prep', [\n",
+    "    pygsti.obj.ComposedSPAMVec([1], StaticStandardOp('Gi', 'chp'), 'prep'), # First qubit to 1 state with no error\n",
+    "    pygsti.obj.ComposedSPAMVec([1], StaticStandardOp('Gxpi', 'chp'), 'prep'), # Second qubit to 1 state with X error\n",
+    "])\n",
+    "\n",
+    "tensorprep_model['rho0'] = rho0\n",
+    "tensorprep_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "\n",
+    "circ = pygsti.obj.Circuit([])\n",
+    "tensorprep_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DOES NOT WORK. This was for debugging TensorProdSPAMVec > ComposedSPAMVec > ComposedOp\n",
+    "# This was sidestepped for now by not building the TensorProdSPAMVec in create_crosstalk_free_model\n",
+    "# #Initialize an empty Model object\n",
+    "# tensorprep2_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "\n",
+    "# # Make a TensorProdSPAMVec equivalent of prep11noise_model\n",
+    "# rho0 = pygsti.obj.TensorProdSPAMVec('prep', [\n",
+    "#     pygsti.obj.ComposedSPAMVec([1, 1], make_2Q_op('Gi', 'Gxpi'), 'prep')\n",
+    "# ])\n",
+    "\n",
+    "# tensorprep2_model['rho0'] = rho0\n",
+    "# tensorprep2_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "\n",
+    "# circ = pygsti.obj.Circuit([])\n",
+    "# tensorprep2_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#prep11noise_model._print_gpindices() # This one works great\n",
+    "#tensorprep2_model._print_gpindices() # This one doesn't\n",
+    "# the ComposedSPAMVec underneath doesn't know about it's gpindices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Measurement"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('01',), 1.0)])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Initialize an empty Model object\n",
+    "povm01_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "\n",
+    "# Make a measurement with a bitflip error on qubit 1\n",
+    "povm01_model['rho0'] = pygsti.obj.ComputationalSPAMVec([0, 0], 'chp')\n",
+    "povm01_model['Mdefault'] = pygsti.obj.ComposedPOVM(make_2Q_op('Gi', 'Gxpi'), )\n",
+    "povm01_model['Gi', 'Q0'] = StaticStandardOp('Gi', 'chp')\n",
+    "povm01_model['Gi', 'Q1'] = StaticStandardOp('Gi', 'chp')\n",
+    "\n",
+    "circ = pygsti.obj.Circuit([])\n",
+    "povm01_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0',), 1.0)])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Try marginalized on qubit 0 (should stay in 0 state)\n",
+    "circ = pygsti.obj.Circuit([('Gi', 'Q0')])\n",
+    "povm01_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('1',), 1.0)])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Try marginalized on qubit 1 (should flip to 1 state due to readout error)\n",
+    "circ = pygsti.obj.Circuit([('Gi', 'Q1')])\n",
+    "povm01_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## CHPForwardSimulator + LocalNoiseModel"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,19 +926,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pygsti.objects.localnoisemodel import LocalNoiseModel\n",
     "from pygsti.objects.spamvec import ComputationalSPAMVec\n",
     "\n",
-    "# TODO: Much less convenient to generate parallel gates\n",
-    "rho0 = ComposedOp([EmbeddedOp(range(3), [i], StaticStandardOp('Gi', 'chp')) for i in range(3)])\n",
+    "rho0 = pygsti.obj.ComputationalSPAMVec([0,]*4, 'chp')\n",
     "Mdefault = pygsti.obj.ComputationalBasisPOVM(4, 'chp')\n",
-    "\n",
-    "\n",
-    "\n",
     "\n",
     "ln_model = LocalNoiseModel(num_qubits=4, gatedict=gatedict, prep_layers=rho0, povm_layers=Mdefault,\n",
     "                           availability={'Gcnot': [(0,1),(1,2),(2,3)]}, simulator=sim, evotype='chp')"
@@ -677,7 +942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -721,7 +986,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computational Z-basis SPAM vec for 4 qubits w/z-values: [0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(ln_model.prep_blks['layers']['rho0'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -745,7 +1027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -780,42 +1062,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('0100',), 0.9300000000000006), (('0000',), 0.07)])"
+       "OutcomeLabelDict([(('0100',), 1.0)])"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Step 5: Actually run circuits with local noise model\n",
-    "# TODO: Marginalized POVMs don't work yet, must specify num_lines as full space\n",
     "circ = pygsti.obj.Circuit([('Gx', 1)], num_lines=4)\n",
     "ln_model.probabilities(circ)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('0110',), 0.7600000000000005),\n",
-       "                  (('0010',), 0.08),\n",
-       "                  (('0000',), 0.060000000000000005),\n",
-       "                  (('0100',), 0.09999999999999999)])"
+       "OutcomeLabelDict([(('0110',), 1.0)])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -827,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,11 +1126,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
-    "rho0 = ComposedOp([EmbeddedOp(range(3), [i], StaticStandardOp('Gi', 'chp')) for i in range(3)])\n",
+    "rho0 = pygsti.obj.ComputationalSPAMVec([0,]*4, 'chp')\n",
     "Mdefault = pygsti.obj.ComputationalBasisPOVM(4, 'chp')\n",
     "\n",
     "chpexe = '/Users/sserita/Documents/notebooks/pyGSTi/2021-CHP/chp'\n",
@@ -864,7 +1142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -892,16 +1170,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('0100',), 0.9100000000000006), (('0000',), 0.09)])"
+       "OutcomeLabelDict([(('0100',), 0.9300000000000006), (('0000',), 0.07)])"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -913,18 +1191,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('0110',), 0.7500000000000004),\n",
-       "                  (('0000',), 0.23000000000000007),\n",
+       "OutcomeLabelDict([(('0110',), 0.7700000000000005),\n",
+       "                  (('0000',), 0.21000000000000005),\n",
        "                  (('0010',), 0.02)])"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -943,7 +1221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -957,8 +1235,8 @@
       " layers :  Mdefault\n",
       "\n",
       "Operation building blocks (.operation_blks):\n",
-      " layers :  Gypi:0, Gypi:1, Gypi:2, Gypi:3, Gi:0, Gi:1, Gi:2, Gi:3, Gcnot:0:1, Gcnot:1:2, Gcnot:2:3, Gxpi:0, Gxpi:1, Gxpi:2, Gxpi:3\n",
-      " gates :  Gypi, Gi, Gcnot, Gxpi\n",
+      " layers :  Gypi:0, Gypi:1, Gypi:2, Gypi:3, Gi:0, Gi:1, Gi:2, Gi:3, Gxpi:0, Gxpi:1, Gxpi:2, Gxpi:3, Gcnot:0:1, Gcnot:1:2, Gcnot:2:3\n",
+      " gates :  Gypi, Gi, Gxpi, Gcnot\n",
       "\n"
      ]
     }
@@ -980,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1007,6 +1285,16 @@
       "Strength: [0.1]\n",
       "\n",
       "\n",
+      "Gate Gxpi\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "CHP operations: h 0,p 0,p 0,h 0\n",
+      "Factor 1:\n",
+      "Depolarize noise operation map with dim = 2, num params = 1\n",
+      "Strength: [0.1]\n",
+      "\n",
+      "\n",
       "Gate Gcnot\n",
       "Composed operation of 2 factors:\n",
       "Factor 0:\n",
@@ -1016,16 +1304,6 @@
       "Stochastic noise operation map with dim = 4, num params = 15\n",
       "Rates: [0.01 0.01 0.01 0.01 0.01 0.1  0.01 0.01 0.01 0.01 0.01 0.01 0.01 0.01\n",
       " 0.01]\n",
-      "\n",
-      "\n",
-      "Gate Gxpi\n",
-      "Composed operation of 2 factors:\n",
-      "Factor 0:\n",
-      "StaticStandardOp with name Gxpi and evotype chp\n",
-      "CHP operations: h 0,p 0,p 0,h 0\n",
-      "Factor 1:\n",
-      "Depolarize noise operation map with dim = 2, num params = 1\n",
-      "Strength: [0.1]\n",
       "\n",
       "\n"
      ]
@@ -1040,16 +1318,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('0100',), 0.9600000000000006), (('0000',), 0.04)])"
+       "OutcomeLabelDict([(('0100',), 0.8400000000000005), (('0000',), 0.16)])"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1061,19 +1339,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('0010',), 0.08),\n",
-       "                  (('0000',), 0.16),\n",
-       "                  (('0110',), 0.7200000000000004),\n",
-       "                  (('0100',), 0.04)])"
+       "OutcomeLabelDict([(('0110',), 0.7800000000000005),\n",
+       "                  (('0000',), 0.17),\n",
+       "                  (('0010',), 0.03),\n",
+       "                  (('0100',), 0.02)])"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1085,19 +1363,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OutcomeLabelDict([(('11',), 0.6800000000000004),\n",
-       "                  (('00',), 0.18000000000000002),\n",
-       "                  (('01',), 0.05),\n",
-       "                  (('10',), 0.09)])"
+       "OutcomeLabelDict([(('11',), 0.6900000000000004),\n",
+       "                  (('00',), 0.19000000000000003),\n",
+       "                  (('10',), 0.05),\n",
+       "                  (('01',), 0.07)])"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1110,6 +1388,54 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's try a model with only readout error\n",
+    "ctf_prep_model = mc.create_crosstalk_free_model(4, ['Gi', 'Gxpi', 'Gypi', 'Gcnot'],\n",
+    "    stochastic_error_probs={'prep': [0.3, 0.0, 0.0]}, # 30% X error on prep\n",
+    "    availability={'Gcnot': [(0,1),(1,2),(2,3)]}, simulator=sim, evotype='chp')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('1011',), 0.03),\n",
+       "                  (('1111',), 0.01),\n",
+       "                  (('0101',), 0.03),\n",
+       "                  (('0000',), 0.25000000000000006),\n",
+       "                  (('1001',), 0.03),\n",
+       "                  (('1110',), 0.02),\n",
+       "                  (('0010',), 0.07),\n",
+       "                  (('1000',), 0.16),\n",
+       "                  (('1100',), 0.04),\n",
+       "                  (('0110',), 0.05),\n",
+       "                  (('0100',), 0.09999999999999999),\n",
+       "                  (('0011',), 0.05),\n",
+       "                  (('0111',), 0.02),\n",
+       "                  (('0001',), 0.09999999999999999),\n",
+       "                  (('1101',), 0.02),\n",
+       "                  (('1010',), 0.02)])"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "circ = pygsti.obj.Circuit([])\n",
+    "ctf_prep_model.probabilities(circ)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
@@ -1118,9 +1444,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (pygsti feature-chp-revive)",
+   "display_name": "Python 3 (pygsti -e install)",
    "language": "python",
-   "name": "pygsti-chp"
+   "name": "pygsti"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pygsti/baseobjs/basis.py
+++ b/pygsti/baseobjs/basis.py
@@ -168,7 +168,7 @@ class Basis(object):
             - `list`: an `ExplicitBasis` if given matrices/vectors or a
                      `DirectSumBasis` if given a `(name, dim)` pairs.
 
-        dim : int or StateSpaceLabels, optional
+        dim : int or StateSpace, optional
             The dimension of the basis to create.  Sometimes this can be
             inferred based on `name_or_basis_or_matrices`, other times it must
             be supplied.  This is the dimension of the space that this basis

--- a/pygsti/evotypes/densitymx_slow/statereps.py
+++ b/pygsti/evotypes/densitymx_slow/statereps.py
@@ -107,10 +107,11 @@ class StateRepComputational(StateRep):
             vec = _np.ascontiguousarray(_np.empty(factor_dim**len(zvals), typ))
             _fastcalc.fast_kron(vec, fast_kron_array, fast_kron_factordims)
 
+        self.zvals = zvals
         super(StateRepComputational, self).__init__(vec, state_space)
 
     def __reduce__(self):
-        return (StateRepComputational, (self.zvals, self.basis, self.state_space), (self.base.flags.writeable,))
+        return (StateRepComputational, (self.zvals, self.basis, self.state_space), (self.data.flags.writeable,))
 
 
 class StateRepComposed(StateRep):

--- a/pygsti/forwardsims/chpforwardsim.py
+++ b/pygsti/forwardsims/chpforwardsim.py
@@ -24,9 +24,12 @@ import os as _os
 import re as _re
 import subprocess as _sp
 import tempfile as _tf
+import numpy as _np
 from pathlib import Path as _Path
 
 from .weakforwardsim import WeakForwardSimulator as _WeakForwardSimulator
+from ..modelmembers import states as _state
+from ..modelmembers import operations as _op
 from ..modelmembers import povms as _povm
 from pygsti.baseobjs.outcomelabeldict import OutcomeLabelDict as _OutcomeLabelDict
 # from . import povm as _povm
@@ -57,7 +60,14 @@ class CHPForwardSimulator(_WeakForwardSimulator):
     def _compute_circuit_outcome_for_shot(self, circuit, resource_alloc, time=None):
         assert(time is None), "CHPForwardSimulator cannot be used to simulate time-dependent circuits yet"
 
-        complete_circuit = self.model.complete_circuit(circuit)
+        # Don't error on POVM, in case it's just an issue of marginalization
+        prep_label, op_labels, povm_label = self.model.split_circuit(circuit, erroron=('prep',))
+        # Try to get unmarginalized POVM
+        if povm_label is None:
+            default_povm_label = self.model._default_primitive_povm_layer_lbl(None)
+            povm_label = _Label(default_povm_label.name, state_space_labels=circuit.line_labels)
+        assert (povm_label is not None), \
+            "Unable to get unmarginalized default POVM for %s" % str(circuit)
 
         # Use temporary file as per https://stackoverflow.com/a/8577225
         fd, path = _tf.mkstemp()
@@ -66,32 +76,17 @@ class CHPForwardSimulator(_WeakForwardSimulator):
                 tmp.write('#\n')
 
                 # Prep
-                # TODO: Make sure this works with State objects
-                rho = self.model.circuit_layer_operator(complete_circuit[0], 'prep')
-                tmp.write(rho.chp_str())
+                rho = self.model.circuit_layer_operator(prep_label, 'prep')
+                self._process_state(rho, tmp)
 
                 # Op layers
-                for op_label in complete_circuit[1:-1]:
+                for op_label in op_labels:
                     op = self.model.circuit_layer_operator(op_label, 'op')
                     tmp.write(op.chp_str())
 
                 # POVM (sort of, actually using it more like a straight PVM)
-                povm_label = complete_circuit[-1]
                 povm = self.model.circuit_layer_operator(_Label(povm_label.name), 'povm')
-                assert(isinstance(povm, _povm.ComputationalBasisPOVM)), "CHP POVM must be a ComputationalBasisPOVM"
-
-                # Handle marginalization (not through MarginalizedPOVM,
-                # where most logic is based on simplify_effects and therefore expensive for many qubits)
-                if povm_label.sslbls is not None:
-                    assert(self.model.state_space.num_tensor_product_blocks == 1), \
-                        "Only single-TPB state spaces are supported with CHPForwardSimulator"
-                    flat_sslbls = self.model.state_space.tensor_product_block_labels(0)
-                    qubit_indices = [flat_sslbls.index(q) for q in povm_label.sslbls]
-                else:
-                    qubit_indices = range(povm.nqubits)
-
-                for qind in qubit_indices:
-                    tmp.write(f'm {qind}\n')
+                self._process_povm(povm, povm_label, tmp)
 
             # Run CHP
             process = _sp.Popen([f'{self.chpexe.resolve()}', f'{path}'], stdout=_sp.PIPE, stderr=_sp.PIPE)
@@ -111,3 +106,107 @@ class CHPForwardSimulator(_WeakForwardSimulator):
         outcome_label = _OutcomeLabelDict.to_outcome(outcome)
 
         return outcome_label
+
+    def _process_state(self, rho, file_handle):
+        """Helper function to process state prep for CHP circuits.
+
+        Recursively handles TensorProd > Composed > Computational
+        SPAMVec objects (e.g. those created by create_crosstalk_free_model).
+
+        Parameters
+        ----------
+        rho: State
+            State vector to process
+
+        file_handle: TextIOWrapper
+            Open file handle for dumping CHP strings
+        """
+        # Handle ComputationalBasisState, applying bitflips as needed
+        def process_computational_state(rho, target_offset=0):
+            assert isinstance(rho, _state.ComputationalBasisState), \
+                "CHP prep must be ComputationalBasisState (may be inside ComposedState/TensorProductState)"
+
+            bitflip = _op.StaticStandardOp('Gxpi', 'pp', evotype='chp', state_space=None)
+            for i, zval in enumerate(rho._zvals):
+                if zval:
+                    file_handle.write(bitflip.get_chp_str([target_offset + i]))
+
+        # Handle ComposedState of ComputationalBasisState + noise op with chp evotype
+        def process_composed_state(rho, target_offset=0):
+            if isinstance(rho, _state.ComposedState):
+                assert(rho._evotype == 'chp'), "ComposedState must have `chp` evotype for noise op"
+                process_computational_state(rho.state_vec, target_offset)
+                nqubits = rho.state_space.num_qubits
+                targets = _np.array(range(nqubits)) + target_offset
+                file_handle.write(rho.error_map.get_chp_str(targets))
+            else:
+                process_computational_state(rho, target_offset)
+
+        # Handle TensorProductSTate made of ComposedState or ComputationalBasisStates
+        target_offset = 0
+        if isinstance(rho, _state.TensorProductState):
+            for rho_factor in rho.factors:
+                nqubits = (rho_factor.noise_op.dim - 1).bit_length()
+                process_composed_state(rho_factor, target_offset)
+                target_offset += nqubits
+        else:
+            process_composed_state(rho, target_offset)
+
+    def _process_povm(self, povm, povm_label, file_handle):
+        """Helper function to process measurement for CHP circuits.
+
+        Recursively handles TensorProd > Composed > ComputationalBasis
+        POVM objects (e.g. those created by create_crosstalk_free_model).
+
+        Parameters
+        ----------
+        povm: POVM
+            Unmarginalized POVM to process
+
+        povm_label: Label
+            POVM label, which may include StateSpaceLabels that result
+            in POVM marginalization
+
+        file_handle: TextIOWrapper
+            Open file handle for dumping CHP strings
+        """
+        # Handle marginalization (not through MarginalizedPOVM,
+        # where most logic is based on simplify_effects and therefore expensive for many qubits)
+        qubit_indices = None
+        if povm_label.sslbls is not None:
+            flat_sslbls = [lbl for tbp in self.model.state_space_labels.labels for lbl in tbp]
+            qubit_indices = [flat_sslbls.index(q) for q in povm_label.sslbls]
+
+        # Handle ComputationalBasisPOVM
+        def process_computational_povm(povm, qubit_indices, target_offset=0):
+            assert isinstance(povm, _povm.ComputationalBasisPOVM), \
+                "CHP povm must be ComputationalPOVM (may be inside ComposedPOVM/TensorProdPOVM)"
+
+            povm_qubits = _np.array(range(povm.nqubits)) + target_offset
+            for target in povm_qubits:
+                if qubit_indices is None or target in qubit_indices:
+                    file_handle.write(f'm {target}\n')
+
+        # Handle ComposedPOVM of ComputationalBasisPOVM + noise op with chp evotype
+        def process_composed_povm(povm, qubit_indices, target_offset=0):
+            if isinstance(povm, _povm.ComposedPOVM):
+                assert povm._evotype == 'chp', \
+                    "ComposedPOVM must have `chp` evotype for noise op"
+
+                nqubits = povm.state_space.num_qubits
+                targets = _np.array(range(nqubits)) + target_offset
+                file_handle.write(povm.error_map.get_chp_str(targets))
+
+                process_computational_povm(povm.base_povm, qubit_indices, target_offset)
+            else:
+                process_computational_povm(povm, qubit_indices, target_offset)
+
+        # Handle TensorProductPOVM made of ComposedPOVM or ComputationalBasisPOVMs
+        target_offset = 0
+        if isinstance(povm, _povm.TensorProductPOVM):
+            for povm_factor in povm.factors:
+                nqubits = povm_factor.error_map.state_space.num_qubits
+                process_composed_povm(povm_factor, qubit_indices, target_offset)
+                target_offset += nqubits
+        else:
+            process_composed_povm(povm, qubit_indices, target_offset)

--- a/pygsti/forwardsims/forwardsim.py
+++ b/pygsti/forwardsims/forwardsim.py
@@ -199,7 +199,7 @@ class ForwardSimulator(object):
             try:
                 return self._compute_sparse_circuit_outcome_probabilities(circuit, resource_alloc, time)
             except NotImplementedError:
-                pass  # continue on to create full layout and calcualte all outcomes
+                pass  # continue on to create full layout and calculate all outcomes
 
         copa_layout = self.create_layout([circuit], array_types=('e',), resource_alloc=resource_alloc)
         probs_array = _np.empty(copa_layout.num_elements, 'd')

--- a/pygsti/forwardsims/weakforwardsim.py
+++ b/pygsti/forwardsims/weakforwardsim.py
@@ -83,3 +83,32 @@ class WeakForwardSimulator(_ForwardSimulator):
 
         for i, outcome in enumerate(outcomes):
             array_to_fill[i] = sparse_probs[outcome]
+
+    def bulk_probs(self, circuits, clip_to=None, resource_alloc=None, smartc=None):
+        """
+        Construct a dictionary containing the probabilities for an entire list of circuits.
+
+        Parameters
+        ----------
+        circuits : list of Circuits
+            The list of circuits.  May also be a :class:`CircuitOutcomeProbabilityArrayLayout`
+            object containing pre-computed quantities that make this function run faster.
+
+        clip_to : 2-tuple, optional
+            (min,max) to clip return value if not None.
+
+        resource_alloc : ResourceAllocation, optional
+            A resource allocation object describing the available resources and a strategy
+            for partitioning them.
+
+        smartc : SmartCache, optional
+            A cache object to cache & use previously cached values inside this
+            function.
+
+        Returns
+        -------
+        probs : dictionary
+            A dictionary such that `probs[circuit]` is an ordered dictionary of
+            outcome probabilities whose keys are outcome labels.
+        """
+        return {circ: self._compute_sparse_circuit_outcome_probabilities(circ, resource_alloc) for circ in circuits}

--- a/pygsti/modelmembers/povms/composedpovm.py
+++ b/pygsti/modelmembers/povms/composedpovm.py
@@ -17,6 +17,7 @@ from .computationalpovm import ComputationalBasisPOVM as _ComputationalBasisPOVM
 from .povm import POVM as _POVM
 from .. import modelmember as _mm
 from .. import operations as _op
+from ...baseobjs import Basis as _Basis
 
 
 class ComposedPOVM(_POVM):
@@ -79,13 +80,13 @@ class ComposedPOVM(_POVM):
         state_space = self.error_map.state_space
 
         if mx_basis is None:
-            if isinstance(errormap, _op.LindbladOp):
+            if isinstance(errormap, _op.ExpErrorgenOp) and isinstance(errormap.errorgen, _op.LindbladErrorgen):
                 mx_basis = errormap.errorgen.matrix_basis
             else:
                 raise ValueError("Cannot extract a matrix-basis from `errormap` (type %s)"
                                  % str(type(errormap)))
 
-        self.matrix_basis = mx_basis
+        self.matrix_basis = _Basis.cast(mx_basis, state_space)
         evotype = self.error_map._evotype
 
         if povm is None:
@@ -357,6 +358,29 @@ class ComposedPOVM(_POVM):
         self.error_map.spam_transform_inplace(s, 'effect')  # only do this *once*
         for lbl, effect in self.items():
             #effect._update_rep()  # these two lines mimic the bookeeping in
+            effect.dirty = True   # a "effect.transform_inplace(s, 'effect')" call.
+        self.dirty = True
+
+    def depolarize(self, amount):
+        """
+        Depolarize this POVM by the given `amount`.
+
+        Parameters
+        ----------
+        amount : float or tuple
+            The amount to depolarize by.  If a tuple, it must have length
+            equal to one less than the dimension of the gate. All but the
+            first element of each spam vector (often corresponding to the
+            identity element) are multiplied by `amount` (if a float) or
+            the corresponding `amount[i]` (if a tuple).
+
+        Returns
+        -------
+        None
+        """
+        self.error_map.depolarize(amount)
+        for lbl, effect in self.items():
+            #effect._update_rep()  # these two lines mimic the bookeepging in
             effect.dirty = True   # a "effect.transform_inplace(s, 'effect')" call.
         self.dirty = True
 

--- a/pygsti/models/localnoisemodel.py
+++ b/pygsti/models/localnoisemodel.py
@@ -65,8 +65,8 @@ class LocalNoiseModel(_ImplicitOpModel):
         If a dict, then the keys are labels and the values are layer operators.
         If a list, then the elements are layer operators and the labels will be
         assigned as "rhoX" where X is an integer starting at 0.  If a single
-        layer operation is given, then this is used as the sole prep and is
-        assigned the label "rho0".
+        layer operation of type :class:`State` is given, then this is used as
+        the sole prep and is assigned the label "rho0".
 
     povm_layers : None or operator or dict or list
         The state preparateion operations as n-qubit layer operations.  If
@@ -74,8 +74,8 @@ class LocalNoiseModel(_ImplicitOpModel):
         then the keys are labels and the values are layer operators.  If a list,
         then the elements are layer operators and the labels will be assigned as
         "MX" where X is an integer starting at 0.  If a single layer operation
-        is given, then this is used as the sole POVM and is assigned the label
-        "Mdefault".
+        of type :class:`POVM` is given, then this is used as the sole POVM and
+        is assigned the label "Mdefault".
 
     availability : dict, optional
         A dictionary whose keys are the same gate names as in

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -113,7 +113,8 @@ class ModelConstructionTester(BaseCase):
             lindblad_error_coeffs={
                 'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
             }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)], 
-            ensure_composed_gates=False, independent_gates=True)
+            ensure_composed_gates=False, independent_gates=True,
+            tensorprod_spamvec_povm=False)
 
         self.assertEqual(cfmdl.num_params, 17)
 
@@ -125,8 +126,10 @@ class ModelConstructionTester(BaseCase):
             lindblad_error_coeffs={
                 'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
-            ensure_composed_gates=True, independent_gates=False)
-        self.assertEqual(cfmdl2.num_params, 11)
+            ensure_composed_gates=True, independent_gates=False,
+            tensorprod_spamvec_povm=False)
+        
+        self.assertEqual(cfmdl2.num_params, 9)
 
         # Same as above but add ('Gx','qb0') to test giving qubit-specific error rates
         cfmdl3 = mc.create_crosstalk_free_model(
@@ -136,8 +139,10 @@ class ModelConstructionTester(BaseCase):
             lindblad_error_coeffs={
                 'Gcnot': {('H', 'ZZ'): 0.01, ('S', 'IX'): 0.01},
              }, qubit_labels=['qb{}'.format(i) for i in range(nQubits)],
-            ensure_composed_gates=True, independent_gates=False)
-        self.assertEqual(cfmdl3.num_params, 12)
+            ensure_composed_gates=True, independent_gates=False,
+            tensorprod_spamvec_povm=False)
+
+        self.assertEqual(cfmdl3.num_params, 10)
 
     def test_build_crosstalk_free_model_depolarize_parameterizations(self):
         nQubits = 2
@@ -172,29 +177,41 @@ class ModelConstructionTester(BaseCase):
         self.assertTrue(isinstance(Gi_op, op.ComposedOp))
         self.assertEqual(mdl_depol3.num_params, 1)
 
-        # For prep and povm, only lindblad parameterization is allowed
-        # Test that proper warnings are raised
-        with self.assertWarns(UserWarning):
-            mc.create_crosstalk_free_model(
-                nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'prep': 0.1},
-                depolarization_parameterization='depolarize'
-            )
-        with self.assertWarns(UserWarning):
-            mc.create_crosstalk_free_model(
-                nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'prep': 0.1},
-                depolarization_parameterization='stochastic'
-            )
-        
-        with self.assertWarns(UserWarning):
-            mc.create_crosstalk_free_model(
-                nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'povm': 0.1},
-                depolarization_parameterization='depolarize'
-            )
-        with self.assertWarns(UserWarning):
-            mc.create_crosstalk_free_model(
-                nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'povm': 0.1},
-                depolarization_parameterization='stochastic'
-            )
+        mdl_prep1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'prep': 0.1},
+            depolarization_parameterization='depolarize',
+            tensorprod_spamvec_povm=False
+        )
+        rho0 = mdl_prep1.prep_blks['layers']['rho0']
+        self.assertTrue(isinstance(rho0, pygsti.modelmembers.states.ComposedState))
+        self.assertEqual(mdl_prep1.num_params, 2)
+    
+        mdl_prep2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'prep': 0.1},
+            depolarization_parameterization='stochastic',
+            tensorprod_spamvec_povm=False
+        )
+        rho0 = mdl_prep2.prep_blks['layers']['rho0']
+        self.assertTrue(isinstance(rho0, pygsti.modelmembers.states.ComposedState))
+        self.assertEqual(mdl_prep2.num_params, 6)
+    
+        mdl_povm1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'povm': 0.1},
+            depolarization_parameterization='depolarize',
+            tensorprod_spamvec_povm=False
+        )
+        Mdefault = mdl_povm1.povm_blks['layers']['Mdefault']
+        self.assertTrue(isinstance(Mdefault, pygsti.modelmembers.povms.ComposedPOVM))
+        self.assertEqual(mdl_povm1.num_params, 2)
+    
+        mdl_povm2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), depolarization_strengths={'Gi': 0.1, 'povm': 0.1},
+            depolarization_parameterization='stochastic',
+            tensorprod_spamvec_povm=False
+        )
+        Mdefault = mdl_povm2.povm_blks['layers']['Mdefault']
+        self.assertTrue(isinstance(Mdefault, pygsti.modelmembers.povms.ComposedPOVM))
+        self.assertEqual(mdl_povm2.num_params, 6)
 
     def test_build_crosstalk_free_model_stochastic_parameterizations(self):
         nQubits = 2
@@ -218,18 +235,23 @@ class ModelConstructionTester(BaseCase):
         self.assertTrue(isinstance(Gi_op, op.ComposedOp))
         self.assertEqual(mdl_sto3.num_params, 3)
 
-        # For prep and povm, only lindblad parameterization is allowed
-        # Test that proper warnings are raised
-        with self.assertWarns(UserWarning):
-            mc.create_crosstalk_free_model(
-                nQubits, ('Gi',), stochastic_error_probs={'Gi': (0.1, 0.1, 0.1), 'prep': (0.01,)*3},
-                stochastic_parameterization='stochastic'
-            )
-        with self.assertWarns(UserWarning):
-            mc.create_crosstalk_free_model(
-                nQubits, ('Gi',), stochastic_error_probs={'Gi': (0.1,)*3, 'povm': (0.01,)*3},
-                stochastic_parameterization='stochastic'
-            )
+        mdl_prep1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), stochastic_error_probs={'Gi': (0.1, 0.1, 0.1), 'prep': (0.01,)*3},
+            stochastic_parameterization='stochastic',
+            tensorprod_spamvec_povm=False
+        )
+        rho0 = mdl_prep1.prep_blks['layers']['rho0']
+        self.assertTrue(isinstance(rho0, pygsti.modelmembers.states.ComposedState))
+        self.assertEqual(mdl_prep1.num_params, 6)
+
+        mdl_povm1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), stochastic_error_probs={'Gi': (0.1,)*3, 'povm': (0.01,)*3},
+            stochastic_parameterization='stochastic',
+            tensorprod_spamvec_povm=False
+        )
+        Mdefault = mdl_povm1.povm_blks['layers']['Mdefault']
+        self.assertTrue(isinstance(Mdefault, pygsti.modelmembers.povms.ComposedPOVM))
+        self.assertEqual(mdl_povm1.num_params, 6)
 
     def test_build_crosstalk_free_model_lindblad_parameterizations(self):
         nQubits = 2
@@ -252,6 +274,45 @@ class ModelConstructionTester(BaseCase):
         self.assertTrue(isinstance(Gi_op, op.ComposedOp))
         self.assertEqual(Gi_op.errorgen_coefficients(), {('H', 'X'): 0.1, ('S', 'Y'): 0.1})
         self.assertEqual(mdl_lb2.num_params, 2)
+
+        mdl_prep1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_coeffs={
+                'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1},
+                'prep': {('H', 'Y'): 0.01}},
+        )
+        rho0 = mdl_prep1.prep_blks['layers']['rho0']
+        self.assertTrue(isinstance(rho0, pygsti.modelmembers.states.TensorProductState))
+        self.assertEqual(mdl_prep1.num_params, 4)
+
+        mdl_povm1 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_coeffs={
+                'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1},
+                'povm': {('H', 'Y'): 0.01}},
+        )
+        Mdefault = mdl_povm1.povm_blks['layers']['Mdefault']
+        self.assertTrue(isinstance(Mdefault, pygsti.modelmembers.povms.TensorProductPOVM))
+        self.assertEqual(mdl_povm1.num_params, 4)
+
+        # Test Composed variants of prep/povm
+        mdl_prep2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_coeffs={
+                'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1},
+                'prep': {('H', 'Y'): 0.01}},
+            tensorprod_spamvec_povm=False
+        )
+        rho0 = mdl_prep2.prep_blks['layers']['rho0']
+        self.assertTrue(isinstance(rho0, pygsti.modelmembers.states.ComposedState))
+        self.assertEqual(mdl_prep2.num_params, 3)
+
+        mdl_povm2 = mc.create_crosstalk_free_model(
+            nQubits, ('Gi',), lindblad_error_coeffs={
+                'Gi': {('H', 'X'): 0.1, ('S', 'Y'): 0.1},
+                'povm': {('H', 'Y'): 0.01}},
+            tensorprod_spamvec_povm=False
+        )
+        Mdefault = mdl_povm2.povm_blks['layers']['Mdefault']
+        self.assertTrue(isinstance(Mdefault, pygsti.modelmembers.povms.ComposedPOVM))
+        self.assertEqual(mdl_povm2.num_params, 3)
 
     def test_build_crosstalk_free_model_with_nonstd_gate_unitary_factory(self):
         nQubits = 2

--- a/test/unit/objects/test_composed_spam.py
+++ b/test/unit/objects/test_composed_spam.py
@@ -1,0 +1,253 @@
+import numpy as np
+import unittest
+
+from ..util import BaseCase
+
+from pygsti.circuits import Circuit
+from pygsti.models import ExplicitOpModel
+from pygsti.modelmembers.states import ComposedState
+from pygsti.modelmembers.povms import ComposedPOVM
+from pygsti.models.gaugegroup import FullGaugeGroupElement, UnitaryGaugeGroupElement
+import pygsti.baseobjs.outcomelabeldict as ld
+import pygsti.modelmembers.operations as op
+import pygsti.modelmembers.povms as pv
+import pygsti.modelmembers.states as sv
+
+
+# Main test of ComposedSpamvecBase:
+# Is the composed SPAM vec equivalent to applying each component separately?
+class ComposedSpamvecBase(object):
+    base_prep_vec = sv.ComputationalBasisState([0], 'pp', 'default')
+    base_noise_op = op.StaticStandardOp('Gxpi2', 'pp', 'default') # X(pi/2) rotation as noise
+    base_povm = pv.ComputationalBasisPOVM(1, 'default') # Z-basis measurement
+    expected_out = ld.OutcomeLabelDict([(('0',), 0.5), (('1',), 0.5)])
+
+    def setUp(self):
+        self.vec = self.build_vec()
+        ExplicitOpModel._strict = False
+
+    def test_num_params(self):
+        self.assertEqual(self.vec.num_params, self.n_params)
+
+    def test_get_dimension(self):
+        self.assertEqual(self.vec.dim, 4)
+    
+    def test_hessian(self):
+        if self.n_params:
+            self.assertTrue(self.vec.has_nonzero_hessian())
+        else:
+            self.assertFalse(self.vec.has_nonzero_hessian())
+
+    def test_forward_simulation(self):
+        pure_vec = self.vec.state_vec
+        noise_op = self.vec.error_map
+
+        # TODO: Would be nice to check more than densitymx evotype
+        indep_mdl = ExplicitOpModel(['Q0'], evotype='default')
+        indep_mdl['rho0'] = pure_vec
+        indep_mdl['G0'] = noise_op
+        indep_mdl['Mdefault'] = self.base_povm
+        
+        composed_mdl = ExplicitOpModel(['Q0'], evotype='default')
+        composed_mdl['rho0'] = self.vec
+        composed_mdl['Mdefault'] = self.base_povm
+        
+        # Sanity check
+        indep_circ = Circuit(['rho0', 'G0', 'Mdefault'])
+        indep_probs = indep_mdl.probabilities(indep_circ)
+        for k,v in indep_probs.items():
+            self.assertAlmostEqual(self.expected_out[k], v)
+
+        composed_circ = Circuit(['rho0', 'Mdefault'])
+        composed_probs = composed_mdl.probabilities(composed_circ)
+        for k,v in composed_probs.items():
+            self.assertAlmostEqual(self.expected_out[k], v)
+
+
+# For ComposedSpamvec, the spam vec is immutable (set_value),
+# but the noise op can be not (transform, depolarize)
+class MutableComposedSpamvecBase(ComposedSpamvecBase):
+    def test_raises_on_set_value(self):
+        v = np.asarray(self.vec)
+        with self.assertRaises(ValueError):
+            self.vec.set_dense(v)
+
+    @unittest.skip("Transform is expected to fail while spam_transform_inplace is not available")
+    def test_transform(self):
+        S = FullGaugeGroupElement(np.identity(4, 'd'))
+        self.vec.transform_inplace(S)
+        # TODO assert correctness
+
+    def test_depolarize(self):
+        self.vec.depolarize(0.9)
+        self.vec.depolarize([0.9, 0.8, 0.7])
+        # TODO assert correctness
+    
+class ImmutableComposedSpamvecBase(ComposedSpamvecBase):
+    def test_raises_on_set_value(self):
+        v = np.asarray(self.vec)
+        with self.assertRaises(ValueError):
+            self.vec.set_dense(v)
+
+    @unittest.skip("Transform is expected to fail while spam_transform_inplace is not available")
+    def test_raises_on_transform(self):
+        S = FullGaugeGroupElement(np.identity(4, 'd'))
+        with self.assertRaises(ValueError):
+            self.vec.transform_inplace(S)
+
+    def test_raises_on_depolarize(self):
+        with self.assertRaises(ValueError):
+            self.vec.depolarize(0.9)
+        # TODO assert correctness
+
+# Cases where noise op is also static acts like an immutable spamvec
+class StandardStaticComposedSpamvecTester(ImmutableComposedSpamvecBase, BaseCase):
+    n_params = 0
+
+    def build_vec(self):
+        return ComposedState(self.base_prep_vec, self.base_noise_op)
+
+class StaticDenseComposedSpamvecTester(ImmutableComposedSpamvecBase, BaseCase):
+    n_params = 0
+
+    def build_vec(self):
+        sdop = op.StaticArbitraryOp(self.base_noise_op.to_dense())
+        return ComposedState(self.base_prep_vec, sdop)
+
+class FullDenseComposedSpamvecTester(MutableComposedSpamvecBase, BaseCase):
+    n_params = 16
+
+    def build_vec(self):
+        fdop = op.FullArbitraryOp(self.base_noise_op.to_dense())
+        return ComposedState(self.base_prep_vec, fdop)
+
+# Currently not inheriting for easy merge, meaning test doesn't quite work
+# class LindbladSpamvecTester(MutableComposedSpamvecBase, BaseCase):
+#     n_params = 12
+
+#     # Transform cannot be FullGaugeGroup for Lindblad
+#     def test_transform(self):
+#         S = UnitaryGaugeGroupElement(np.identity(4, 'd'))
+#         self.vec.transform_inplace(S, 'prep')
+#         self.vec.transform_inplace(S, 'effect')
+
+#     def build_vec(self):
+#         lop = op.LindbladDenseOp.from_operation_matrix(self.base_noise_op.to_dense())
+#         return sv.LindbladSPAMVec(self.base_prep_vec, lop, 'prep')
+
+
+## POVM ##
+
+# Main test of ComposedPovmBase:
+# Is the composed POVM equivalent to applying each component separately?
+class ComposedPovmBase(object):
+    base_prep = sv.ComputationalBasisState([0], 'pp', 'default') # 0 state prep
+    base_noise_op = op.StaticStandardOp('Gxpi2', 'pp', 'default') # X(pi/2) rotation as noise
+    base_povm = pv.ComputationalBasisPOVM(1, 'default') # Z-basis measurement
+    expected_out = ld.OutcomeLabelDict([(('0',), 0.5), (('1',), 0.5)])
+    
+    def setUp(self):
+        self.povm = self.build_povm()
+        ExplicitOpModel._strict = False
+
+    def test_num_params(self):
+        self.assertEqual(self.povm.num_params, self.n_params)
+
+    def test_get_dimension(self):
+        self.assertEqual(self.povm.state_space.dim, 4)
+    
+    def test_forward_simulation(self):
+        pure_povm = self.povm.base_povm
+        noise_op = self.povm.error_map
+
+        # TODO: Would be nice to check more than densitymx evotype
+        indep_mdl = ExplicitOpModel(['Q0'], evotype='default')
+        indep_mdl['rho0'] = self.base_prep
+        indep_mdl['G0'] = noise_op.copy()
+        indep_mdl['Mdefault'] = pure_povm
+        
+        composed_mdl = ExplicitOpModel(['Q0'], evotype='default')
+        composed_mdl['rho0'] = self.base_prep
+        composed_mdl['Mdefault'] = self.povm
+        
+        # Sanity check
+        indep_circ = Circuit(['rho0', 'G0', 'Mdefault'])
+        indep_probs = indep_mdl.probabilities(indep_circ)
+        for k,v in indep_probs.items():
+            self.assertAlmostEqual(self.expected_out[k], v)
+
+        composed_circ = Circuit(['rho0', 'Mdefault'])
+        composed_probs = composed_mdl.probabilities(composed_circ)
+        for k,v in composed_probs.items():
+            self.assertAlmostEqual(self.expected_out[k], v)
+
+# For ComposedPOVM, the noise op could be mutable
+class MutableComposedPovmBase(ComposedPovmBase):
+    def test_vector_conversion(self):
+        v = self.povm.to_vector()
+        self.povm.from_vector(v)
+
+    @unittest.skip("Transform is expected to fail while spam_transform_inplace is not available")
+    def test_transform(self):
+        S = FullGaugeGroupElement(np.identity(4, 'd'))
+        self.povm.transform_inplace(S)
+        # TODO assert correctness
+
+    def test_depolarize(self):
+        self.povm.depolarize(0.9)
+        self.povm.depolarize([0.9, 0.8, 0.7])
+        # TODO assert correctness
+    
+class ImmutableComposedPovmBase(ComposedPovmBase):
+    def test_vector_conversion(self):
+        v = self.povm.to_vector()
+        self.povm.from_vector(v)
+        # TODO: 
+        # with self.assertRaises(ValueError):
+        #     self.vec.set_dense(v)
+
+    @unittest.skip("Transform is expected to fail while spam_transform_inplace is not available")
+    def test_raises_on_transform(self):
+        S = FullGaugeGroupElement(np.identity(4, 'd'))
+        with self.assertRaises(ValueError):
+            self.povm.transform_inplace(S)
+
+    def test_raises_on_depolarize(self):
+        with self.assertRaises(ValueError):
+            self.povm.depolarize(0.9)
+        # TODO assert correctness
+
+class StandardStaticComposedPovmTester(ImmutableComposedPovmBase, BaseCase):
+    n_params = 0
+
+    def build_povm(self):
+        return ComposedPOVM(self.base_noise_op, self.base_povm, 'pp')
+
+class StaticDenseComposedPovmTester(ImmutableComposedPovmBase, BaseCase):
+    n_params = 0
+
+    def build_povm(self):
+        sdop = op.StaticArbitraryOp(self.base_noise_op.to_dense())
+        return ComposedPOVM(sdop, self.base_povm, 'pp')
+
+class FullDenseComposedPovmTester(MutableComposedPovmBase, BaseCase):
+    n_params = 16
+
+    def build_povm(self):
+        fdop = op.FullArbitraryOp(self.base_noise_op.to_dense())
+        return ComposedPOVM(fdop, self.base_povm, 'pp')
+
+# Currently not inheriting for easy merge, meaning test doesn't quite work
+# class LindbladPovmTester(MutableComposedPovmBase, BaseCase):
+#     n_params = 12
+
+#     # Transform cannot be FullGaugeGroup for Lindblad
+#     def test_transform(self):
+#         S = UnitaryGaugeGroupElement(np.identity(4, 'd'))
+#         self.povm.transform_inplace(S, 'prep')
+#         self.povm.transform_inplace(S, 'effect')
+
+#     def build_povm(self):
+#         lop = op.LindbladDenseOp.from_operation_matrix(self.base_noise_op.to_dense())
+#         return pv.LindbladPOVM(lop, self.base_povm)
+

--- a/test/unit/objects/test_spamvec.py
+++ b/test/unit/objects/test_spamvec.py
@@ -55,11 +55,6 @@ class StateBase(object):
     def test_num_params(self):
         self.assertEqual(self.vec.num_params, self.n_params)
 
-    def test_copy(self):
-        vec_copy = self.vec.copy()
-        self.assertArraysAlmostEqual(vec_copy.to_dense(), self.vec.to_dense())
-        self.assertEqual(type(vec_copy), type(self.vec))
-
     def test_get_dimension(self):
         self.assertEqual(self.vec.dim, 4)
 
@@ -90,6 +85,12 @@ class StateBase(object):
 
 class DenseStateBase(StateBase):
 
+    def test_vector_conversion(self):
+        v = self.vec.to_vector()
+        self.vec.from_vector(v)
+        deriv = self.vec.deriv_wrt_params()
+        # TODO assert correctness
+    
     def test_element_accessors(self):
         a = self.vec[:]
         b = self.vec[0]
@@ -99,6 +100,11 @@ class DenseStateBase(StateBase):
         self.vec_as_str = str(self.vec)
         a1 = self.vec[:]  # invoke getslice method
         # TODO assert correctness
+
+    def test_copy(self):
+        vec_copy = self.vec.copy()
+        self.assertArraysAlmostEqual(vec_copy.to_dense(), self.vec.to_dense())
+        self.assertEqual(type(vec_copy), type(self.vec))
 
     def test_arithmetic(self):
         result = self.vec + self.vec


### PR DESCRIPTION
The recent large refactor duplicated some of the work in an existing
(feature-noiseop-spamvec) branch and it would have been difficult for
git to merge it correctly.  This commit is the result of taking all
the new commits on that branch and applying/adjusting them on top
of the post-refactored code.

**Text from the original PR (which may not all be entirely relevant now):**

Several changes designed to allow general noisy operations after state prep/before measurement.

- New ComposedSPAMVec/POVM that takes a general LinearOperator and a ComputationalSPAMVec/ComputationalBasisPOVM
- CHPForwardSimulator updated to handle ComposedSPAMVec/POVM (rather than LinearOperator/ComputationalBasisPOVM)
- create_crosstalk_free_model updated to allow Composed instead of Lindblad for SPAMVec/POVM

Currently, model construction avoids the use of TensorProdSPAMVec/POVM as it does not set parameters properly when used with a ComposedSPAMVec of ComposedOps.