### PR TITLE
Feature add SPAM elements to processor specs

### DIFF
--- a/pygsti/processors/processorspec.py
+++ b/pygsti/processors/processorspec.py
@@ -112,7 +112,9 @@ class QubitProcessorSpec(ProcessorSpec):
     """
 
     def __init__(self, num_qubits, gate_names, nonstd_gate_unitaries=None, availability=None,
-                 geometry=None, qubit_labels=None, nonstd_gate_symplecticreps=None, aux_info=None):
+                 geometry=None, qubit_labels=None, nonstd_gate_symplecticreps=None,
+                 prep_names=('rho0',), povm_names=('Mdefault',), instrument_names=(),
+                 nonstd_preps=None, nonstd_povms=None, nonstd_instruments=None, aux_info=None):
         assert(type(num_qubits) is int), "The number of qubits, n, should be an integer!"
         if nonstd_gate_unitaries is None: nonstd_gate_unitaries = {}
         assert(not (num_qubits > 1 and availability is None and geometry is None)), \
@@ -121,9 +123,14 @@ class QubitProcessorSpec(ProcessorSpec):
         #Store inputs for adding models later
         self.gate_names = tuple(gate_names[:])  # copy & cast to tuple
         self.nonstd_gate_unitaries = nonstd_gate_unitaries.copy() if (nonstd_gate_unitaries is not None) else {}
-        #self.gate_names += list(self.nonstd_gate_unitaries.keys())  # must specify all names in `gate_names`
+        self.prep_names = tuple(prep_names[:])
+        self.nonstd_preps = nonstd_preps.copy() if (nonstd_preps is not None) else {}
+        self.povm_names = tuple(povm_names[:])
+        self.nonstd_povms = nonstd_povms.copy() if (nonstd_povms is not None) else {}
+        self.instrument_names = tuple(instrument_names[:])
+        self.nonstd_instruments = nonstd_instruments.copy() if (nonstd_instruments is not None) else {}
 
-        # Stores the basic unitary matrices defining the gates, as it is convenient to have these easily accessable.
+        # Store the unitary matrices defining the gates, as it is convenient to have these easily accessable.
         self.gate_unitaries = _collections.OrderedDict()
         std_gate_unitaries = _itgs.standard_gatename_unitaries()
         for gname in gate_names:
@@ -157,6 +164,9 @@ class QubitProcessorSpec(ProcessorSpec):
             else:
                 raise ValueError(
                     str(gname) + " is not a valid 'standard' gate name, it must be given in `nonstd_gate_unitaries`")
+
+        # Note: do *not* store the complex vectors defining states, POVM effects, and instrument members
+        # as these can be large n-qubit vectors.
 
         # Set self.qubit_graph
         if geometry is None:
@@ -200,11 +210,44 @@ class QubitProcessorSpec(ProcessorSpec):
         nonstd_unitaries = {k: (obj.to_nice_serialization() if isinstance(obj, _NicelySerializable)
                                 else (int(obj) if isinstance(obj, (int, _np.int64)) else self._encodemx(obj)))
                             for k, obj in self.nonstd_gate_unitaries.items()}
+
+        def _serialize_state(obj):
+            return (obj.to_nice_serialization() if isinstance(obj, _NicelySerializable)
+                    else (obj if isinstance(obj, str) else self._encodemx(obj)))
+
+        def _serialize_povm(obj):
+            if isinstance(obj, _NicelySerializable) or isinstance(obj, str): return obj
+            if isinstance(obj, dict): return {k: _serialize_state(v) for k, v in obj.items()}
+            raise ValueError("Cannot serialize POVM specifier of type %s!" % str(type(obj)))
+
+        def _serialize_instrument_member(obj):
+            if isinstance(obj, _NicelySerializable) or isinstance(obj, str): return obj
+            if isinstance(obj, (list, tuple)):
+                assert(all([isinstance(rank1op_spec, (list, tuple)) and len(rank1op_spec) == 2
+                           for rank1op_spec in obj]))
+                return [(_serialize_state(espec), _serialize_state(rspec)) for espec, rspec in obj]
+            raise ValueError("Cannot serialize Instrument member specifier of type %s!" % str(type(obj)))
+
+        def _serialize_instrument(obj):
+            if isinstance(obj, _NicelySerializable) or isinstance(obj, str): return obj
+            if isinstance(obj, dict): return {k: _serialize_instrument_member(v) for k, v in obj.items()}
+            raise ValueError("Cannot serialize Instrument specifier of type %s!" % str(type(obj)))
+
+        nonstd_preps = {k: _serialize_state(obj) for k, obj in self.nonstd_preps.items()}
+        nonstd_povms = {k: _serialize_povm(obj) for k, obj in self.nonstd_povms.items()}
+        nonstd_instruments = {k: _serialize_instrument(obj) for k, obj in self.nonstd_instruments.items()}
+
         state.update({'qubit_labels': list(self.qubit_labels),
-                      'gate_names': list(self.gate_names),  # TODO: what if labels and not just strings?
-                      'availability': self.availability,  # should just have native types
-                      'geometry': self.qubit_graph.to_nice_serialization(),
+                      'gate_names': list(self.gate_names),  # Note: not labels, just strings, so OK
                       'nonstd_gate_unitaries': nonstd_unitaries,
+                      'availability': self.availability,  # should just have native types
+                      'prep_names': list(self.prep_names),
+                      'nonstd_preps': nonstd_preps,
+                      'povm_names': list(self.povm_names),
+                      'nonstd_povm': nonstd_povms,
+                      'instrument_names': list(self.instrument_names),
+                      'nonstd_instrument': nonstd_instruments,
+                      'geometry': self.qubit_graph.to_nice_serialization(),
                       'symplectic_reps': {k: (self._encodemx(s), self._encodemx(p))
                                           for k, (s, p) in self._symplectic_reps.items()},
                       'aux_info': self.aux_info
@@ -219,6 +262,7 @@ class QubitProcessorSpec(ProcessorSpec):
                 return tuple((_tuplize(el) for el in x))
             return x
 
+        #HERE - need to revamp serialization routines - but first we're working through model construction interface to make sure this pspec approach is good
         nonstd_gate_unitaries = {}
         for k, obj in state['nonstd_gate_unitaries'].items():
             if isinstance(obj, int):
@@ -228,17 +272,118 @@ class QubitProcessorSpec(ProcessorSpec):
             else:  # assume a matrix encoding of some sort (could be list or dict)
                 nonstd_gate_unitaries[k] = cls._decodemx(obj)
 
+        nonstd_preps = {}
+        for k, obj in state['nonstd_preps'].items():
+            if isinstance(obj, str):
+                nonstd_preps[k] = obj
+            elif isinstance(obj, dict) and "module" in obj:  # then a NicelySerializable object
+                nonstd_preps[k] = _NicelySerializable.from_nice_serialization(obj)
+            else:  # assume a matrix encoding of some sort (could be list or dict)
+                nonstd_preps[k] = cls._decodemx(obj)
+
+        nonstd_povms = {}
+        for k, obj in state['nonstd_povms'].items():
+            if isinstance(obj, str):
+                nonstd_povms[k] = obj
+            elif isinstance(obj, dict) and "module" in obj:  # then a NicelySerializable object
+                nonstd_povms[k] = _NicelySerializable.from_nice_serialization(obj)
+            else:  # assume a matrix encoding of some sort (could be list or dict)
+                nonstd_povms[k] = cls._decodemx(obj)
+
+        nonstd_instruments = {}
+        for k, obj in state['nonstd_instruments'].items():
+            if isinstance(obj, str):
+                nonstd_instruments[k] = obj
+            elif isinstance(obj, dict) and "module" in obj:  # then a NicelySerializable object
+                nonstd_instruments[k] = _NicelySerializable.from_nice_serialization(obj)
+            else:  # assume a matrix encoding of some sort (could be list or dict)
+                nonstd_instruments[k] = cls._decodemx(obj)
+
         symplectic_reps = {k: (cls._decodemx(s), cls._decodemx(p)) for k, (s, p) in state['symplectic_reps'].items()}
         availability = {k: _tuplize(v) for k, v in state['availability'].items()}
         geometry = _qgraph.QubitGraph.from_nice_serialization(state['geometry'])
 
         return cls(len(state['qubit_labels']), state['gate_names'], nonstd_gate_unitaries, availability,
-                   geometry, state['qubit_labels'], symplectic_reps, state['aux_info'])
+                   geometry, state['qubit_labels'], symplectic_reps, state['prep_names'], state['povm_names'],
+                   state['instrument_names'], nonstd_preps, nonstd_povms, nonstd_instruments, state['aux_info'])
 
     @property
     def num_qubits(self):
         """ The number of qubits. """
         return len(self.qubit_labels)
+
+    def prep_specifier(self, name):
+        """
+        The specifier for a given state preparation name.
+
+        The returned value specifies a state in one of several ways.  It can
+        either be a string identifying a standard state preparation (like `"rho0"`),
+        or a complex array describing a pure state.
+
+        Parameters
+        ----------
+        name : str
+            The name of the state preparation to access.
+
+        Returns
+        -------
+        str or numpy.ndarray
+        """
+        if name in self.nonstd_preps:
+            return self.nonstd_preps[name]
+        else:
+            # assert(is_standard_prep_name(name)) TODO
+            return name
+
+    def povm_specifier(self, name):
+        """
+        The specifier for a given POVM name.
+
+        The returned value specifies a POVM in one of several ways.  It can
+        either be a string identifying a standard POVM (like `"Mz"`),
+        or a dictionary with values describing the pure states that each element
+        of the POVM projects onto.  Each value can be either a string describing
+        a standard state or a complex array.
+
+        Parameters
+        ----------
+        name : str
+            The name of the POVM to access.
+
+        Returns
+        -------
+        str or numpy.ndarray
+        """
+        if name in self.nonstd_povms:
+            return self.nonstd_povms[name]
+        else:
+            # assert(is_standard_povm_name(name)) TODO
+            return name
+
+    def instrument_specifier(self, name):
+        """
+        The specifier for a given instrument name.
+
+        The returned value specifies an instrument in one of several ways.  It can
+        either be a string identifying a standard instrument (like `"Iz"`),
+        or a dictionary with values that are lists/tuples of 2-tuples describing each instrument
+        member as the sum of rank-1 process matrices.  Each 2-tuple element can be a
+        string describing a standard state or a complex array describing an arbitrary pure state.
+
+        Parameters
+        ----------
+        name : str
+            The name of the state preparation to access.
+
+        Returns
+        -------
+        str or dict
+        """
+        if name in self.nonstd_instruments:
+            return self.nonstd_instruments[name]
+        else:
+            # assert(is_standard_instrument_name(name)) TODO
+            return name
 
     @property
     def primitive_op_labels(self):

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1221,7 +1221,6 @@ class GateSetTomography(_proto.Protocol):
         tnxt = _time.time(); profiler.add_time('GST: loading', tref); tref = tnxt
         mdl_start = self.initial_model.retrieve_model(data.edesign, self.gaugeopt_suite.gaugeopt_target,
                                                       data.dataset, comm)
-        hack_mdl_start_copy = mdl_start.copy()  # HACK TODO REMOVE LATER - in case edesign can't make a target model
 
         tnxt = _time.time(); profiler.add_time('GST: Prep Initial seed', tref); tref = tnxt
 
@@ -1253,12 +1252,7 @@ class GateSetTomography(_proto.Protocol):
             target_model = self.gaugeopt_suite.gaugeopt_target
         elif self.gaugeopt_suite.is_empty() is False:
             if isinstance(data.edesign, HasProcessorSpec):
-                try:
-                    target_model = data.edesign.create_target_model()
-                except:
-                    _warnings.warn(("Could not create target model for gauge opt. from edesign"
-                                    " - falling back to initial model!"))
-                    target_model = hack_mdl_start_copy
+                target_model = data.edesign.create_target_model()
             else:
                 target_model = None
         else:

--- a/test/unit/construction/test_modelconstruction.py
+++ b/test/unit/construction/test_modelconstruction.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy
 import unittest
+import itertools
 from functools import reduce
 
 import pygsti
@@ -13,6 +14,11 @@ import pygsti.tools.basistools as bt
 from pygsti.processors.processorspec import QubitProcessorSpec as _ProcessorSpec
 from pygsti.baseobjs.errorgenlabel import GlobalElementaryErrorgenLabel as GEEL
 from ..util import BaseCase
+
+
+def save_and_load_pspec(pspec):
+    s = pspec.dumps()
+    return pygsti.processors.QubitProcessorSpec.loads(s)
 
 
 class ModelConstructionTester(BaseCase):
@@ -453,6 +459,142 @@ class ModelConstructionTester(BaseCase):
             mc.create_explicit_model_from_expressions([('Q0',)], ['Gi', 'Gx', 'Gy'],
                                                       ["I(Q0)", "X(pi/8,Q0)", "Y(pi/8,Q0)"],
                                                       effect_labels=['0', '1'], effect_expressions=["FooBar", "1"])
+
+    def test_default_spam_in_processorspecs(self):
+        pspec_defaults = pygsti.processors.QubitProcessorSpec(4, ['Gxpi2', 'Gypi2'], geometry='line')
+        pspec_defaults = save_and_load_pspec(pspec_defaults)  # make sure serialization works too
+
+        self.assertEqual(pspec_defaults.prep_names, ('rho0',))
+        self.assertEqual(pspec_defaults.povm_names, ('Mdefault',))
+
+        mdl_default = pygsti.models.modelconstruction.create_crosstalk_free_model(pspec_defaults)
+
+        all4Qoutcomes = list(map(lambda x: ''.join(x), itertools.product(['0','1'], repeat=4)))
+        self.assertArraysAlmostEqual(mdl_default.prep_blks['layers']['rho0']._zvals, [0, 0, 0, 0])
+        self.assertEqual(list(mdl_default.povm_blks['layers']['Mdefault'].keys()), all4Qoutcomes)
+
+        mdl_default_explicit = pygsti.models.modelconstruction.create_explicit_model(pspec_defaults)
+        self.assertArraysAlmostEqual(mdl_default_explicit.preps['rho0']._zvals, [0, 0, 0, 0])
+        self.assertEqual(list(mdl_default_explicit.povms['Mdefault'].keys()), all4Qoutcomes)
+
+        mdl_default_cloud = pygsti.models.modelconstruction.create_cloud_crosstalk_model(pspec_defaults)
+        self.assertArraysAlmostEqual(mdl_default_cloud.prep_blks['layers']['rho0']._zvals, [0, 0, 0, 0])
+        self.assertEqual(list(mdl_default_cloud.povm_blks['layers']['Mdefault'].keys()), all4Qoutcomes)
+
+    def test_named_spam_in_processorspecs(self):
+        pspec_names = pygsti.processors.QubitProcessorSpec(4, ['Gxpi2', 'Gypi2'], geometry='line',
+                                                           prep_names=("rho1", "rho_1100"), povm_names=("Mz",))
+        pspec_names = save_and_load_pspec(pspec_names)  # make sure serialization works too
+
+        self.assertEqual(pspec_names.prep_names, ('rho1', 'rho_1100'))
+        self.assertEqual(pspec_names.povm_names, ('Mz',))
+
+        mdl_names = pygsti.models.modelconstruction.create_crosstalk_free_model(pspec_names)
+
+        all4Qoutcomes = list(map(lambda x: ''.join(x), itertools.product(['0','1'], repeat=4)))
+        self.assertArraysAlmostEqual(mdl_names.prep_blks['layers']['rho1']._zvals, [0, 0, 0, 1])
+        self.assertArraysAlmostEqual(mdl_names.prep_blks['layers']['rho_1100']._zvals, [1, 1, 0, 0])
+        self.assertEqual(list(mdl_names.povm_blks['layers']['Mz'].keys()), all4Qoutcomes)
+
+    def test_spamvecs_in_processorspecs(self):
+        prep_vec = np.zeros(2**4, complex)
+        prep_vec[4] = 1.0
+        EA = np.zeros(2**4, complex)
+        EA[14] = 1.0
+        EB = np.zeros(2**4, complex)
+        EB[15] = 1.0
+
+        pspec_vecs = pygsti.processors.QubitProcessorSpec(4, ['Gxpi2', 'Gypi2'], geometry='line',
+                                                          prep_names=("rhoA", "rhoC"), povm_names=("Ma", "Mc"),
+                                                          nonstd_preps={'rhoA': "rho0", 'rhoC': prep_vec},
+                                                          nonstd_povms={'Ma': {'0': "0000", '1': EA},
+                                                                        'Mc': {'OutA': "0000", 'OutB': [EA, EB]}})
+        pspec_vecs = save_and_load_pspec(pspec_vecs)  # make sure serialization works too
+
+        self.assertEqual(pspec_vecs.prep_names, ('rhoA', 'rhoC'))
+        self.assertEqual(pspec_vecs.povm_names, ('Ma','Mc'))
+
+        mdl_vecs = pygsti.models.modelconstruction.create_crosstalk_free_model(pspec_vecs, ideal_spam_type='full TP')
+
+        from pygsti.tools import state_to_dmvec, change_basis
+        prep_supervec = change_basis(state_to_dmvec(prep_vec), 'std', 'pp')
+        prep0_vec = np.zeros(2**4, complex); prep0_vec[0] = 1.0
+        prep0_supervec = change_basis(state_to_dmvec(prep0_vec), 'std', 'pp')
+
+        self.assertArraysAlmostEqual(mdl_vecs.prep_blks['layers']['rhoA'].to_dense(), prep0_supervec)
+        self.assertArraysAlmostEqual(mdl_vecs.prep_blks['layers']['rhoC'].to_dense(), prep_supervec)
+
+        self.assertEqual(list(mdl_vecs.povm_blks['layers']['Ma'].keys()), ['0', '1'])
+        self.assertEqual(list(mdl_vecs.povm_blks['layers']['Mc'].keys()), ['OutA', 'OutB'])
+
+        def Zeffect(index):
+            v = np.zeros(2**4, complex); v[index] = 1.0
+            return change_basis(state_to_dmvec(v), 'std', 'pp')
+
+        self.assertArraysAlmostEqual(mdl_vecs.povm_blks['layers']['Ma']['0'].to_dense(), Zeffect(0))
+        self.assertArraysAlmostEqual(mdl_vecs.povm_blks['layers']['Ma']['1'].to_dense(), Zeffect(14))
+
+        self.assertArraysAlmostEqual(mdl_vecs.povm_blks['layers']['Mc']['OutA'].to_dense(), Zeffect(0))
+        self.assertArraysAlmostEqual(mdl_vecs.povm_blks['layers']['Mc']['OutB'].to_dense(), Zeffect(14) + Zeffect(15))
+
+    def test_instruments_in_processorspecs(self):
+        #Instruments
+        pspec_with_instrument = pygsti.processors.QubitProcessorSpec(4, ['Gxpi2', 'Gypi2'], geometry='line',
+                                                                     instrument_names=('Iz',))
+        mdl_default_explicit = pygsti.models.modelconstruction.create_explicit_model(pspec_with_instrument)
+
+        all4Qoutcomes = list(map(lambda x: ''.join(x), itertools.product(['0','1'], repeat=4)))
+        self.assertEqual(list(mdl_default_explicit.instruments['Iz'].keys()), all4Qoutcomes)
+
+        pspec_with_instrument2 = pygsti.processors.QubitProcessorSpec(
+            2, ['Gxpi2', 'Gypi2'], geometry='line', instrument_names=('Iparity',),
+            nonstd_instruments={'Iparity': {'plus': [('00', '00'), ('11','11')],
+                                            'minus': [('10', '10'), ('01','01')]}})
+        mdl_default_explicit2 = pygsti.models.modelconstruction.create_explicit_model(pspec_with_instrument2)
+        self.assertEqual(list(mdl_default_explicit2.instruments['Iparity']), ['plus', 'minus'])
+
+        from pygsti.tools import state_to_dmvec, change_basis
+
+        def Ivec(index):
+            v = np.zeros(2**2, complex); v[index] = 1.0
+            return v
+
+        def Isupervec(index):
+            return change_basis(state_to_dmvec(Ivec(index)), 'std', 'pp')
+
+        sv00 = Isupervec(0)
+        sv01 = Isupervec(1)
+        sv10 = Isupervec(2)
+        sv11 = Isupervec(3)
+        Iplus = np.outer(sv00, sv00) + np.outer(sv11, sv11)
+        Iminus = np.outer(sv01, sv01) + np.outer(sv10, sv10)
+        Itot = Iplus + Iminus
+        self.assertAlmostEqual(Itot[0,0], 1.0)
+        self.assertArraysAlmostEqual(mdl_default_explicit2.instruments['Iparity']['plus'].to_dense(), Iplus)
+        self.assertArraysAlmostEqual(mdl_default_explicit2.instruments['Iparity']['minus'].to_dense(), Iminus)
+        
+        
+        # In[14]:
+        
+        
+        v00 = Ivec(0)
+        v01 = Ivec(1)
+        v10 = Ivec(2)
+        v11 = Ivec(3)
+        
+        pspec_with_instrument3 = pygsti.processors.QubitProcessorSpec(
+            2, ['Gxpi2', 'Gypi2'], geometry='line', instrument_names=('Iparity',),
+            nonstd_instruments={'Iparity': {'plus': [(v00, v00), (v11,v11)],
+                                            'minus': [(v10, v10), (v01,v01)]}})
+        mdl_default_explicit3 = pygsti.models.modelconstruction.create_explicit_model(pspec_with_instrument3)
+        self.assertEqual(list(mdl_default_explicit3.instruments['Iparity']), ['plus', 'minus'])
+        
+        self.assertArraysAlmostEqual(mdl_default_explicit3.instruments['Iparity']['plus'].to_dense(), Iplus)
+        self.assertArraysAlmostEqual(mdl_default_explicit3.instruments['Iparity']['minus'].to_dense(), Iminus)
+
+
+
+
 
 
 class GateConstructionBase(object):


### PR DESCRIPTION
Adds SPAM and instrument elements to the `QubitProcessorSpec` class, allowing processor specifications to specify more than just the available gates API.

This is particularly useful for working with models that have non-default SPAM (and/or instrument) elements, as these elements should now be able to be captured by the processor spec and therefore held within an experiment design as needed (e.g. for running GST).