### PR TITLE
Bugfix windows integers

### DIFF
--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -34,9 +34,13 @@ jobs:
         os: [ubuntu-18.04, windows-2019]
         python-version: [3.6, 3.7, 3.8, 3.9]
         nose-tests:
-        - "algorithms algorithmsb"
-        - "report reportb"
-        - "drivers objects tools iotest optimize construction extras"
+        - "algorithms"
+        - "algorithmsb"
+        - "report"
+        - "reportb"
+        - "report"
+        - "drivers objects tools iotest"
+        - "optimize construction extras"
         # - "mpi" # Fails in GitHub Actions, passes locally but doesn't terminate threads properly
 
     steps:

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -39,8 +39,13 @@ jobs:
         - "report"
         - "reportb"
         - "report"
-        - "drivers objects tools iotest"
-        - "optimize construction extras"
+        - "objects"
+        - "tools"
+        - "iotest"
+        - "drivers"
+        - "optimize"
+        - "construction"
+        - "extras"
         # - "mpi" # Fails in GitHub Actions, passes locally but doesn't terminate threads properly
 
     steps:

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -59,13 +59,22 @@ jobs:
         # Installing with -e to keep installation local (for NOSE_NOPATH)
         # but still compile Cython extensions
         python -m pip install -e .[testing]
-    - name: Run test_packages ${{ matrix.nose-tests }}
+    - name: Run test_packages Ubuntu ${{ matrix.nose-tests }}
+      if: ${{matrix.os == 'ubuntu-18.04'}}
       env:
         NOSETESTS: ${{ matrix.nose-tests }}
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
         echo "nosetests: $NOSETESTS"
         nosetests $NOSETESTS
+    - name: Run test_packages Windows ${{ matrix.nose-tests }}
+      if: ${{matrix.os == ''windows-2019''}}
+      env:
+        NOSETESTS: ${{ matrix.nose-tests }}
+      run: |
+        python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
+        echo "nosetests: $Env:NOSETESTS"
+        nosetests $Env:NOSETESTS
 
 
 

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false # Finish all tests even if one fails
       matrix:
-        os: [windows-2019]
+        os: [ubuntu-18.04, windows-2019]
         python-version: [3.6, 3.7, 3.8, 3.9]
         nose-tests:
         - "algorithms"

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         python -Ic "import pygsti; print(pygsti.__version__); print(pygsti.__path__)"
         echo "nosetests: $Env:NOSETESTS"
-        nosetests $Env:NOSETESTS
+        nosetests --traverse-namespace $Env:NOSETESTS
 
 
 

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false # Finish all tests even if one fails
       matrix:
-        os: [ubuntu-18.04, windows-2019]
+        os: [windows-2019]
         python-version: [3.6, 3.7, 3.8, 3.9]
         nose-tests:
         - "algorithms"

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -68,7 +68,7 @@ jobs:
         echo "nosetests: $NOSETESTS"
         nosetests $NOSETESTS
     - name: Run test_packages Windows ${{ matrix.nose-tests }}
-      if: ${{matrix.os == ''windows-2019''}}
+      if: ${{matrix.os == 'windows-2019'}}
       env:
         NOSETESTS: ${{ matrix.nose-tests }}
       run: |

