### PR TITLE
Bugfix hessian projection

### DIFF
--- a/pygsti/algorithms/gaugeopt.py
+++ b/pygsti/algorithms/gaugeopt.py
@@ -304,7 +304,7 @@ def gaugeopt_custom(model, objective_fn, gauge_group=None,
     else:
         _call_jacobian_fn = None
 
-    printer.log("--- Gauge Optimization (%s method) ---" % method, 2)
+    printer.log("--- Gauge Optimization (%s method, %s) ---" % (method, str(type(gauge_group))), 2)
     if method == 'ls':
         #minSol  = _opt.least_squares(_call_objective_fn, x0, #jac=_call_jacobian_fn,
         #                            max_nfev=maxfev, ftol=tol)

--- a/pygsti/evotypes/densitymx/opreps.pyx
+++ b/pygsti/evotypes/densitymx/opreps.pyx
@@ -177,7 +177,7 @@ cdef class OpRepStandard(OpRepDenseSuperop):
         self.basis = basis
 
         U = std_unitaries[self.name]
-        superop = _bt.change_basis(_ot.unitary_to_process_mx(U), 'std', basis)
+        superop = _ot.unitary_to_superop(U, basis)
         state_space = _StateSpace.cast(state_space)
         assert(superop.shape[0] == state_space.dim)
 

--- a/pygsti/evotypes/densitymx_slow/opreps.py
+++ b/pygsti/evotypes/densitymx_slow/opreps.py
@@ -129,7 +129,7 @@ class OpRepStandard(OpRepDenseSuperop):
             raise ValueError("Name '%s' not in standard unitaries" % self.name)
 
         U = std_unitaries[self.name]
-        superop = _bt.change_basis(_ot.unitary_to_process_mx(U), 'std', basis)
+        superop = _ot.unitary_to_superop(U, basis)
         state_space = _StateSpace.cast(state_space)
         assert(superop.shape[0] == state_space.dim)
 

--- a/pygsti/evotypes/stabilizer/opreps.pyx
+++ b/pygsti/evotypes/stabilizer/opreps.pyx
@@ -104,7 +104,7 @@ cdef class OpRepClifford(OpRep):
         if on_space in ('minimal', 'Hilbert'):
             return self.unitary
         elif on_space == 'HilbertSchmidt':
-            return _bt.change_basis(_ot.unitary_to_process_mx(self.unitary), 'std', self.basis)
+            return _ot.unitary_to_superop(self.unitary, self.basis)
         else:
             raise ValueError("Invalid `on_space` argument: %s" % str(on_space))
 

--- a/pygsti/evotypes/statevec/opreps.pyx
+++ b/pygsti/evotypes/statevec/opreps.pyx
@@ -95,7 +95,7 @@ cdef class OpRepDenseUnitary(OpRep):
         if on_space in ('minimal', 'Hilbert'):
             return self.base
         elif on_space == 'HilbertSchmidt':
-            return _bt.change_basis(_ot.unitary_to_process_mx(self.base), 'std', self.basis)
+            return _ot.unitary_to_superop(self.base, self.basis)
         else:
             raise ValueError("Invalid `on_space` argument: %s" % str(on_space))
 

--- a/pygsti/evotypes/statevec_slow/opreps.py
+++ b/pygsti/evotypes/statevec_slow/opreps.py
@@ -71,7 +71,7 @@ class OpRepDenseUnitary(OpRep):
         if on_space in ('minimal', 'Hilbert'):
             return self.base
         elif on_space == 'HilbertSchmidt':
-            return _bt.change_basis(_ot.unitary_to_process_mx(self.base), 'std', self.basis)
+            return _ot.unitary_to_superop(self.base, self.basis)
         else:
             raise ValueError("Invalid `on_space` argument: %s" % str(on_space))
 

--- a/pygsti/io/stdinput.py
+++ b/pygsti/io/stdinput.py
@@ -1148,11 +1148,11 @@ def parse_model(filename):
 
         elif prefix + "UnitaryMx" in props:
             ar = _eval_row_list(props[prefix + "UnitaryMx"], b_complex=True)
-            lmx = _tools.change_basis(_tools.unitary_to_process_mx(ar), 'std', basis)
+            lmx = _tools.unitary_to_superop(ar, basis)
 
         elif prefix + "UnitaryMxExp" in props:
             ar = _eval_row_list(props[prefix + "UnitaryMxExp"], b_complex=True)
-            lmx = _tools.change_basis(_tools.unitary_to_process_mx(_expm(-1j * ar)), 'std', basis)
+            lmx = _tools.unitary_to_superop(_expm(-1j * ar), basis)
 
         elif prefix + "LiouvilleMx" in props:
             lmx = _eval_row_list(props[prefix + "LiouvilleMx"], b_complex=False)

--- a/pygsti/modelmembers/operations/__init__.py
+++ b/pygsti/modelmembers/operations/__init__.py
@@ -59,7 +59,7 @@ def create_from_unitary_mx(unitary_mx, op_type, basis='pp', stdname=None, evotyp
             elif typ == "full unitary":
                 op = FullUnitaryOp(U, basis, evotype, state_space)
             elif typ in ('static', 'full', 'full TP', 'linear'):
-                superop_mx = _bt.change_basis(_ot.unitary_to_process_mx(U), 'std', basis)
+                superop_mx = _ot.unitary_to_superop(U, basis)
                 op = create_from_superop_mx(superop_mx, op_type, basis, stdname, evotype, state_space)
             elif _ot.is_valid_lindblad_paramtype(typ):  # maybe "lindblad XXX" where XXX is a valid lindblad type?
                 if _np.allclose(U, _np.identity(U.shape[0], 'd')):
@@ -78,7 +78,7 @@ def create_from_unitary_mx(unitary_mx, op_type, basis='pp', stdname=None, evotyp
                     else ComposedOp([unitary_postfactor, ExpErrorgenOp(errorgen)])
 
                 if op.dim <= 16:  # only do this for up to 2Q operations, otherwise to_dense is too expensive
-                    expected_superop_mx = _bt.change_basis(_ot.unitary_to_process_mx(U), 'std', basis)
+                    expected_superop_mx = _ot.unitary_to_superop(U, basis)
                     assert (_np.linalg.norm(op.to_dense('HilbertSchmidt') - expected_superop_mx) < 1e-6), \
                         "Failure to create Lindblad operation (maybe due the complex log's branch cut?)"
             else:

--- a/pygsti/modelmembers/operations/denseop.py
+++ b/pygsti/modelmembers/operations/denseop.py
@@ -427,7 +427,7 @@ class DenseUnitaryOperator(DenseOperatorInterface, _LinearOperator):
                 # Special case when a *superop* was provided instead of a unitary mx
                 superop_mx = mx.real  # used as a convenience case that really shouldn't be used
             else:
-                superop_mx = _bt.change_basis(_ot.unitary_to_process_mx(mx), 'std', basis)
+                superop_mx = _ot.unitary_to_superop(mx, basis)
             rep = evotype.create_dense_superop_rep(superop_mx, state_space)
             self._reptype = 'superop'
             self._unitary = mx
@@ -445,7 +445,7 @@ class DenseUnitaryOperator(DenseOperatorInterface, _LinearOperator):
         """ Derived classes should override this function to handle rep updates
             when the `_ptr` property is changed. """
         if self._reptype == 'superop':
-            self._rep.base[:, :] = _bt.change_basis(_ot.unitary_to_process_mx(self._unitary), 'std', self._basis)
+            self._rep.base[:, :] = _ot.unitary_to_superop(self._unitary, self._basis)
         self._rep.base_has_changed()
 
     def to_dense(self, on_space='minimal'):

--- a/pygsti/modelmembers/operations/fullunitaryop.py
+++ b/pygsti/modelmembers/operations/fullunitaryop.py
@@ -199,10 +199,10 @@ class FullUnitaryOp(_DenseUnitaryOperator):
             U = s.transform_matrix
             Uinv = s.transform_matrix_inverse
 
-            my_superop_mx = _bt.change_basis(_ot.unitary_to_process_mx(self._ptr), 'std', self._basis)  # to_dense()?
+            my_superop_mx = _ot.unitary_to_superop(self._ptr, self._basis)
             my_superop_mx = _mt.safe_dot(Uinv, _mt.safe_dot(my_superop_mx, U))
 
-            self._ptr[:, :] = _ot.process_mx_to_unitary(_bt.change_basis(my_superop_mx, self._basis, 'std'))
+            self._ptr[:, :] = _ot.superop_to_unitary(my_superop_mx, self._basis)
             self._ptr_has_changed()
             self.dirty = True
         else:
@@ -246,7 +246,7 @@ class FullUnitaryOp(_DenseUnitaryOperator):
             U = s.transform_matrix
             Uinv = s.transform_matrix_inverse
 
-            my_superop_mx = _bt.change_basis(_ot.unitary_to_process_mx(self._ptr), 'std', self._basis)  # to_dense()?
+            my_superop_mx = _ot.unitary_to_superop(self._ptr, self._basis)
 
             #Note: this code may need to be tweaked to work with sparse matrices
             if typ == "prep":
@@ -254,7 +254,7 @@ class FullUnitaryOp(_DenseUnitaryOperator):
             else:
                 my_superop_mx = _mt.safe_dot(my_superop_mx, U)
 
-            self._ptr[:, :] = _ot.process_mx_to_unitary(_bt.change_basis(my_superop_mx, self._basis, 'std'))
+            self._ptr[:, :] = _ot.superop_to_unitary(my_superop_mx, self._basis)
             self._ptr_has_changed()
             self.dirty = True
         else:

--- a/pygsti/modelmembers/operations/opfactory.py
+++ b/pygsti/modelmembers/operations/opfactory.py
@@ -822,8 +822,8 @@ class UnitaryOpFactory(OpFactory):
         assert(sslbls is None), "UnitaryOpFactory.create_object must be called with `sslbls=None`!"
         U = self.fn(args)
 
-        # Expanded call to _bt.change_basis(_ot.unitary_to_process_mx(U), 'std', self.basis) for speed
-        std_superop = _ot.unitary_to_process_mx(U)
+        # Expanded call to _bt.change_basis(_ot.unitary_to_std_process_mx(U), 'std', self.basis) for speed
+        std_superop = _ot.unitary_to_std_process_mx(U)
         superop_mx = _np.dot(self.transform_std_to_basis, _np.dot(std_superop, self.transform_basis_to_std))
         if self.basis.real:
             assert(_np.linalg.norm(superop_mx.imag) < 1e-8)

--- a/pygsti/models/explicitcalc.py
+++ b/pygsti/models/explicitcalc.py
@@ -624,7 +624,8 @@ class ExplicitOpModelCalc(object):
         assert(nongauge_space.shape[0] == gauge_space.shape[0] == nongauge_space.shape[1] + gauge_space.shape[1])
         return nongauge_space, gauge_space
 
-    def gauge_orbit_curvature(self, item_weights=None, non_gauge_mix_mx=None):
+    #UNUSED - just used for checking understanding of where the nonzero logL Hessian on gauge space comes from.
+    def _gauge_orbit_curvature(self, item_weights=None, non_gauge_mix_mx=None):
 
         nParams = self.Np
         dPG = self._buildup_dpg()

--- a/pygsti/models/explicitcalc.py
+++ b/pygsti/models/explicitcalc.py
@@ -473,7 +473,7 @@ class ExplicitOpModelCalc(object):
         # effect vecs, which is historically what we've done, even though
         # this seems somewhat wrong.  Not skipping them will alter the
         # number of "gauge params" since a complement Evec has a *fixed*
-        # identity from the perspective of the Model params (which
+        # identity from the perspective of the Model params (which are
         # *varied* in gauge optimization, even though it's not a POVMEffect
         # param, creating a weird inconsistency...) SKIP
         if bSkipEcs:
@@ -503,16 +503,16 @@ class ExplicitOpModelCalc(object):
         ## elements, they are treated as not being a part of the "model"
         #bIgnoreUnparameterizedEls = True
 
-        #Note: model object (gsDeriv) must have all elements of gate
+        #Note: model object (mdlDeriv) must have all elements of gate
         # mxs and spam vectors as parameters (i.e. be "fully parameterized") in
         # order to match deriv_wrt_params call, which gives derivatives wrt
         # *all* elements of a model.
 
         mdlDeriv_ops = _collections.OrderedDict(
             [(label, _np.zeros((dim, dim), 'd')) for label in self_operations])
-        gsDeriv_preps = _collections.OrderedDict(
+        mdlDeriv_preps = _collections.OrderedDict(
             [(label, _np.zeros((dim, 1), 'd')) for label in self_preps])
-        gsDeriv_effects = _collections.OrderedDict(
+        mdlDeriv_effects = _collections.OrderedDict(
             [(label, _np.zeros((dim, 1), 'd')) for label in self_effects])
 
         dPG = _np.empty((nElements, nParams + dim**2), 'd')
@@ -520,9 +520,9 @@ class ExplicitOpModelCalc(object):
             for j in range(dim):  # *generator* mx, not gauge mx itself
                 unitMx = _bc.mut(i, j, dim)
                 for lbl, rhoVec in self_preps.items():
-                    gsDeriv_preps[lbl] = _np.dot(unitMx, rhoVec)
+                    mdlDeriv_preps[lbl] = _np.dot(unitMx, rhoVec)
                 for lbl, EVec in self_effects.items():
-                    gsDeriv_effects[lbl] = -_np.dot(EVec.T, unitMx).T
+                    mdlDeriv_effects[lbl] = -_np.dot(EVec.T, unitMx).T
 
                 for lbl, gate in self_operations.items():
                     #if isinstance(gate,_op.DenseOperator):
@@ -546,12 +546,161 @@ class ExplicitOpModelCalc(object):
                 # equal to the number of model *elements*.
                 to_vector = _np.concatenate(
                     [obj.flatten() for obj in _itertools.chain(
-                        gsDeriv_preps.values(), gsDeriv_effects.values(),
+                        mdlDeriv_preps.values(), mdlDeriv_effects.values(),
                         mdlDeriv_ops.values())], axis=0)
                 dPG[:, nParams + i * dim + j] = to_vector
 
         dPG[:, 0:nParams] = self.deriv_wrt_params()
         return dPG
+
+    def nongauge_and_gauge_spaces(self, item_weights=None, non_gauge_mix_mx=None):
+        nParams = self.Np
+        dPG = self._buildup_dpg()
+
+        #print("DB: shapes = ",dP.shape,dG.shape)
+        nullsp = _mt.nullspace_qr(dPG)  # columns are nullspace basis vectors
+        gauge_space = nullsp[0:nParams, :]  # take upper (gate-param-segment) of vectors for basis
+        # of subspace intersection in gate-parameter space
+        #Note: gauge_space is (nParams)x(nullSpaceDim==gaugeSpaceDim)
+
+        # Build final non-gauge space by getting a mx of column vectors
+        # orthogonal (w.r.t. some metric) to the cols of gauge_space:
+        #     gauge_space^T @ metric @ nongauge_space = 0
+        #       => nongauge_space = nullspace(gauge_space^T @ metric)
+        #                         = nullspace(orthog_to^T) below
+
+        if non_gauge_mix_mx is not None:
+            msg = "You've set both non_gauge_mix_mx and item_weights, both of which"\
+                + " set the gauge metric... You probably don't want to do this."
+            assert(item_weights is None), msg
+
+            # BEGIN GAUGE MIX ----------------------------------------
+            # Let metric^T = I + mix_gauge_to_nongauge so
+            # orthog_to = metric^T @ gauge_space
+            #           = gauge_space + mix_gauge_to_nongauge @ gauge_space
+            #           = gauge_space + nongauge_directions @ nongauge_mix_mx
+            #
+            # where the last line is motivated by the fact that we don't change the space we're
+            # orthogonalizing with respect to if we just add gauge directions.
+            nonGaugeDirections = _mt.nullspace_qr(gauge_space.T)
+
+            #for each column of gen_dG, which is a gauge direction in model parameter space,
+            # we add some amount of non-gauge direction, given by coefficients of the
+            # numNonGaugeParams non-gauge directions.
+            orthog_to = gauge_space + _np.dot(nonGaugeDirections, non_gauge_mix_mx)  # add non-gauge components in
+            # dims: (nParams,n_gauge_params) + (nParams,n_non_gauge_params) * (n_non_gauge_params,n_gauge_params)
+            # non_gauge_mix_mx is a (n_non_gauge_params,n_gauge_params) matrix whose i-th column specifies the
+            #  coefficents to multipy each of the non-gauge directions by before adding them to the i-th
+            #  direction to project out (i.e. what were the pure gauge directions).
+
+        elif item_weights is not None:
+            metric_diag = _np.ones(self.Np, 'd')
+            opWeight = item_weights.get('gates', 1.0)
+            spamWeight = item_weights.get('spam', 1.0)
+            for lbl, gate in self.operations.items():
+                metric_diag[gate.gpindices] = item_weights.get(lbl, opWeight)
+            for lbl, vec in _itertools.chain(iter(self.preps.items()),
+                                             iter(self.effects.items())):
+                metric_diag[vec.gpindices] = item_weights.get(lbl, spamWeight)
+            metric = _np.diag(metric_diag)
+            #OLD: gen_ndG = _mt.nullspace(_np.dot(gen_dG.T,metric))
+            orthog_to = _np.dot(metric.T, gauge_space)
+
+        else:
+            orthog_to = gauge_space
+
+        #OLD: nongauge_space = _mt.nullspace(orthog_to.T) #cols are non-gauge directions
+        nongauge_space = _mt.nullspace_qr(orthog_to.T)  # cols are non-gauge directions
+        # print("DB: nullspace of gen_dG (shape = %s, rank=%d) = %s" \
+        #       % (str(gen_dG.shape),_np.linalg.matrix_rank(gen_dG),str(gen_ndG.shape)))
+
+        #REMOVE
+        ## reduce gen_dG if it doesn't have full rank
+        #u, s, vh = _np.linalg.svd(gen_dG, full_matrices=False)
+        #rank = _np.count_nonzero(s > P_RANK_TOL)
+        #if rank < gen_dG.shape[1]:
+        #    gen_dG = u[:, 0:rank]
+
+        assert(nongauge_space.shape[0] == gauge_space.shape[0] == nongauge_space.shape[1] + gauge_space.shape[1])
+        return nongauge_space, gauge_space
+
+    def gauge_orbit_curvature(self, item_weights=None, non_gauge_mix_mx=None):
+
+        nParams = self.Np
+        dPG = self._buildup_dpg()
+        nongauge_space, gauge_space = self.nongauge_and_gauge_spaces(item_weights, non_gauge_mix_mx)
+
+        #Fill Heps == hessian d2/d(eps_j)d(eps_i) exp(sum(eps_k unit_k)) G exp(-sum(eps_k unit_k)) for ops, etc.
+        from ..modelmembers.povms.complementeffect import ComplementPOVMEffect as _ComplementPOVMEffect
+        on_space = 'minimal'
+        try:
+            self_operations = _collections.OrderedDict([(lbl, gate.to_dense(on_space=on_space))
+                                                        for lbl, gate in self.operations.items()])
+            self_preps = _collections.OrderedDict([(lbl, vec.to_dense(on_space=on_space)[:, None])
+                                                   for lbl, vec in self.preps.items()])
+            self_effects = _collections.OrderedDict([(lbl, vec.to_dense(on_space=on_space)[:, None])
+                                                     for lbl, vec in self.effects.items()])
+        except:
+            raise NotImplementedError(("Cannot (yet) extract gauge/non-gauge "
+                                       "parameters for Models with non-dense "
+                                       "member representations"))
+
+        bSkipEcs = True  # see above
+        if bSkipEcs:
+            newSelf = self.copy()
+            newSelf.effects = self.effects.copy()  # b/c ForwardSimulator.__init__ doesn't copy members (for efficiency)
+            for effectlbl, EVec in self.effects.items():
+                if isinstance(EVec, _ComplementPOVMEffect):
+                    del newSelf.effects[effectlbl]
+            self = newSelf  # HACK!!! replacing self for remainder of this fn with version without Ecs
+
+            #recompute effects in case we deleted any ComplementPOVMEffects
+            self_effects = _collections.OrderedDict([(lbl, vec.to_dense(on_space=on_space)[:, None])
+                                                     for lbl, vec in self.effects.items()])
+
+        #Use a Model object to hold & then vectorize the derivatives wrt each gauge transform basis element (each ij)
+        dim = self.dim
+        nParams = self.Np
+
+        nElements = sum([obj.hilbert_schmidt_size for _, obj in self.all_objects()])
+        mdlHess_ops = _collections.OrderedDict(
+            [(label, _np.zeros((dim, dim), 'd')) for label in self_operations])
+        mdlHess_preps = _collections.OrderedDict(
+            [(label, _np.zeros((dim, 1), 'd')) for label in self_preps])
+        mdlHess_effects = _collections.OrderedDict(
+            [(label, _np.zeros((dim, 1), 'd')) for label in self_effects])
+
+        Heps = _np.empty((nElements, dim**2, dim**2), 'd')  # dim**2 == num of gauge "units"
+        for i1 in range(dim):      # always range over all rows: this is the
+            for i2 in range(dim):      # always range over all rows: this is the
+                unitMx_i = _bc.mut(i1, i2, dim)
+                for j1 in range(dim):  # *generator* mx, not gauge mx itself
+                    for j2 in range(dim):  # *generator* mx, not gauge mx itself
+                        unitMx_j = _bc.mut(j1, j2, dim)
+                        antiComm = (unitMx_i @ unitMx_j + unitMx_j @ unitMx_i)
+                        for lbl, rhoVec in self_preps.items():
+                            mdlHess_preps[lbl] = 0.5 * _np.dot(antiComm, rhoVec)
+                        for lbl, EVec in self_effects.items():
+                            mdlHess_effects[lbl] = 0.5 * _np.dot(EVec.T, antiComm).T
+                        for lbl, gate in self_operations.items():
+                            mdlHess_ops[lbl] = 0.5 * (antiComm @ gate + gate @ antiComm) \
+                                - unitMx_i @ gate @ unitMx_j - unitMx_j @ gate @ unitMx_i
+
+                        to_vector = _np.concatenate(
+                            [obj.flatten() for obj in _itertools.chain(
+                                mdlHess_preps.values(), mdlHess_effects.values(),
+                                mdlHess_ops.values())], axis=0)
+                        Heps[:, i1 * dim + i2, j1 * dim + j2] = to_vector
+
+        paramspace_to_elspace = dPG[:, 0:nParams]
+        nongauge_to_elspace = paramspace_to_elspace @ nongauge_space
+        elspace_to_nongauge = _np.linalg.pinv(nongauge_to_elspace)
+        physHeps = _np.einsum('kij,lk->lij', Heps, elspace_to_nongauge)
+
+        T = _mt.nullspace_qr(dPG)[nParams:, :]  # cols = gauge directions in eps space (gauge -> eps)
+        # coord change physHeps from eps => gauge = invT @ eps, so H => T.T @ H @ T
+        Q = _np.einsum('ik,jkl,lm->jim', T.T, physHeps, T)  # ~ inv(T) @ physHeps @ T
+        return Q
 
     def nongauge_projector(self, item_weights=None, non_gauge_mix_mx=None):
         """
@@ -648,86 +797,7 @@ class ExplicitOpModelCalc(object):
         #
         #   Still, we just substitue these dParams_ij vectors (as many as the nullspace dimension) for dG_ij
         #   above to get the general case projector.
-
-        nParams = self.Np
-        dPG = self._buildup_dpg()
-
-        #print("DB: shapes = ",dP.shape,dG.shape)
-        nullsp = _mt.nullspace_qr(dPG)  # columns are nullspace basis vectors
-        gen_dG = nullsp[0:nParams, :]  # take upper (gate-param-segment) of vectors for basis
-        # of subspace intersection in gate-parameter space
-        #Note: gen_dG == "generalized dG", and is (nParams)x(nullSpaceDim==gaugeSpaceDim), so P
-        #  (below) is (nParams)x(nParams) as desired.
-
-        #DEBUG
-        #nElements = self.num_elements
-        #for iRow in range(nElements):
-        #    pNorm = _np.linalg.norm(dP[iRow])
-        #    if pNorm < 1e-6:
-        #        print "Row %d of dP is zero" % iRow
-        #
-        #print "------------------------------"
-        #print "nParams = ",nParams
-        #print "nElements = ",nElements
-        #print " shape(M) = ",M.shape
-        #print " shape(dG) = ",dG.shape
-        #print " shape(dP) = ",dP.shape
-        #print " shape(gen_dG) = ",gen_dG.shape
-        #print " shape(nullsp) = ",nullsp.shape
-        #print " rank(dG) = ",_np.linalg.matrix_rank(dG)
-        #print " rank(dP) = ",_np.linalg.matrix_rank(dP)
-        #print "------------------------------"
-        #assert(_np.linalg.norm(_np.imag(gen_dG)) < 1e-9) #gen_dG is real
-
-        if non_gauge_mix_mx is not None:
-            msg = "You've set both non_gauge_mix_mx and item_weights, both of which"\
-                + " set the gauge metric... You probably don't want to do this."
-            assert(item_weights is None), msg
-
-            # BEGIN GAUGE MIX ----------------------------------------
-            # nullspace of gen_dG^T (mx with gauge direction vecs as rows) gives non-gauge directions
-            # columns are the non-gauge directions *orthogonal* to the gauge directions
-            nonGaugeDirections = _mt.nullspace_qr(gen_dG.T)
-
-            #for each column of gen_dG, which is a gauge direction in model parameter space,
-            # we add some amount of non-gauge direction, given by coefficients of the
-            # numNonGaugeParams non-gauge directions.
-            gen_dG = gen_dG + _np.dot(nonGaugeDirections, non_gauge_mix_mx)  # add non-gauge direction components in
-            # dims: (nParams,n_gauge_params) + (nParams,n_non_gauge_params) * (n_non_gauge_params,n_gauge_params)
-            # non_gauge_mix_mx is a (n_non_gauge_params,n_gauge_params) matrix whose i-th column specifies the
-            #  coefficents to multipy each of the non-gauge directions by before adding them to the i-th
-            #  direction to project out (i.e. what were the pure gauge directions).
-
-            #DEBUG
-            #print "gen_dG shape = ",gen_dG.shape
-            #print "NGD shape = ",nonGaugeDirections.shape
-            #print "NGD rank = ",_np.linalg.matrix_rank(nonGaugeDirections, P_RANK_TOL)
-            #END GAUGE MIX ----------------------------------------
-
-        # Build final non-gauge projector by getting a mx of column vectors
-        # orthogonal to the cols fo gen_dG:
-        #     gen_dG^T * gen_ndG = 0 => nullspace(gen_dG^T)
-        # or for a general metric W:
-        #     gen_dG^T * W * gen_ndG = 0 => nullspace(gen_dG^T * W)
-        # (This is instead of construction as I - gaugeSpaceProjector)
-
-        if item_weights is not None:
-            metric_diag = _np.ones(self.Np, 'd')
-            opWeight = item_weights.get('gates', 1.0)
-            spamWeight = item_weights.get('spam', 1.0)
-            for lbl, gate in self.operations.items():
-                metric_diag[gate.gpindices] = item_weights.get(lbl, opWeight)
-            for lbl, vec in _itertools.chain(iter(self.preps.items()),
-                                             iter(self.effects.items())):
-                metric_diag[vec.gpindices] = item_weights.get(lbl, spamWeight)
-            metric = _np.diag(metric_diag)
-            #OLD: gen_ndG = _mt.nullspace(_np.dot(gen_dG.T,metric))
-            gen_ndG = _mt.nullspace_qr(_np.dot(gen_dG.T, metric))
-        else:
-            #OLD: gen_ndG = _mt.nullspace(gen_dG.T) #cols are non-gauge directions
-            gen_ndG = _mt.nullspace_qr(gen_dG.T)  # cols are non-gauge directions
-            # print("DB: nullspace of gen_dG (shape = %s, rank=%d) = %s" \
-            #       % (str(gen_dG.shape),_np.linalg.matrix_rank(gen_dG),str(gen_ndG.shape)))
+        gen_ndG, _ = self.nongauge_and_gauge_spaces(item_weights, non_gauge_mix_mx)
 
         # ORIG WAY: use psuedo-inverse to normalize projector.  Ran into problems where
         #  default rcond == 1e-15 didn't work for 2-qubit case, but still more stable than inv method below

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -559,6 +559,12 @@ class ExplicitOpModel(_mdl.OpModel):
         """
         return self._excalc().deriv_wrt_params()
 
+    def compute_nongauge_and_gauge_spaces(self, item_weights=None, non_gauge_mix_mx=None):
+        """
+        TODO: docstring
+        """
+        return self._excalc().nongauge_and_gauge_spaces(item_weights, non_gauge_mix_mx)
+
     def compute_nongauge_projector(self, item_weights=None, non_gauge_mix_mx=None):
         """
         Construct a projector onto the non-gauge parameter space.

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -1135,8 +1135,7 @@ class ExplicitOpModel(_mdl.OpModel):
             # make randMat Hermetian: (A_dag + A)^dag = (A_dag + A)
             randUnitary = _scipy.linalg.expm(-1j * randMat)
 
-            randOp = _ot.unitary_to_process_mx(randUnitary)  # in std basis
-            randOp = _bt.change_basis(randOp, "std", self.basis)
+            randOp = _ot.unitary_to_superop(randUnitary, self.basis)
 
             mdl_randomized.operations[opLabel] = _op.FullArbitraryOp(
                 _np.dot(randOp, gate))
@@ -1520,8 +1519,7 @@ class ExplicitOpModel(_mdl.OpModel):
                     #    observed_sslbls.update(sslbls)
 
                 if gn not in gate_unitaries or gate_unitaries[gn] is None:
-                    U = _ot.process_mx_to_unitary(_bt.change_basis(
-                        op.to_dense('HilbertSchmidt'), self.basis, 'std')) \
+                    U = _ot.superop_to_unitary(op.to_dense('HilbertSchmidt'), self.basis) \
                         if (op is not None) else None  # U == None indicates "unknown, up until this point"
 
                     Ulocal = extract_unitary(U, all_sslbls, sslbls)

--- a/pygsti/models/modelconstruction.py
+++ b/pygsti/models/modelconstruction.py
@@ -387,7 +387,7 @@ def create_operation(op_expr, state_space, basis="pp", parameterization="full", 
             Utot[i2, i2] = Uop[1, 1]
 
             # dmDim^2 x dmDim^2 mx operating on vectorized total densty matrix
-            opTermInStdBasis = _ot.unitary_to_process_mx(Utot)
+            opTermInStdBasis = _ot.unitary_to_std_process_mx(Utot)
 
             # contract [3] to [2, 1]
             embedded_std_basis = _Basis.cast('std', 9)  # [2]

--- a/pygsti/models/qutrit.py
+++ b/pygsti/models/qutrit.py
@@ -18,7 +18,7 @@ from pygsti.models.gaugegroup import FullGaugeGroup as _FullGaugeGroup
 from pygsti.modelmembers.operations import FullArbitraryOp as _FullArbitraryOp
 from pygsti.modelmembers.povms import UnconstrainedPOVM as _UnconstrainedPOVM
 from pygsti.models import ExplicitOpModel as _ExplicitOpModel
-from pygsti.tools import unitary_to_process_mx, change_basis
+from pygsti.tools import unitary_to_superop, change_basis
 
 #Define 2 qubit to symmetric (+) antisymmetric space transformation A:
 A = _np.matrix([[1, 0, 0, 0],
@@ -270,14 +270,10 @@ def create_qutrit_model(error_scale, x_angle=_np.pi / 2, y_angle=_np.pi / 2,
         gateImx = _np.dot(gateImx, Irand)
 
     #Change gate representation to superoperator in Gell-Mann basis
-    gateISO = unitary_to_process_mx(gateImx)
-    gateISOfinal = change_basis(gateISO, "std", basis)
-    gateXSO = unitary_to_process_mx(gateXmx)
-    gateXSOfinal = change_basis(gateXSO, "std", basis)
-    gateYSO = unitary_to_process_mx(gateYmx)
-    gateYSOfinal = change_basis(gateYSO, "std", basis)
-    gateMSO = unitary_to_process_mx(gateMmx)
-    gateMSOfinal = change_basis(gateMSO, "std", basis)
+    gateISOfinal = unitary_to_superop(gateImx, basis)
+    gateXSOfinal = unitary_to_superop(gateXmx, basis)
+    gateYSOfinal = unitary_to_superop(gateYmx, basis)
+    gateMSOfinal = unitary_to_superop(gateMmx, basis)
 
     rho0final = change_basis(_np.reshape(rho0, (9, 1)), "std", basis)
     E0final = change_basis(_np.reshape(E0, (9, 1)), "std", basis)

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -675,7 +675,7 @@ def unitary_superoperator_matrix_log(m, mx_basis):
     evals = _np.linalg.eigvals(M_std)
     assert(_np.allclose(_np.abs(evals), 1.0))  # simple but technically incomplete check for a unitary superop
     # (e.g. could be anti-unitary: diag(1, -1, -1, -1))
-    U = _ot.process_mx_to_unitary(M_std)
+    U = _ot.std_process_mx_to_unitary(M_std)
     H = _spl.logm(U) / -1j  # U = exp(-iH)
     logM_std = _lt.create_elementary_errorgen('H', H)  # rho --> -i[H, rho]
     logM = change_basis(logM_std, "std", mx_basis)

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -1090,7 +1090,17 @@ def dmvec_to_state(dmvec, tol=1e-6):
     return psi
 
 
+def unitary_to_superop(u, superop_mx_basis='pp'):
+    """ TODO: docstring """
+    return _bt.change_basis(unitary_to_std_process_mx(u), 'std', superop_mx_basis)
+
+
+@_deprecated_fn('pygsti.tools.unitary_to_std_process_mx(...) or unitary_to_superop(...)')
 def unitary_to_process_mx(u):
+    return unitary_to_std_process_mx(u)
+
+
+def unitary_to_std_process_mx(u):
     """
     Compute the superoperator corresponding to unitary matrix `u`.
 
@@ -1729,7 +1739,7 @@ def create_elementary_errorgen_nqudit(typ, basis_element_labels, basis_1q, norma
 
 
 #TODO: replace two_qubit_gate, one_qubit_gate, unitary_to_pauligate_* with
-# calls to this one and unitary_to_processmx
+# calls to this one and unitary_to_std_processmx
 def rotation_gate_mx(r, mx_basis="gm"):
     """
     Construct a rotation operation matrix.
@@ -1773,11 +1783,8 @@ def rotation_gate_mx(r, mx_basis="gm"):
     for rot, pp_mx in zip(r, pp[1:]):
         ex += rot / 2.0 * pp_mx * _np.sqrt(d)
     U = _spl.expm(-1j * ex)
-    stdGate = unitary_to_process_mx(U)
 
-    ret = _bt.change_basis(stdGate, 'std', mx_basis)
-
-    return ret
+    return unitary_to_superop(U, mx_basis)
 
 
 def project_model(model, target_model,
@@ -2259,7 +2266,7 @@ def unitary_to_pauligate(u):
         vectorized as d**2 vectors in the Pauli basis.
     """
     assert u.shape[0] == u.shape[1], '"Unitary" matrix is not square'
-    return _bt.change_basis(unitary_to_process_mx(u), 'std', 'pp')
+    return unitary_to_superop(u, 'pp')
 
 
 def is_valid_lindblad_paramtype(typ):

--- a/test/unit/drivers/test_bootstrap.py
+++ b/test/unit/drivers/test_bootstrap.py
@@ -17,10 +17,12 @@ class BootstrapBase(BaseCase):
         cls.mdl = alg.run_lgst(
             cls.ds, cls.fiducials, cls.fiducials, target_model=tp_target, svd_truncate_to=4, verbosity=0
         )
+        cls.target_mdl = tp_target
 
     def setUp(self):
         self.ds = self.ds.copy()
         self.mdl = self.mdl.copy()
+        self.target_mdl = self.target_mdl.copy()
 
 
 class BootstrapDatasetTester(BootstrapBase):
@@ -54,7 +56,7 @@ class BootstrapModelTester(BootstrapBase):
         # TODO optimize
         bootgs_p = bs.create_bootstrap_models(
             2, self.ds, 'parametric', self.fiducials, self.fiducials,
-            self.germs, self.maxLengths, input_model=self.mdl,
+            self.germs, self.maxLengths, input_model=self.target_mdl,
             return_data=False
         )
         # TODO assert correctness
@@ -62,11 +64,11 @@ class BootstrapModelTester(BootstrapBase):
     def test_make_bootstrap_models_with_list(self):
         # TODO optimize
         custom_strs = pc.create_lsgst_circuit_lists(
-            self.mdl, self.fiducials, self.fiducials, self.germs, [1]
+            self.target_mdl, self.fiducials, self.fiducials, self.germs, [1]
         )
         bootgs_p_custom = bs.create_bootstrap_models(
             2, self.ds, 'parametric', None, None, None, None,
-            lsgst_lists=custom_strs, input_model=self.mdl,
+            lsgst_lists=custom_strs, input_model=self.target_mdl,
             return_data=False
         )
         # TODO assert correctness
@@ -75,7 +77,7 @@ class BootstrapModelTester(BootstrapBase):
         # TODO optimize
         bootgs_np, bootds_np2 = bs.create_bootstrap_models(
             2, self.ds, 'nonparametric', self.fiducials, self.fiducials,
-            self.germs, self.maxLengths, target_model=self.mdl,
+            self.germs, self.maxLengths, target_model=self.target_mdl,
             return_data=True
         )
         # TODO assert correctness
@@ -91,7 +93,7 @@ class BootstrapModelTester(BootstrapBase):
         with self.assertRaises(ValueError):
             bs.create_bootstrap_models(
                 2, self.ds, 'parametric', self.fiducials, self.fiducials,
-                self.germs, self.maxLengths, input_model=self.mdl, target_model=self.mdl,
+                self.germs, self.maxLengths, input_model=self.mdl, target_model=self.target_mdl,
                 return_data=False
             )
 
@@ -103,7 +105,7 @@ class BootstrapUtilityTester(BootstrapBase):
         maxLengths = [0]
         cls.bootgs_p = bs.create_bootstrap_models(
             2, cls.ds, 'parametric', cls.fiducials, cls.fiducials,
-            cls.germs, maxLengths, input_model=cls.mdl,
+            cls.germs, maxLengths, input_model=cls.target_mdl,
             return_data=False
         )
 


### PR DESCRIPTION
**Fixes an algebra bug in how Hessian matrices were being projected.**

This fix potentially affects *all* error bar calculations, and while we hope it doesn't do so drastically, it would be worthwhile to recompute suspicious error bars after this fix has been applied.  

This PR also introduces some new functions for converting between unitary and superoperator matrices.  In particular, it renames `unitary_to_process_mx` to `unitary_to_std_process_mx` and `process_mx_to_unitary` to `std_process_mx_to_unitary` and deprecates the old names.  It also adds new `superop_to_unitary` and `unitary_to_superop` functions (all in `pygsti.tools`). 