### PR TITLE
use unicode to specify quotes in css file

### DIFF
--- a/pygsti/report/templates/offline/pygsti_dashboard.css
+++ b/pygsti/report/templates/offline/pygsti_dashboard.css
@@ -53,16 +53,16 @@ code {
   display: inline-block;
 }
 q:before {
-  content: "“";
+  content: "\201c";
 }
 q:after {
-  content: "”";
+  content: "\201d";
 }
 q > q:before {
-  content: "‘";
+  content: "\2018";
 }
 q > q:after {
-  content: "’";
+  content: "\2019";
 }
 figure {
   /*margin: 1.333em 0 2.333em;*/


### PR DESCRIPTION
The quotes tag `<q>` is modified in the file `pygsti_dashboard.css`. In that file special characters are used for the quotes, which render incorrectly in the browser:

![image](https://user-images.githubusercontent.com/883786/148436471-fe93b27a-cfe0-4378-afad-2e19e19a540f.png)

This PR defines the quotes using unicode, which renders the quotes as intended:

![image](https://user-images.githubusercontent.com/883786/148436626-b274fc6e-10fd-4290-bd90-2941186aaae1.png)

@enielse 