--- a/pygsti/algorithms/compilers.py
+++ b/pygsti/algorithms/compilers.py
@@ -659,10 +659,10 @@ def _compile_symplectic_using_ogge_algorithm(s, eliminationorder, pspec=None, pa
     # Re-order the s matrix to reflect the order we want to eliminate the qubits in,
     # because we hand the symp. matrix to a function that eliminates them in a fixed order.
     n = _np.shape(s)[0] // 2
-    P = _np.zeros((n, n), int)
+    P = _np.zeros((n, n), _np.int64)
     for j in range(0, n):
         P[j, eliminationorder[j]] = 1
-    P2n = _np.zeros((2 * n, 2 * n), int)
+    P2n = _np.zeros((2 * n, 2 * n), _np.int64)
     P2n[0:n, 0:n] = P
     P2n[n:2 * n, n:2 * n] = P
     permuted_s = _mtx.dot_mod2(_mtx.dot_mod2(P2n, s), _np.transpose(P2n))
@@ -911,10 +911,10 @@ def _compile_symplectic_using_gge_core(s, check=True):
         _symp.apply_internal_gate_to_symplectic(sout, 'H', [j], optype='row')
 
         # If the matrix has been mapped to the identity, quit the loop as we are done.
-        if _np.array_equal(sout, _np.identity(2 * n, int)):
+        if _np.array_equal(sout, _np.identity(2 * n, _np.int64)):
             break
 
-    assert(_np.array_equal(sout, _np.identity(2 * n, int))), "Compilation has failed!"
+    assert(_np.array_equal(sout, _np.identity(2 * n, _np.int64))), "Compilation has failed!"
     # Operations that are the same next to each other cancel, and this algorithm can have these. So
     # we go through and delete them.
     j = 1
@@ -1214,7 +1214,7 @@ def _compile_symplectic_using_iag_algorithm(s, pspec, qubit_labels=None, cnotalg
     # Stage 11: A CNOT circuit from the LHS to map the to I. (can do the GE on either UL or LR)
     sout, LHS7_CNOTs, success = _submatrix_gaussian_elimination_using_cnots(sout, 'row', 'UL', qubit_labels)
     assert(_symp.check_symplectic(sout))
-    assert(_np.array_equal(sout, _np.identity(2 * n, int))), "Algorithm has failed!"
+    assert(_np.array_equal(sout, _np.identity(2 * n, _np.int64))), "Algorithm has failed!"
 
     RHS1A_CNOTs.reverse()
     RHS1B_CNOTs.reverse()
@@ -1346,9 +1346,9 @@ def compile_cnot_circuit(s, pspec, compilation, qubit_labels=None, algorithm='CO
     else: qubits = list(pspec.qubit_labels)
     n = len(qubits)
     assert(n == _np.shape(s)[0] // 2), "The CNOT circuit is over the wrong number of qubits!"
-    assert(_np.array_equal(s[:n, n:2 * n], _np.zeros((n, n), int))
+    assert(_np.array_equal(s[:n, n:2 * n], _np.zeros((n, n), _np.int64))
            ), "`s` is not block-diagonal and so does not rep. a valid CNOT circuit!"
-    assert(_np.array_equal(s[n:2 * n, :n], _np.zeros((n, n), int))
+    assert(_np.array_equal(s[n:2 * n, :n], _np.zeros((n, n), _np.int64))
            ), "`s` is not block-diagonal and so does not rep. a valid CNOT circuit!"
     assert(_symp.check_symplectic(s)), "`s` is not symplectic, so it does not rep. a valid CNOT circuit!"
 
@@ -1479,7 +1479,7 @@ def _compile_cnot_circuit_using_bge_algorithm(s, pspec, qubit_labels=None, compi
     assert(len(qubit_labels) == n), "The CNOT circuit is over the wrong number of qubits!"
     # We can just use this more general function for this task.
     sout, instructions, success = _submatrix_gaussian_elimination_using_cnots(s, 'row', 'UL', qubit_labels)
-    assert(_np.array_equal(sout, _np.identity(2 * n, int))
+    assert(_np.array_equal(sout, _np.identity(2 * n, _np.int64))
            ), "Algorithm has failed! Perhaps the input wasn't a CNOT circuit."
     # The instructions returned are for mapping s -> I, so we need to reverse them.
     instructions.reverse()
@@ -2171,7 +2171,7 @@ def compile_stabilizer_state(s, p, pspec, absolute_compilation, paulieq_compilat
     # Add CNOT into the dictionary, because the gates in check_circuit are 'CNOT'.
     sreps = pspec.compute_clifford_symplectic_reps()
     sreps['CNOT'] = (_np.array([[1, 0, 0, 0], [1, 1, 0, 0], [0, 0, 1, 1],
-                                [0, 0, 0, 1]], int), _np.array([0, 0, 0, 0], int))
+                                [0, 0, 0, 1]], _np.int64), _np.array([0, 0, 0, 0], _np.int64))
     implemented_scheck, implemented_pcheck = _symp.symplectic_rep_of_clifford_circuit(check_circuit, srep_dict=sreps)
 
     # We should have a circuit with the same RHS as `s`. This is only true when we have prefixed the additional
@@ -2359,7 +2359,7 @@ def compile_stabilizer_measurement(s, p, pspec, absolute_compilation, paulieq_co
 
     sreps = pspec.compute_clifford_symplectic_reps()
     sreps['CNOT'] = (_np.array([[1, 0, 0, 0], [1, 1, 0, 0], [0, 0, 1, 1],
-                                [0, 0, 0, 1]], int), _np.array([0, 0, 0, 0], int))
+                                [0, 0, 0, 1]], _np.int64), _np.array([0, 0, 0, 0], _np.int64))
     #implemented_s, implemented_p = _symp.symplectic_rep_of_clifford_circuit(circuit, srep_dict=sreps)
 
     # Find the (s,p) implemented by the circuit when the additional CNOT circuit is at the end.

--- a/pygsti/algorithms/mirroring.py
+++ b/pygsti/algorithms/mirroring.py
@@ -43,7 +43,7 @@ from . import randomcircuit as _rc
 #     d = circ.depth
 #     if pauli_labels is None: pauli_labels = ['Gi', 'Gxpi', 'Gypi', 'Gzpi']
 #     qubits = circ.line_labels
-#     identity = _np.identity(2 * n, int)
+#     identity = _np.identity(2 * n, _np.int64)
 #     zrotname = 'Gzr'
 #     # qubit_labels = ['G{}'.format(i) for i in range(n)]
 
@@ -326,7 +326,7 @@ def create_mirror_circuit(circ, pspec, circ_type='clifford+zxzxz'):
 #     d = circ.depth
 #     pauli_labels = ['I', 'X', 'Y', 'Z']
 #     qubits = circ.line_labels
-#     identity = _np.identity(2 * n, int)
+#     identity = _np.identity(2 * n, _np.int64)
 #     zrotname = 'Gzr'
 #     # qubit_labels = ['G{}'.format(i) for i in range(n)]
 

--- a/pygsti/algorithms/randomcircuit.py
+++ b/pygsti/algorithms/randomcircuit.py
@@ -934,7 +934,7 @@ def create_random_circuit(pspec, length, qubit_labels=None, sampler='Qeliminatio
 #     p_rc_dict = {}
 #     circuit_dict = {}
 
-#     if isinstance(length, int):
+#     if isinstance(length, _np.int64):
 #         length_per_subset = [length for i in range(len(structure))]
 #     else:
 #         length_per_subset = length
@@ -1492,8 +1492,8 @@ def create_direct_rb_circuit(pspec, clifford_compilations, length, qubit_labels=
     # Find the expected outcome of the circuit.
     s_out, p_out = _symp.symplectic_rep_of_clifford_circuit(full_circuit, pspec=pspec)
     if conditionaltwirl:  # s_out is not always the identity with a conditional twirl, only conditional on prep/measure.
-        assert(_np.array_equal(s_out[:n, n:], _np.zeros((n, n), int))), "Compiler has failed!"
-    else: assert(_np.array_equal(s_out, _np.identity(2 * n, int))), "Compiler has failed!"
+        assert(_np.array_equal(s_out[:n, n:], _np.zeros((n, n), _np.int64))), "Compiler has failed!"
+    else: assert(_np.array_equal(s_out, _np.identity(2 * n, _np.int64))), "Compiler has failed!"
 
     # Find the ideal output of the circuit.
     s_inputstate, p_inputstate = _symp.prep_stabilizer_state(n, zvals=None)
@@ -1778,8 +1778,8 @@ def create_direct_rb_circuit(pspec, clifford_compilations, length, qubit_labels=
 #     s_out, p_out = _symp.symplectic_rep_of_clifford_circuit(full_circuit, pspec=pspec)
 #     if conditionaltwirl:  # s_out is not always the identity with a conditional twirl,
 #         # only conditional on prep/measure.
-#         assert(_np.array_equal(s_out[:n, n:], _np.zeros((n, n), int))), "Compiler has failed!"
-#     else: assert(_np.array_equal(s_out, _np.identity(2 * n, int))), "Compiler has failed!"
+#         assert(_np.array_equal(s_out[:n, n:], _np.zeros((n, n), _np.int64))), "Compiler has failed!"
+#     else: assert(_np.array_equal(s_out, _np.identity(2 * n, _np.int64))), "Compiler has failed!"
 
 #     # Find the ideal output of the circuit.
 #     s_inputstate, p_inputstate = _symp.prep_stabilizer_state(n, zvals=None)
@@ -2177,8 +2177,8 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
     rand_state = _np.random.RandomState(seed)  # OK if seed is None
 
     # Initialize the identity circuit rep.
-    s_composite = _np.identity(2 * n, int)
-    p_composite = _np.zeros((2 * n), int)
+    s_composite = _np.identity(2 * n, _np.int64)
+    p_composite = _np.zeros((2 * n), _np.int64)
     # Initialize an empty circuit
     full_circuit = _cir.Circuit(layer_labels=[], line_labels=qubits, editable=True)
 
@@ -2219,7 +2219,7 @@ def create_clifford_rb_circuit(pspec, clifford_compilations, length, qubit_label
     # Find the expected outcome of the circuit.
     s_out, p_out = _symp.symplectic_rep_of_clifford_circuit(full_circuit, pspec=pspec)
     # Check the output is the identity up to Paulis.
-    assert(_np.array_equal(s_out[:n, n:], _np.zeros((n, n), int)))
+    assert(_np.array_equal(s_out[:n, n:], _np.zeros((n, n), _np.int64)))
     # Find the ideal-out of the circuit, as a bit-string.
     s_inputstate, p_inputstate = _symp.prep_stabilizer_state(n, zvals=None)
     s_outstate, p_outstate = _symp.apply_clifford_to_stabilizer_state(s_out, p_out, s_inputstate, p_inputstate)
@@ -2525,7 +2525,7 @@ def create_mirror_rb_circuit(pspec, absolute_compilation, length, qubit_labels=N
 
     # The full circuit should be, up to a Pauli, the identity.
     s_out, p_out = _symp.symplectic_rep_of_clifford_circuit(circuit, pspec=pspec)
-    assert(_np.array_equal(s_out, _np.identity(2 * n, int)))
+    assert(_np.array_equal(s_out, _np.identity(2 * n, _np.int64)))
 
     # Find the error-free output.
     s_inputstate, p_inputstate = _symp.prep_stabilizer_state(n, zvals=None)
@@ -2647,7 +2647,7 @@ def create_mirror_rb_circuit(pspec, absolute_compilation, length, qubit_labels=N
 #         rndm_indices = rndm.randint(0, len(group), m)
 #         if interleaved:
 #             interleaved_index = group.label_indices[interleaved]
-#             interleaved_indices = interleaved_index * _np.ones((m, 2), int)
+#             interleaved_indices = interleaved_index * _np.ones((m, 2), _np.int64)
 #             interleaved_indices[:, 0] = rndm_indices
 #             rndm_indices = interleaved_indices.flatten()
 
@@ -2677,7 +2677,7 @@ def create_mirror_rb_circuit(pspec, absolute_compilation, length, qubit_labels=N
 #         rndm_indices = rndm.randint(0, len(opLabels), m)
 #         if interleaved:
 #             interleaved_index = opLabels.index(interleaved)
-#             interleaved_indices = interleaved_index * _np.ones((m, 2), int)
+#             interleaved_indices = interleaved_index * _np.ones((m, 2), _np.int64)
 #             interleaved_indices[:, 0] = rndm_indices
 #             rndm_indices = interleaved_indices.flatten()
 
@@ -2716,7 +2716,7 @@ def create_mirror_rb_circuit(pspec, absolute_compilation, length, qubit_labels=N
 #             rndm_indices = rndm.randint(0, len(opLabels), m)
 #             if interleaved:
 #                 interleaved_index = opLabels.index(interleaved)
-#                 interleaved_indices = interleaved_index * _np.ones((m, 2), int)
+#                 interleaved_indices = interleaved_index * _np.ones((m, 2), _np.int64)
 #                 interleaved_indices[:, 0] = rndm_indices
 #                 rndm_indices = interleaved_indices.flatten()
 #             random_string = [opLabels[i] for i in rndm_indices]
@@ -2725,7 +2725,7 @@ def create_mirror_rb_circuit(pspec, absolute_compilation, length, qubit_labels=N
 #             rndm_indices = rndm.randint(0, len(group), m)
 #             if interleaved:
 #                 interleaved_index = group.label_indices[interleaved]
-#                 interleaved_indices = interleaved_index * _np.ones((m, 2), int)
+#                 interleaved_indices = interleaved_index * _np.ones((m, 2), _np.int64)
 #                 interleaved_indices[:, 0] = rndm_indices
 #                 rndm_indices = interleaved_indices.flatten()
 #             random_string = [group.labels[i] for i in rndm_indices]
@@ -3060,7 +3060,7 @@ def create_random_germpower_mirror_circuits(pspec, absolute_compilation, depths,
 
         # The full circuit should be, up to a Pauli, the identity.
         s_out, p_out = _symp.symplectic_rep_of_clifford_circuit(circuit, pspec=pspec)
-        assert(_np.array_equal(s_out, _np.identity(2 * n, int)))
+        assert(_np.array_equal(s_out, _np.identity(2 * n, _np.int64)))
 
         # Find the error-free output.
         s_inputstate, p_inputstate = _symp.prep_stabilizer_state(n, zvals=None)

--- a/pygsti/algorithms/rbfit.py
+++ b/pygsti/algorithms/rbfit.py
@@ -244,7 +244,7 @@ def custom_least_squares_fit(lengths, asps, n, a=None, b=None, seed=None, rtype=
     variable['a'] = True
     variable['b'] = True
     variable['p'] = True
-    lengths = _np.array(lengths, int)
+    lengths = _np.array(lengths, _np.int64)
     asps = _np.array(asps, 'd')
 
     # The fit to do if a fixed value for a is given

--- a/pygsti/baseobjs/qubitgraph.py
+++ b/pygsti/baseobjs/qubitgraph.py
@@ -193,7 +193,7 @@ class QubitGraph(_NicelySerializable):
                     "`initial_connectivity` must hold *integer* direction-indices when `direction_names` is non-None"
             else:
                 #TODO: fix numpy integer-type test here
-                assert(initial_connectivity.dtype == _np.int), \
+                assert(initial_connectivity.dtype == _np.int or initial_connectivity.dtype == _np.int64), \
                     ("`initial_connectivity` can only have dtype == bool or "
                      "int (but has dtype=%s)") % str(initial_connectivity.dtype)
                 assert(direction_names is not None), \

--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -300,7 +300,7 @@ class _DataSetRow(object):
         #        seriesDict[outcome_label] = []
 
         if self.reps is None:
-            reps = _np.ones(len(self.time), int)
+            reps = _np.ones(len(self.time), _np.int64)
         else: reps = self.reps
 
         # An alternate implementation that appears to be (surprisingly?) slower...
@@ -314,7 +314,7 @@ class _DataSetRow(object):
         #time_bins_borders.append(len(self.time))
         #nTimes = len(time_bins_borders) - 1
         #
-        #seriesDict = {self.dataset.olIndex[ol]: _np.zeros(nTimes, int) for ol in self.dataset.outcome_labels}
+        #seriesDict = {self.dataset.olIndex[ol]: _np.zeros(nTimes, _np.int64) for ol in self.dataset.outcome_labels}
         #
         #for i in range(nTimes):
         #    slc = slice(time_bins_borders[i],time_bins_borders[i+1])
@@ -353,7 +353,7 @@ class _DataSetRow(object):
         last_time = None
 
         if self.reps is None:
-            reps = list(_np.ones(len(self.time), int))
+            reps = list(_np.ones(len(self.time), _np.int64))
         else: reps = self.reps
 
         for t, outcome_label, rep in zip(self.time, self.outcomes, reps):
@@ -389,7 +389,7 @@ class _DataSetRow(object):
         last_time = None
 
         if self.reps is None:
-            return list(self.time), list(_np.ones(len(self.time), int))
+            return list(self.time), list(_np.ones(len(self.time), _np.int64))
 
         else:
             for t, rep in zip(self.time, self.reps):
@@ -1027,7 +1027,7 @@ class DataSet(object):
             self.olIndex = outcome_label_indices
             self.olIndex_max = max(self.olIndex.values()) if len(self.olIndex) > 0 else -1
         elif outcome_labels is not None:
-            if isinstance(outcome_labels, int):
+            if isinstance(outcome_labels, _np.int64):
                 nqubits = outcome_labels
                 tup_outcomeLabels = [("".join(x),) for x in _itertools.product(*([('0', '1')] * nqubits))]
             else:

--- a/pygsti/evotypes/stabilizer/opreps.pyx
+++ b/pygsti/evotypes/stabilizer/opreps.pyx
@@ -88,10 +88,10 @@ cdef class OpRepClifford(OpRep):
         self.basis = basis
 
         #Make sure all arrays are contiguous
-        self.smatrix = _np.ascontiguousarray(self.smatrix)
-        self.svector = _np.ascontiguousarray(self.svector)
-        self.smatrix_inv = _np.ascontiguousarray(self.smatrix_inv)
-        self.svector_inv = _np.ascontiguousarray(self.svector_inv)
+        self.smatrix = _np.ascontiguousarray(self.smatrix, dtype=_np.int64)
+        self.svector = _np.ascontiguousarray(self.svector, dtype=_np.int64)
+        self.smatrix_inv = _np.ascontiguousarray(self.smatrix_inv, dtype=_np.int64)
+        self.svector_inv = _np.ascontiguousarray(self.svector_inv, dtype=_np.int64)
 
         self.state_space = _StateSpace.cast(state_space)
         assert(self.state_space.num_qubits == self.smatrix.shape[0] // 2)

--- a/pygsti/forwardsims/termforwardsim_calc_generic.py
+++ b/pygsti/forwardsims/termforwardsim_calc_generic.py
@@ -352,7 +352,7 @@ def circuit_achieved_and_max_sopm(fwdsim, rholabel, elabels, circuit, repcache, 
          for elbl in elabels], 'd')
 
     mag = _np.zeros(len(elabels), 'd')
-    nPaths = _np.zeros(len(elabels), int)
+    nPaths = _np.zeros(len(elabels), _np.int64)
 
     def count_path(b, mg, incd):
         mag[E_indices[b[-1]]] += mg
@@ -1189,7 +1189,7 @@ def pathmagnitude_threshold(oprep_lists, e_indices, num_elabels, target_sum_of_p
 
     while nIters < 100:  # TODO: allow setting max_nIters as an arg?
         mag = _np.zeros(num_elabels, 'd')
-        nPaths = _np.zeros(num_elabels, int)
+        nPaths = _np.zeros(num_elabels, _np.int64)
 
         traverse_paths_upto_threshold(oprep_lists, threshold, num_elabels,
                                       foat_indices_per_op, count_path)  # sets mag and nPaths
@@ -1224,7 +1224,7 @@ def pathmagnitude_threshold(oprep_lists, e_indices, num_elabels, target_sum_of_p
         nPaths[e_indices[b[-1]]] += 1
 
     mag = _np.zeros(num_elabels, 'd')
-    nPaths = _np.zeros(num_elabels, int)
+    nPaths = _np.zeros(num_elabels, _np.int64)
     traverse_paths_upto_threshold(oprep_lists, threshold_lower_bound, num_elabels,
                                   foat_indices_per_op, count_path_nomax)  # sets mag and nPaths
 

--- a/pygsti/modelmembers/operations/composederrorgen.py
+++ b/pygsti/modelmembers/operations/composederrorgen.py
@@ -668,7 +668,7 @@ class ComposedErrorgen(_LinearOperator):
         for eg in self.factors:
             eg_terms = [t.copy() for t in eg.taylor_order_terms(order, max_polynomial_vars, return_coeff_polys)]
             mapvec = _np.ascontiguousarray(_modelmember._decompose_gpindices(
-                self.gpindices, _modelmember._compose_gpindices(eg.gpindices, _np.arange(eg.num_params))))
+                self.gpindices, _modelmember._compose_gpindices(eg.gpindices, _np.arange(eg.num_params))), _np.int64)
             for t in eg_terms:
                 # t.map_indices_inplace(lambda x: tuple(_modelmember._decompose_gpindices(
                 #     # map global to *local* indices

--- a/pygsti/modelmembers/states/computationalstate.py
+++ b/pygsti/modelmembers/states/computationalstate.py
@@ -141,7 +141,7 @@ class ComputationalBasisState(_State):
 
         evotype = _Evotype.cast(evotype)
         self._evotype = evotype  # set this before call to _State.__init__ so self.to_dense() can work...
-        rep = evotype.create_computational_state_rep(zvals, basis, state_space)
+        rep = evotype.create_computational_state_rep(self._zvals, basis, state_space)
         _State.__init__(self, rep, evotype)
 
     def to_dense(self, on_space='minimal', scratch=None):

--- a/pygsti/models/oplessmodel.py
+++ b/pygsti/models/oplessmodel.py
@@ -387,7 +387,7 @@ class ErrorRatesModel(SuccessFailModel):
         #             if q not in usedQs:
         #                 inds_to_mult.append(g_inds[q])
 
-        #         inds_to_mult_by_layer.append(_np.array(inds_to_mult, int))
+        #         inds_to_mult_by_layer.append(_np.array(inds_to_mult, _np.int64))
 
         # else:
 
@@ -406,13 +406,13 @@ class ErrorRatesModel(SuccessFailModel):
 
         if self._idlename is not None:
             layers_with_idles = [circuit.layer_label_with_idles(i, idle_gate_name=self._idlename) for i in range(depth)]
-            inds_to_mult_by_layer = [_np.array(indices_for_label(layer), int) for layer in layers_with_idles]
+            inds_to_mult_by_layer = [_np.array(indices_for_label(layer), _np.int64) for layer in layers_with_idles]
         else:
-            inds_to_mult_by_layer = [_np.array(indices_for_label(circuit.layer_label(i)), int) for i in range(depth)]
+            inds_to_mult_by_layer = [_np.array(indices_for_label(circuit.layer_label(i)), _np.int64) for i in range(depth)]
 
         # Bit-flip readout error as a pre-measurement depolarizing channel.
         inds_to_mult = [r_inds[q] for q in circuit.line_labels]
-        inds_to_mult_by_layer.append(_np.array(inds_to_mult, int))
+        inds_to_mult_by_layer.append(_np.array(inds_to_mult, _np.int64))
 
         # The scaling constant such that lambda = 1 - alpha * epsilon where lambda is the diagonal of a depolarizing
         # channel with entanglement infidelity of epsilon.
@@ -570,7 +570,7 @@ class TwirledGatesModel(ErrorRatesModel):
         width, depth, alpha, one_over_2_width, inds_to_mult_by_layer = super()._circuit_cache(circuit)
         all_inds_to_mult = _np.concatenate(inds_to_mult_by_layer[:-1])
         readout_inds_to_mult = inds_to_mult_by_layer[-1]
-        all_inds_to_mult_cnt = _np.zeros(self.num_params, int)
+        all_inds_to_mult_cnt = _np.zeros(self.num_params, _np.int64)
         for i in all_inds_to_mult:
             all_inds_to_mult_cnt[i] += 1
         return width, depth, alpha, one_over_2_width, all_inds_to_mult, readout_inds_to_mult, all_inds_to_mult_cnt
@@ -676,7 +676,7 @@ class AnyErrorCausesFailureModel(ErrorRatesModel):
     def _circuit_cache(self, circuit):
         width, depth, alpha, one_over_2_width, inds_to_mult_by_layer = super()._circuit_cache(circuit)
         all_inds_to_mult = _np.concatenate(inds_to_mult_by_layer)
-        all_inds_to_mult_cnt = _np.zeros(self.num_params, int)
+        all_inds_to_mult_cnt = _np.zeros(self.num_params, _np.int64)
         for i in all_inds_to_mult:
             all_inds_to_mult_cnt[i] += 1
         return all_inds_to_mult, all_inds_to_mult_cnt
@@ -758,7 +758,7 @@ class AnyErrorCausesRandomOutputModel(ErrorRatesModel):
     def _circuit_cache(self, circuit):
         width, depth, alpha, one_over_2_width, inds_to_mult_by_layer = super()._circuit_cache(circuit)
         all_inds_to_mult = _np.concatenate(inds_to_mult_by_layer)
-        all_inds_to_mult_cnt = _np.zeros(self.num_params, int)
+        all_inds_to_mult_cnt = _np.zeros(self.num_params, _np.int64)
         for i in all_inds_to_mult:
             all_inds_to_mult_cnt[i] += 1
         return one_over_2_width, all_inds_to_mult, all_inds_to_mult_cnt

--- a/pygsti/objectivefns/wildcardbudget.py
+++ b/pygsti/objectivefns/wildcardbudget.py
@@ -872,11 +872,11 @@ def update_circuit_probs(probs, freqs, circuit_budget):
 
         # move j from A/B -> C
         if typ == 'A':
-            Alst = list(A); del Alst[Alst.index(j)]; A = _np.array(Alst, int)
-            Clst = list(C); Clst.append(j); C = _np.array(Clst, int)  # move A -> C
+            Alst = list(A); del Alst[Alst.index(j)]; A = _np.array(Alst, _np.int64)
+            Clst = list(C); Clst.append(j); C = _np.array(Clst, _np.int64)  # move A -> C
         else:  # typ == 'B'
-            Blst = list(B); del Blst[Blst.index(j)]; B = _np.array(Blst, int)
-            Clst = list(C); Clst.append(j); C = _np.array(Clst, int)  # move B -> C
+            Blst = list(B); del Blst[Blst.index(j)]; B = _np.array(Blst, _np.int64)
+            Clst = list(C); Clst.append(j); C = _np.array(Clst, _np.int64)  # move B -> C
 
         #update ratios
         del ratios[j]

--- a/pygsti/optimize/customsolve.py
+++ b/pygsti/optimize/customsolve.py
@@ -88,7 +88,7 @@ def custom_solve(a, b, x, ari, resource_alloc, proc_threshold=100):
 
     comm = resource_alloc.comm
     host_comm = resource_alloc.host_comm
-    ok_buf = _np.empty(1, int)
+    ok_buf = _np.empty(1, _np.int64)
 
     if comm is None or isinstance(ari, _UndistributedArraysInterface):
         x[:] = _scipy.linalg.solve(a, b, assume_a='pos')
@@ -129,19 +129,19 @@ def custom_solve(a, b, x, ari, resource_alloc, proc_threshold=100):
         shared_floats, shared_floats_shm = _smt.create_shared_ndarray(
             resource_alloc, (host_comm.size,), 'd')
         shared_ints, shared_ints_shm = _smt.create_shared_ndarray(
-            resource_alloc, (max(host_comm.size, 3),), int)
+            resource_alloc, (max(host_comm.size, 3),), _np.int64)
         shared_rowb, shared_rowb_shm = _smt.create_shared_ndarray(
             resource_alloc, (a.shape[1] + 1,), 'd')
 
         # Scratch buffers
-        host_index_buf = _np.empty((resource_alloc.interhost_comm.size, 2), int) \
+        host_index_buf = _np.empty((resource_alloc.interhost_comm.size, 2), _np.int64) \
             if resource_alloc.interhost_comm.rank == 0 else None
         host_val_buf = _np.empty((resource_alloc.interhost_comm.size, 1), 'd') \
             if resource_alloc.interhost_comm.rank == 0 else None
     else:
         shared_floats = shared_ints = shared_rowb = None
 
-        host_index_buf = _np.empty((comm.size, 1), int) if comm.rank == 0 else None
+        host_index_buf = _np.empty((comm.size, 1), _np.int64) if comm.rank == 0 else None
         host_val_buf = _np.empty((comm.size, 1), 'd') if comm.rank == 0 else None
 
     # Idea: bring a|b into RREF then back-substitute to get x.
@@ -154,8 +154,8 @@ def custom_solve(a, b, x, ari, resource_alloc, proc_threshold=100):
     #Scratch space
     local_pivot_rowb = _np.empty(a.shape[1] + 1, 'd')
     smbuf1 = _np.empty(1, 'd')
-    smbuf2 = _np.empty(2, int)
-    smbuf3 = _np.empty(3, int)
+    smbuf2 = _np.empty(2, _np.int64)
+    smbuf3 = _np.empty(3, _np.int64)
 
     for icol in range(a.shape[1]):
 
@@ -346,7 +346,7 @@ def _back_substitution(a, b, x, pivot_row_indices, my_row_slice, ari, resource_a
 
     # x_indices_host = XXX  # x values to send to other procs -- TODO: slice of SHARED host array
     # x_values_host
-    # x_indices = _np.empty(_slct.length(my_row_slice), int)
+    # x_indices = _np.empty(_slct.length(my_row_slice), _np.int64)
     # x_valuess = _np.empty(_slct.length(my_row_slice), 'd')
     xval_buf = _np.empty(1, 'd')  # for MPI Send/Recv to work
 

--- a/pygsti/tools/fastcalc.pyx
+++ b/pygsti/tools/fastcalc.pyx
@@ -1263,7 +1263,7 @@ def fast_compose_cliffords(np.ndarray[np.int64_t, ndim=2] s1, np.ndarray[np.int6
     cdef INT N = s1.shape[0] // 2 # Number of qubits
 
     # Temporary space of C^T U C terms
-    cdef np.ndarray[np.int64_t, ndim=2, mode="c"] inner = np.zeros([2*N, 2*N], dtype=np.int)
+    cdef np.ndarray[np.int64_t, ndim=2, mode="c"] inner = np.zeros([2*N, 2*N], dtype=np.int64)
 
     # Outputs
     cdef np.ndarray[np.int64_t, ndim=2, mode="c"] s = np.zeros([2*N, 2*N], dtype=np.int64)

--- a/pygsti/tools/fastcalc.pyx
+++ b/pygsti/tools/fastcalc.pyx
@@ -1255,19 +1255,19 @@ def restricted_abs_argmax(np.ndarray[double, ndim=1] ar, np.ndarray[np.int64_t, 
 #@cython.cdivision(True) # turn off divide-by-zero checking (keeping off for Python behavior of div/mods)
 @cython.boundscheck(False) # turn off bounds-checking for entire function
 @cython.wraparound(False)  # turn off negative index wrapping for entire function
-def fast_compose_cliffords(np.ndarray[INT, ndim=2] s1, np.ndarray[INT, ndim=1] p1,
-                           np.ndarray[INT, ndim=2] s2, np.ndarray[INT, ndim=1] p2):
+def fast_compose_cliffords(np.ndarray[np.int64_t, ndim=2] s1, np.ndarray[np.int64_t, ndim=1] p1,
+                           np.ndarray[np.int64_t, ndim=2] s2, np.ndarray[np.int64_t, ndim=1] p2):
     cdef INT i
     cdef INT j
     cdef INT k
     cdef INT N = s1.shape[0] // 2 # Number of qubits
 
     # Temporary space of C^T U C terms
-    cdef np.ndarray[INT, ndim=2, mode="c"] inner = np.zeros([2*N, 2*N], dtype=np.int)
+    cdef np.ndarray[np.int64_t, ndim=2, mode="c"] inner = np.zeros([2*N, 2*N], dtype=np.int)
 
     # Outputs
-    cdef np.ndarray[INT, ndim=2, mode="c"] s = np.zeros([2*N, 2*N], dtype=np.int)
-    cdef np.ndarray[INT, ndim=1, mode="c"] p = np.zeros([2*N], dtype=np.int)
+    cdef np.ndarray[np.int64_t, ndim=2, mode="c"] s = np.zeros([2*N, 2*N], dtype=np.int64)
+    cdef np.ndarray[np.int64_t, ndim=1, mode="c"] p = np.zeros([2*N], dtype=np.int64)
 
     # If C' = [[C^00, C^01], [C^10, C^11]] and U = [[0, 0], [I, 0]]
     # then C'^T U C' = [[C^10^T C00, C^10^T C^01], [C^11^T C^00, C^11^T C^01]]

--- a/pygsti/tools/matrixmod2.py
+++ b/pygsti/tools/matrixmod2.py
@@ -177,7 +177,7 @@ def diagonal_as_vec(m):
     numpy.ndarray
     """
     l = _np.shape(m)[0]
-    vec = _np.zeros(l, int)
+    vec = _np.zeros(l, _np.int64)
     for i in range(0, l):
         vec[i] = m[i, i]
     return vec
@@ -220,7 +220,7 @@ def diagonal_as_matrix(m):
     numpy.ndarray
     """
     l = _np.shape(m)[0]
-    out = _np.zeros((l, l), int)
+    out = _np.zeros((l, l), _np.int64)
 
     for i in range(0, l):
         out[i, i] = m[i, i]
@@ -394,7 +394,7 @@ def onesify(a, failcount=0, maxfailcount=100):
 
     M = _np.array(M, dtype='int')
 
-    if _np.array_equal(dot_mod2(M, inv_mod2(M)), _np.identity(t, int)):
+    if _np.array_equal(dot_mod2(M, inv_mod2(M)), _np.identity(t, _np.int64)):
         return _np.array(M)
     else:
         return onesify(a, failcount + 1, maxfailcount=maxfailcount)

--- a/pygsti/tools/rbtheory.py
+++ b/pygsti/tools/rbtheory.py
@@ -537,7 +537,7 @@ def R_matrix(model, group, group_to_model=None, weights=None):  # noqa N802
 #                    ), "Some group elements not in `model`, so `compilation must be specified."
 
 #     i_max = _np.floor((m_max - m_min) / m_step).astype('int')
-#     m = _np.zeros(1 + i_max, int)
+#     m = _np.zeros(1 + i_max, _np.int64)
 #     P_m = _np.zeros(1 + i_max, float)
 #     group_dim = len(group)
 #     R = R_matrix(model, group, group_to_model=group_to_model, weights=weights)
@@ -680,7 +680,7 @@ def R_matrix(model, group, group_to_model=None, weights=None):  # noqa N802
 #         E_eff = _np.dot(model_go.povms['Mdefault'][success_effectLabel].T, emaps.operations['Gavg'])
 
 #     i_max = _np.floor((m_max - m_min) / m_step).astype('int')
-#     m = _np.zeros(1 + i_max, int)
+#     m = _np.zeros(1 + i_max, _np.int64)
 #     P_m = _np.zeros(1 + i_max, float)
 #     upper_bound = _np.zeros(1 + i_max, float)
 #     lower_bound = _np.zeros(1 + i_max, float)

--- a/pygsti/tools/symplectic.py
+++ b/pygsti/tools/symplectic.py
@@ -54,13 +54,13 @@ def symplectic_form(n, convention='standard'):
         The specified symplectic form.
     """
     nn = 2 * n
-    sym_form = _np.zeros((nn, nn), int)
+    sym_form = _np.zeros((nn, nn), _np.int64)
 
     assert(convention == 'standard' or convention == 'directsum')
 
     if convention == 'standard':
-        sym_form[n:nn, 0:n] = _np.identity(n, int)
-        sym_form[0:n, n:nn] = _np.identity(n, int)
+        sym_form[n:nn, 0:n] = _np.identity(n, _np.int64)
+        sym_form[0:n, n:nn] = _np.identity(n, _np.int64)
 
     if convention == 'directsum':
         # This current construction method is pretty stupid.
@@ -104,7 +104,7 @@ def change_symplectic_form_convention(s, outconvention='standard'):
     if n == 1:
         return _np.copy(s)
 
-    permutation_matrix = _np.zeros((2 * n, 2 * n), int)
+    permutation_matrix = _np.zeros((2 * n, 2 * n), _np.int64)
     for i in range(0, n):
         permutation_matrix[2 * i, i] = 1
         permutation_matrix[2 * i + 1, n + i] = 1
@@ -165,7 +165,7 @@ def inverse_symplectic(s):
     s_inverse = _mtx.dot_mod2(_np.dot(s_form, _np.transpose(s)), s_form)
 
     assert(check_symplectic(s_inverse)), "The inverse is not symplectic. Function has failed"
-    assert(_np.array_equal(_mtx.dot_mod2(s_inverse, s), _np.identity(2 * n, int))
+    assert(_np.array_equal(_mtx.dot_mod2(s_inverse, s), _np.identity(2 * n, _np.int64))
            ), "The found matrix is not the inverse of the input. Function has failed"
 
     return s_inverse
@@ -201,8 +201,8 @@ def inverse_clifford(s, p):
 
     # The formula used below for the inverse p vector comes from Hostens
     # and De Moor PRA 71, 042315 (2005).
-    u = _np.zeros((2 * n, 2 * n), int)
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
 
     vec1 = -1 * _np.dot(_np.transpose(sinverse), p)
     inner = _np.dot(_np.dot(_np.transpose(sinverse), u), sinverse)
@@ -217,15 +217,15 @@ def inverse_clifford(s, p):
     assert(check_valid_clifford(sinverse, pinverse)), "The output does not define a valid Clifford. Function has failed"
 
     s_check, p_check = compose_cliffords(s, p, sinverse, pinverse)
-    assert(_np.array_equal(s_check, _np.identity(2 * n, int))
+    assert(_np.array_equal(s_check, _np.identity(2 * n, _np.int64))
            ), "The output is not the inverse of the input. Function has failed"
-    assert(_np.array_equal(p_check, _np.zeros(2 * n, int))
+    assert(_np.array_equal(p_check, _np.zeros(2 * n, _np.int64))
            ), "The output is not the inverse of the input. Function has failed"
 
     s_check, p_check = compose_cliffords(sinverse, pinverse, s, p)
-    assert(_np.array_equal(s_check, _np.identity(2 * n, int))
+    assert(_np.array_equal(s_check, _np.identity(2 * n, _np.int64))
            ), "The output is not the inverse of the input. Function has failed"
-    assert(_np.array_equal(p_check, _np.zeros(2 * n, int))
+    assert(_np.array_equal(p_check, _np.zeros(2 * n, _np.int64))
            ), "The output is not the inverse of the input. Function has failed"
 
     return sinverse, pinverse
@@ -257,12 +257,12 @@ def check_valid_clifford(s, p):
     # that p is a vector over [0,1,2,3]. Perhaps it should. The constraint
     # that we check is satisfied comes from Hostens and De Moor PRA 71, 042315 (2005).
     n = _np.shape(s)[0] // 2
-    u = _np.zeros((2 * n, 2 * n), int)
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
     vec = p + _mtx.diagonal_as_vec(_np.dot(_np.dot(_np.transpose(s), u), s))
     vec = vec % 2
 
-    is_valid_phase_vector = _np.array_equal(vec, _np.zeros(len(p), int))
+    is_valid_phase_vector = _np.array_equal(vec, _np.zeros(len(p), _np.int64))
     assert(is_valid_phase_vector)
 
     return (is_symplectic_matrix and is_valid_phase_vector)
@@ -295,8 +295,8 @@ def construct_valid_phase_vector(s, pseed):
 
     assert(check_symplectic(s)), "The input matrix is not symplectic!"
 
-    u = _np.zeros((2 * n, 2 * n), int)
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
 
     # Each element of this vector should be 0 (mod 2) if this is a valid phase vector.
     # This comes from the formulas in Hostens and De Moor PRA 71, 042315 (2005).
@@ -489,8 +489,8 @@ def compose_cliffords(s1, p1, s2, p2, do_checks=True):
     # Hostens and De Moor PRA 71, 042315 (2005).
     s = _mtx.dot_mod2(s2, s1)
 
-    u = _np.zeros((2 * n, 2 * n), int)
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
 
     vec1 = _np.dot(_np.transpose(s1), p2)
     inner = _np.dot(_np.dot(_np.transpose(s2), u), s2)
@@ -535,8 +535,8 @@ def symplectic_kronecker(sp_factors):
     nlist = [len(p) // 2 for s, p in sp_factors]  # number of qubits per factor
     n = sum(nlist)  # total number of qubits
 
-    sout = _np.zeros((2 * n, 2 * n), int)
-    pout = _np.zeros(2 * n, int)
+    sout = _np.zeros((2 * n, 2 * n), _np.int64)
+    pout = _np.zeros(2 * n, _np.int64)
     k = 0  # current qubit index
     for (s, p), nq in zip(sp_factors, nlist):
         assert(s.shape == (2 * nq, 2 * nq))
@@ -574,8 +574,8 @@ def prep_stabilizer_state(nqubits, zvals=None):
         has shape 2n, where n equals `nqubits`.
     """
     n = nqubits
-    s = _np.fliplr(_np.identity(2 * n, int))  # flip b/c stab cols are *first*
-    p = _np.zeros(2 * n, int)
+    s = _np.fliplr(_np.identity(2 * n, _np.int64))  # flip b/c stab cols are *first*
+    p = _np.zeros(2 * n, _np.int64)
     if zvals:
         for i, z in enumerate(zvals):
             p[i] = p[i + n] = 2 if bool(z) else 0  # EGN TODO: check this is right -- (how to update the destabilizers?)
@@ -619,8 +619,8 @@ def apply_clifford_to_stabilizer_state(s, p, state_s, state_p):
     # Hostens and De Moor PRA 71, 042315 (2005).
     out_s = _mtx.dot_mod2(s, state_s)
 
-    u = _np.zeros((2 * n, 2 * n), int)
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
 
     inner = _np.dot(_np.dot(_np.transpose(s), u), s)
     vec1 = _np.dot(_np.transpose(state_s), p - _mtx.diagonal_as_vec(inner))
@@ -631,7 +631,7 @@ def apply_clifford_to_stabilizer_state(s, p, state_s, state_p):
     out_p = out_p % 4
 
     ##More explicitly operates on stabilizer and antistabilizer separately, but same as above
-    #out_p = _np.zeros(2*n,int)
+    #out_p = _np.zeros(2*n, _np.int64)
     #for slc in (slice(0,n),slice(n,2*n)):
     #    ss = state_s[:,slc]
     #    inner = _np.dot(_np.dot(_np.transpose(s),u),s)
@@ -720,7 +720,7 @@ def pauli_z_measurement(state_s, state_p, qubit_index):
     # no break ==> all commute, so outcome is deterministic, so no
     # state update; just determine whether Z_a or -Z_a is in the stabilizer,
     # which we do using the "anti-stabilizer" cleverness of PRA 70, 052328
-    acc_s = _np.zeros(two_n, int); acc_p = _np.zeros(1, int)
+    acc_s = _np.zeros(two_n, _np.int64); acc_p = _np.zeros(1, _np.int64)
     for i in range(n, two_n):  # loop over anti-stabilizer
         if state_s[a, i] == 1:  # for elements that anti-commute w/Z_a
             colsum_acc(acc_s, acc_p, i - n, state_s, state_p, n)  # act w/corresponding *stabilizer* el
@@ -775,8 +775,8 @@ def colsum(i, j, s, p, n):
     #assert(test in (0,2)) # test should never be congruent to 1 or 3 (mod 4)
     #p[i] = 0 if (test == 0) else 2 # ( = 10 = 1 in high bit)
 
-    u = _np.zeros((2 * n, 2 * n), int)  # CACHE!
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)  # CACHE!
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
 
     p[i] += p[j] + 2 * float(_np.dot(s[:, i].T, _np.dot(u, s[:, j])))
     for k in range(n):
@@ -829,8 +829,8 @@ def colsum_acc(acc_s, acc_p, j, s, p, n):
     #assert(test in (0,2)) # test should never be congruent to 1 or 3 (mod 4)
     #acc_p[0] = 0 if (test == 0) else 2 # ( = 10 = 1 in high bit)
 
-    u = _np.zeros((2 * n, 2 * n), int)  # CACHE!
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)  # CACHE!
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
 
     acc_p[0] += p[j] + 2 * float(_np.dot(acc_s.T, _np.dot(u, s[:, j])))
 
@@ -919,8 +919,8 @@ def embed_clifford(s, p, qubit_inds, n):
         The 'phase vector' over the integers mod 4 representing the embedded Clifford
     """
     ne = len(qubit_inds)  # nQubits for embedded_op
-    s_out = _np.identity(2 * n, int)
-    p_out = _np.zeros(2 * n, int)
+    s_out = _np.identity(2 * n, _np.int64)
+    p_out = _np.zeros(2 * n, _np.int64)
 
     for i, di in enumerate(qubit_inds):  # di = "destination index"
         p_out[di] = p[i]
@@ -966,85 +966,85 @@ def compute_internal_gate_symplectic_representations(gllist=None):
     complete_p_dict = {}
 
     # The Pauli gates
-    complete_s_dict['I'] = _np.array([[1, 0], [0, 1]], int)
-    complete_s_dict['X'] = _np.array([[1, 0], [0, 1]], int)
-    complete_s_dict['Y'] = _np.array([[1, 0], [0, 1]], int)
-    complete_s_dict['Z'] = _np.array([[1, 0], [0, 1]], int)
+    complete_s_dict['I'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_s_dict['X'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_s_dict['Y'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_s_dict['Z'] = _np.array([[1, 0], [0, 1]], _np.int64)
 
-    complete_p_dict['I'] = _np.array([0, 0], int)
-    complete_p_dict['X'] = _np.array([0, 2], int)
-    complete_p_dict['Y'] = _np.array([2, 2], int)
-    complete_p_dict['Z'] = _np.array([2, 0], int)
+    complete_p_dict['I'] = _np.array([0, 0], _np.int64)
+    complete_p_dict['X'] = _np.array([0, 2], _np.int64)
+    complete_p_dict['Y'] = _np.array([2, 2], _np.int64)
+    complete_p_dict['Z'] = _np.array([2, 0], _np.int64)
 
     # Five single qubit gates that each represent one of five classes of Cliffords
     # that equivalent up to Pauli gates and are not equivalent to idle (that class
     # is covered by any one of the Pauli gates above).
-    complete_s_dict['H'] = _np.array([[0, 1], [1, 0]], int)
-    complete_s_dict['P'] = _np.array([[1, 0], [1, 1]], int)
-    complete_s_dict['PH'] = _np.array([[0, 1], [1, 1]], int)
-    complete_s_dict['HP'] = _np.array([[1, 1], [1, 0]], int)
-    complete_s_dict['HPH'] = _np.array([[1, 1], [0, 1]], int)
-    complete_p_dict['H'] = _np.array([0, 0], int)
-    complete_p_dict['P'] = _np.array([1, 0], int)
-    complete_p_dict['PH'] = _np.array([0, 1], int)
-    complete_p_dict['HP'] = _np.array([3, 0], int)
-    complete_p_dict['HPH'] = _np.array([0, 3], int)
+    complete_s_dict['H'] = _np.array([[0, 1], [1, 0]], _np.int64)
+    complete_s_dict['P'] = _np.array([[1, 0], [1, 1]], _np.int64)
+    complete_s_dict['PH'] = _np.array([[0, 1], [1, 1]], _np.int64)
+    complete_s_dict['HP'] = _np.array([[1, 1], [1, 0]], _np.int64)
+    complete_s_dict['HPH'] = _np.array([[1, 1], [0, 1]], _np.int64)
+    complete_p_dict['H'] = _np.array([0, 0], _np.int64)
+    complete_p_dict['P'] = _np.array([1, 0], _np.int64)
+    complete_p_dict['PH'] = _np.array([0, 1], _np.int64)
+    complete_p_dict['HP'] = _np.array([3, 0], _np.int64)
+    complete_p_dict['HPH'] = _np.array([0, 3], _np.int64)
     # The full 1-qubit Cliffor group, using the same labelling as in extras.rb.group
-    complete_s_dict['C0'] = _np.array([[1, 0], [0, 1]], int)
-    complete_p_dict['C0'] = _np.array([0, 0], int)
-    complete_s_dict['C1'] = _np.array([[1, 1], [1, 0]], int)
-    complete_p_dict['C1'] = _np.array([1, 0], int)
-    complete_s_dict['C2'] = _np.array([[0, 1], [1, 1]], int)
-    complete_p_dict['C2'] = _np.array([0, 1], int)
-    complete_s_dict['C3'] = _np.array([[1, 0], [0, 1]], int)
-    complete_p_dict['C3'] = _np.array([0, 2], int)
-    complete_s_dict['C4'] = _np.array([[1, 1], [1, 0]], int)
-    complete_p_dict['C4'] = _np.array([1, 2], int)
-    complete_s_dict['C5'] = _np.array([[0, 1], [1, 1]], int)
-    complete_p_dict['C5'] = _np.array([0, 3], int)
-    complete_s_dict['C6'] = _np.array([[1, 0], [0, 1]], int)
-    complete_p_dict['C6'] = _np.array([2, 2], int)
-    complete_s_dict['C7'] = _np.array([[1, 1], [1, 0]], int)
-    complete_p_dict['C7'] = _np.array([3, 2], int)
-    complete_s_dict['C8'] = _np.array([[0, 1], [1, 1]], int)
-    complete_p_dict['C8'] = _np.array([2, 3], int)
-    complete_s_dict['C9'] = _np.array([[1, 0], [0, 1]], int)
-    complete_p_dict['C9'] = _np.array([2, 0], int)
-    complete_s_dict['C10'] = _np.array([[1, 1], [1, 0]], int)
-    complete_p_dict['C10'] = _np.array([3, 0], int)
-    complete_s_dict['C11'] = _np.array([[0, 1], [1, 1]], int)
-    complete_p_dict['C11'] = _np.array([2, 1], int)
-    complete_s_dict['C12'] = _np.array([[0, 1], [1, 0]], int)
-    complete_p_dict['C12'] = _np.array([0, 0], int)
-    complete_s_dict['C13'] = _np.array([[1, 1], [0, 1]], int)
-    complete_p_dict['C13'] = _np.array([0, 1], int)
-    complete_s_dict['C14'] = _np.array([[1, 0], [1, 1]], int)
-    complete_p_dict['C14'] = _np.array([1, 0], int)
-    complete_s_dict['C15'] = _np.array([[0, 1], [1, 0]], int)
-    complete_p_dict['C15'] = _np.array([0, 2], int)
-    complete_s_dict['C16'] = _np.array([[1, 1], [0, 1]], int)
-    complete_p_dict['C16'] = _np.array([0, 3], int)
-    complete_s_dict['C17'] = _np.array([[1, 0], [1, 1]], int)
-    complete_p_dict['C17'] = _np.array([1, 2], int)
-    complete_s_dict['C18'] = _np.array([[0, 1], [1, 0]], int)
-    complete_p_dict['C18'] = _np.array([2, 2], int)
-    complete_s_dict['C19'] = _np.array([[1, 1], [0, 1]], int)
-    complete_p_dict['C19'] = _np.array([2, 3], int)
-    complete_s_dict['C20'] = _np.array([[1, 0], [1, 1]], int)
-    complete_p_dict['C20'] = _np.array([3, 2], int)
-    complete_s_dict['C21'] = _np.array([[0, 1], [1, 0]], int)
-    complete_p_dict['C21'] = _np.array([2, 0], int)
-    complete_s_dict['C22'] = _np.array([[1, 1], [0, 1]], int)
-    complete_p_dict['C22'] = _np.array([2, 1], int)
-    complete_s_dict['C23'] = _np.array([[1, 0], [1, 1]], int)
-    complete_p_dict['C23'] = _np.array([3, 0], int)
+    complete_s_dict['C0'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_p_dict['C0'] = _np.array([0, 0], _np.int64)
+    complete_s_dict['C1'] = _np.array([[1, 1], [1, 0]], _np.int64)
+    complete_p_dict['C1'] = _np.array([1, 0], _np.int64)
+    complete_s_dict['C2'] = _np.array([[0, 1], [1, 1]], _np.int64)
+    complete_p_dict['C2'] = _np.array([0, 1], _np.int64)
+    complete_s_dict['C3'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_p_dict['C3'] = _np.array([0, 2], _np.int64)
+    complete_s_dict['C4'] = _np.array([[1, 1], [1, 0]], _np.int64)
+    complete_p_dict['C4'] = _np.array([1, 2], _np.int64)
+    complete_s_dict['C5'] = _np.array([[0, 1], [1, 1]], _np.int64)
+    complete_p_dict['C5'] = _np.array([0, 3], _np.int64)
+    complete_s_dict['C6'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_p_dict['C6'] = _np.array([2, 2], _np.int64)
+    complete_s_dict['C7'] = _np.array([[1, 1], [1, 0]], _np.int64)
+    complete_p_dict['C7'] = _np.array([3, 2], _np.int64)
+    complete_s_dict['C8'] = _np.array([[0, 1], [1, 1]], _np.int64)
+    complete_p_dict['C8'] = _np.array([2, 3], _np.int64)
+    complete_s_dict['C9'] = _np.array([[1, 0], [0, 1]], _np.int64)
+    complete_p_dict['C9'] = _np.array([2, 0], _np.int64)
+    complete_s_dict['C10'] = _np.array([[1, 1], [1, 0]], _np.int64)
+    complete_p_dict['C10'] = _np.array([3, 0], _np.int64)
+    complete_s_dict['C11'] = _np.array([[0, 1], [1, 1]], _np.int64)
+    complete_p_dict['C11'] = _np.array([2, 1], _np.int64)
+    complete_s_dict['C12'] = _np.array([[0, 1], [1, 0]], _np.int64)
+    complete_p_dict['C12'] = _np.array([0, 0], _np.int64)
+    complete_s_dict['C13'] = _np.array([[1, 1], [0, 1]], _np.int64)
+    complete_p_dict['C13'] = _np.array([0, 1], _np.int64)
+    complete_s_dict['C14'] = _np.array([[1, 0], [1, 1]], _np.int64)
+    complete_p_dict['C14'] = _np.array([1, 0], _np.int64)
+    complete_s_dict['C15'] = _np.array([[0, 1], [1, 0]], _np.int64)
+    complete_p_dict['C15'] = _np.array([0, 2], _np.int64)
+    complete_s_dict['C16'] = _np.array([[1, 1], [0, 1]], _np.int64)
+    complete_p_dict['C16'] = _np.array([0, 3], _np.int64)
+    complete_s_dict['C17'] = _np.array([[1, 0], [1, 1]], _np.int64)
+    complete_p_dict['C17'] = _np.array([1, 2], _np.int64)
+    complete_s_dict['C18'] = _np.array([[0, 1], [1, 0]], _np.int64)
+    complete_p_dict['C18'] = _np.array([2, 2], _np.int64)
+    complete_s_dict['C19'] = _np.array([[1, 1], [0, 1]], _np.int64)
+    complete_p_dict['C19'] = _np.array([2, 3], _np.int64)
+    complete_s_dict['C20'] = _np.array([[1, 0], [1, 1]], _np.int64)
+    complete_p_dict['C20'] = _np.array([3, 2], _np.int64)
+    complete_s_dict['C21'] = _np.array([[0, 1], [1, 0]], _np.int64)
+    complete_p_dict['C21'] = _np.array([2, 0], _np.int64)
+    complete_s_dict['C22'] = _np.array([[1, 1], [0, 1]], _np.int64)
+    complete_p_dict['C22'] = _np.array([2, 1], _np.int64)
+    complete_s_dict['C23'] = _np.array([[1, 0], [1, 1]], _np.int64)
+    complete_p_dict['C23'] = _np.array([3, 0], _np.int64)
     # The CNOT gate, CPHASE gate, and SWAP gate.
-    complete_s_dict['CNOT'] = _np.array([[1, 0, 0, 0], [1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 0, 1]], int)
+    complete_s_dict['CNOT'] = _np.array([[1, 0, 0, 0], [1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 0, 1]], _np.int64)
     complete_s_dict['CPHASE'] = _np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 1, 1, 0], [1, 0, 0, 1]])
     complete_s_dict['SWAP'] = _np.array([[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
-    complete_p_dict['CNOT'] = _np.array([0, 0, 0, 0], int)
-    complete_p_dict['CPHASE'] = _np.array([0, 0, 0, 0], int)
-    complete_p_dict['SWAP'] = _np.array([0, 0, 0, 0], int)
+    complete_p_dict['CNOT'] = _np.array([0, 0, 0, 0], _np.int64)
+    complete_p_dict['CPHASE'] = _np.array([0, 0, 0, 0], _np.int64)
+    complete_p_dict['SWAP'] = _np.array([0, 0, 0, 0], _np.int64)
 
     if gllist is None:
         keys = list(complete_s_dict.keys())
@@ -1100,8 +1100,8 @@ def symplectic_rep_of_clifford_circuit(circuit, srep_dict=None, pspec=None):
         srep_dict.update(pspec.compute_clifford_symplectic_reps())
 
     # The initial action of the circuit before any layers are applied.
-    s = _np.identity(2 * n, int)
-    p = _np.zeros(2 * n, int)
+    s = _np.identity(2 * n, _np.int64)
+    p = _np.zeros(2 * n, _np.int64)
 
     for i in range(0, depth):
         # This relies on the circuit having a valid self.identity identifier -- as those gates are
@@ -1179,8 +1179,8 @@ def symplectic_rep_of_clifford_layer(layer, n=None, q_labels=None, srep_dict=Non
     else:
         assert(len(q_labels) == n), "`n` and `q_labels` are inconsistent!"
 
-    s = _np.identity(2 * n, int)
-    p = _np.zeros(2 * n, int)
+    s = _np.identity(2 * n, _np.int64)
+    p = _np.zeros(2 * n, _np.int64)
 
     if not isinstance(layer, _Label):
         layer = _Label(layer)
@@ -1325,8 +1325,8 @@ def _unitary_to_symplectic_1q(u, flagnonclifford=True):
     z = _np.array([[1., 0], [0, -1.]])
     fund_paulis = [x, z]
 
-    s = _np.zeros((2, 2), int)
-    p = _np.zeros(2, int)
+    s = _np.zeros((2, 2), _np.int64)
+    p = _np.zeros(2, _np.int64)
 
     for pauli_label in range(0, 2):
 
@@ -1401,8 +1401,8 @@ def _unitary_to_symplectic_2q(u, flagnonclifford=True):
 
     fund_paulis = [xi, ix, zi, iz]
 
-    s = _np.zeros((4, 4), int)
-    p = _np.zeros(4, int)
+    s = _np.zeros((4, 4), _np.int64)
+    p = _np.zeros(4, _np.int64)
 
     for pauli_label in range(0, 4):
 
@@ -1575,21 +1575,21 @@ def random_phase_vector(s, n, rand_state=None):
     if rand_state is None:
         rand_state = _np.random.RandomState()
 
-    p = _np.zeros(2 * n, int)
+    p = _np.zeros(2 * n, _np.int64)
 
     # A matrix to hold all possible phase vectors -- half of which do not, when
     # combined with the sampled symplectic matrix -- represent Cliffords.
-    all_values = _np.zeros((2 * n, 4), int)
+    all_values = _np.zeros((2 * n, 4), _np.int64)
     for i in range(0, 2 * n):
         all_values[i, :] = _np.array([0, 1, 2, 3])
 
     # We now work out which of these are valid choices for the phase vector.
     possible = _np.zeros((2 * n, 4), bool)
 
-    u = _np.zeros((2 * n, 2 * n), int)
-    u[n:2 * n, 0:n] = _np.identity(n, int)
+    u = _np.zeros((2 * n, 2 * n), _np.int64)
+    u[n:2 * n, 0:n] = _np.identity(n, _np.int64)
     v = _mtx.diagonal_as_vec(_np.dot(_np.dot(_np.transpose(s), u), s))
-    v_matrix = _np.zeros((2 * n, 4), int)
+    v_matrix = _np.zeros((2 * n, 4), _np.int64)
 
     for i in range(0, 4):
         v_matrix[:, i] = v

--- a/test/test_packages/drivers/testCalcMethods1Q.py
+++ b/test/test_packages/drivers/testCalcMethods1Q.py
@@ -659,7 +659,6 @@ class CalcMethods1QTestCase(BaseTestCase):
                     self.assertTrue(False)
         print("Done checking %d sequences!" % len(listOfExperiments))
 
-    @unittest.skip("Temp skip for windows test debugging")
     def test_circuitsim_cterm(self):
         # Density-matrix simulation (of superoperator gates) using stabilizer-based term calcs
         c0 = pygsti.circuits.Circuit(layer_labels=(), num_lines=1) # 1-qubit circuit

--- a/test/test_packages/drivers/testCalcMethods1Q.py
+++ b/test/test_packages/drivers/testCalcMethods1Q.py
@@ -659,6 +659,7 @@ class CalcMethods1QTestCase(BaseTestCase):
                     self.assertTrue(False)
         print("Done checking %d sequences!" % len(listOfExperiments))
 
+    @unittest.skip("Temp skip for windows test debugging")
     def test_circuitsim_cterm(self):
         # Density-matrix simulation (of superoperator gates) using stabilizer-based term calcs
         c0 = pygsti.circuits.Circuit(layer_labels=(), num_lines=1) # 1-qubit circuit


### PR DESCRIPTION
Fixes a number of bugs related to using "int" vs "np.int64" throughout pygsti.  This caused crashed (some exceptions, some segfaults!) on Windows, where using a numpy dtype of "int" specifies a 32-bit integer, conflicting with other uses in pyGSTi of np.int64.  This PR attempts to convert all usages to np.int64, and at least gets all of the unit and system tests to pass on a windows build.