### PR TITLE
Feature chp fix updates

### DIFF
--- a/jupyter_notebooks/Tutorials/algorithms/advanced/CircuitSimulation-CHP.ipynb
+++ b/jupyter_notebooks/Tutorials/algorithms/advanced/CircuitSimulation-CHP.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,9 +32,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "Gx = StaticStandardOp('Gxpi', evotype='chp')\n",
     "print(Gx)\n",
@@ -44,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,9 +70,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<pygsti.modelmembers.operations.linearop.LinearOperator object at 0x137a7d8b0>\n",
+      "h 0\n",
+      "c 1 2\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(c)\n",
     "print(c.chp_str)"
@@ -66,9 +91,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "StaticStandardOp with name Gc20 and evotype chp\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(StaticStandardOp('Gc20', evotype='chp'))"
    ]
@@ -84,12 +118,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Stochastic noise operation map with state space = QubitSpace((0,)), num params = 3\n",
+      "Rates: [0.5 0.1 0.1]\n",
+      "\n",
+      "p 0\n",
+      "p 0\n",
+      "\n",
+      "\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "nqubits = 1\n",
-    "scop = StochasticNoiseOp(nqubits, evotype='chp', initial_rates=[0.5, 0.1, 0.1], seed_or_state=2021)\n",
+    "scop = StochasticNoiseOp(nqubits, basis='pp', evotype='chp', initial_rates=[0.5, 0.1, 0.1], seed_or_state=2021)\n",
     "print(scop)\n",
     "for _ in range(4): # With seed 2021, pulls Z, I (no output), X, X\n",
     "    print(scop.chp_str)\n",
@@ -101,12 +159,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Depolarize noise operation map with dim = 4, num params = 1\n",
+      "Strength: [0.7]\n",
+      "\n",
+      "p 0\n",
+      "p 0\n",
+      "\n",
+      "\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "\n",
+      "p 0\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "p 0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "nqubits = 1\n",
-    "dop = DepolarizeOp(nqubits, evotype='chp', initial_rate=0.7, seed_or_state=2021)\n",
+    "dop = DepolarizeOp(nqubits, basis='pp', evotype='chp', initial_rate=0.7, seed_or_state=2021)\n",
     "print(dop)\n",
     "for _ in range(4): # With seed 2021, pulls Z, I (no output), X, Y\n",
     "    print(dop.chp_str)\n",
@@ -125,9 +211,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gzpi and evotype chp\n",
+      "Factor 1:\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# ComposedOp\n",
     "Gzx_composed = ComposedOp([StaticStandardOp('Gzpi', evotype='chp'), StaticStandardOp('Gxpi', evotype='chp')])\n",
@@ -138,9 +244,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "h 0\n",
+      "p 0\n",
+      "p 0\n",
+      "h 0\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# EmbeddedOp\n",
     "Gxi_embedded = EmbeddedOp(['Q0', 'Q1'], ['Q0'], StaticStandardOp('Gxpi', evotype='chp'))\n",
@@ -151,9 +273,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "h 1\n",
+      "p 1\n",
+      "p 1\n",
+      "h 1\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "Gix_embedded = EmbeddedOp(['Q0', 'Q1'], ['Q1'], StaticStandardOp('Gxpi', evotype='chp'))\n",
     "print(Gix_embedded)\n",
@@ -163,9 +301,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedded operation with full dimension 256 and state space QubitSpace(('Q0', 'Q1', 'Q2', 'Q3'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gzpi and evotype chp\n",
+      "Factor 1:\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "p 1\n",
+      "p 1\n",
+      "h 1\n",
+      "p 1\n",
+      "p 1\n",
+      "h 1\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# EmbeddedOp made of ComposedOps\n",
     "Gzx_comp_embed = EmbeddedOp(['Q0', 'Q1', 'Q2', 'Q3'], ['Q1'], Gzx_composed)\n",
@@ -183,19 +343,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "chpexe = '/Users/sserita/Documents/notebooks/pyGSTi/2021-CHP/chp'\n",
-    "sim = pygsti.forwardsims.CHPForwardSimulator(chpexe, shots=1)"
+    "sim = pygsti.forwardsims.CHPForwardSimulator(chpexe, shots=100)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rho0 = Computational Z-basis state vec for 2 qubits w/z-values: [0 0]\n",
+      "\n",
+      "Mdefault = Computational(Z)-basis POVM on 2 qubits and filter None\n",
+      "\n",
+      "\n",
+      "Gii = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "\n",
+      "\n",
+      "Gxi = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "\n",
+      "\n",
+      "Gix = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "\n",
+      "Gxx = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "\n",
+      "\n",
+      "Gyi = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gypi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "\n",
+      "\n",
+      "Giy = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gypi and evotype chp\n",
+      "\n",
+      "\n",
+      "Gyy = \n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q0',) space\n",
+      "StaticStandardOp with name Gypi and evotype chp\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace(('Q0', 'Q1'))\n",
+      " that embeds the following 4-dimensional operation into acting on the ('Q1',) space\n",
+      "StaticStandardOp with name Gypi and evotype chp\n",
+      "\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "#Initialize an empty Model object\n",
     "model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
@@ -225,9 +483,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('01',), 1.0000000000000007)])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit(['Gix'])\n",
     "model.probabilities(circ)"
@@ -235,9 +504,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('11',), 1.0000000000000007)])"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit(['Gix', 'Gxi'])\n",
     "model.probabilities(circ)"
@@ -245,9 +525,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('11',), 1.0000000000000007)])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit(['rho0', 'Gxx', 'Mdefault'])\n",
     "model.probabilities(circ)"
@@ -266,117 +557,95 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('01',), 1.0000000000000007)])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#Initialize an empty Model object\n",
-    "#prep01_model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "prep01_model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
     "\n",
     "# Make a ComputationalSPAMVec with one bit in 1 state\n",
-    "#model['rho0'] = pygsti.modelmembers.states.ComputationalBasisState([0, 1], evotype='chp')\n",
-    "#model['Mdefault'] = pygsti.modelmembers.povms.ComputationalBasisPOVM(2, evotype='chp')\n",
+    "prep01_model.preps['rho0'] = pygsti.modelmembers.states.ComputationalBasisState([0, 1], evotype='chp')\n",
+    "prep01_model.povms['Mdefault'] = pygsti.modelmembers.povms.ComputationalBasisPOVM(2, evotype='chp')\n",
     "\n",
-    "#circ = pygsti.circuits.Circuit([])\n",
-    "#prep01_model.probabilities(circ)"
+    "circ = pygsti.circuits.Circuit([])\n",
+    "prep01_model.probabilities(circ)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('00',), 0.16), (('01',), 0.8400000000000005)])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#Initialize an empty Model object\n",
-    "#prep00noise_model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "prep00noise_model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
     "\n",
     "# Make a ComposedSPAMVec where second qubit has X error\n",
-    "#rho0 = pygsti.obj.ComposedSPAMVec(\n",
-    "#    pygsti.obj.ComputationalSPAMVec([0, 0], 'chp', 'prep'), # Pure SPAM vec is 00 state\n",
-    "#    make_2Q_op('Gi', 'Gxpi'), 'prep') # Second qubit has X error (flipping up to 1)\n",
+    "rho0 = pygsti.modelmembers.states.ComposedState(\n",
+    "    pygsti.modelmembers.states.ComputationalBasisState([0, 0], evotype='chp'), # Pure SPAM vec is 00 state\n",
+    "    make_2Q_op('Gi', 'Gxpi2')) # Second qubit has X(pi/2) error (partial flip on qubit 1)\n",
     "\n",
-    "#prep00noise_model['rho0'] = rho0\n",
-    "#prep00noise_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "prep00noise_model['rho0'] = rho0\n",
+    "prep00noise_model['Mdefault'] = pygsti.modelmembers.povms.ComputationalBasisPOVM(2, 'chp')\n",
     "\n",
-    "#circ = pygsti.obj.Circuit([])\n",
-    "#prep00noise_model.probabilities(circ)"
+    "circ = pygsti.circuits.Circuit([])\n",
+    "prep00noise_model.probabilities(circ)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('11',), 0.16), (('10',), 0.8400000000000005)])"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#Initialize an empty Model object\n",
-    "#prep11noise_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "prep11noise_model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
     "\n",
     "# Make a ComposedSPAMVec where second qubit has X error AND is initialized to 1 state\n",
-    "#rho0 = pygsti.obj.ComposedSPAMVec(\n",
-    "#    pygsti.obj.ComputationalSPAMVec([1, 1], 'chp', 'prep'), # Pure SPAM vec is 11 state\n",
-    "#    make_2Q_op('Gi', 'Gxpi'), 'prep') # Second qubit has X error (flipping back to 0)\n",
+    "# Make a ComposedSPAMVec where second qubit has X error\n",
+    "rho0 = pygsti.modelmembers.states.ComposedState(\n",
+    "    pygsti.modelmembers.states.ComputationalBasisState([1, 1], evotype='chp'), # Pure SPAM vec is 00 state\n",
+    "    make_2Q_op('Gi', 'Gxpi2')) # Second qubit has X(pi/2) error (partial flip on qubit 1)\n",
     "\n",
-    "#prep11noise_model['rho0'] = rho0\n",
-    "#prep11noise_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
+    "prep11noise_model['rho0'] = rho0\n",
+    "prep11noise_model['Mdefault'] = pygsti.modelmembers.povms.ComputationalBasisPOVM(2, 'chp')\n",
     "\n",
-    "#circ = pygsti.obj.Circuit([])\n",
-    "#prep11noise_model.probabilities(circ)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Initialize an empty Model object\n",
-    "#tensorprep_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
-    "\n",
-    "# Make a TensorProdSPAMVec equivalent of prep11noise_model\n",
-    "#rho0 = pygsti.obj.TensorProdSPAMVec('prep', [\n",
-    "#    pygsti.obj.ComposedSPAMVec([1], StaticStandardOp('Gi', 'chp'), 'prep'), # First qubit to 1 state with no error\n",
-    "#    pygsti.obj.ComposedSPAMVec([1], StaticStandardOp('Gxpi', 'chp'), 'prep'), # Second qubit to 1 state with X error\n",
-    "#])\n",
-    "\n",
-    "#tensorprep_model['rho0'] = rho0\n",
-    "#tensorprep_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
-    "\n",
-    "#circ = pygsti.obj.Circuit([])\n",
-    "#tensorprep_model.probabilities(circ)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# DOES NOT WORK. This was for debugging TensorProdSPAMVec > ComposedSPAMVec > ComposedOp\n",
-    "# This was sidestepped for now by not building the TensorProdSPAMVec in create_crosstalk_free_model\n",
-    "# #Initialize an empty Model object\n",
-    "# tensorprep2_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
-    "\n",
-    "# # Make a TensorProdSPAMVec equivalent of prep11noise_model\n",
-    "# rho0 = pygsti.obj.TensorProdSPAMVec('prep', [\n",
-    "#     pygsti.obj.ComposedSPAMVec([1, 1], make_2Q_op('Gi', 'Gxpi'), 'prep')\n",
-    "# ])\n",
-    "\n",
-    "# tensorprep2_model['rho0'] = rho0\n",
-    "# tensorprep2_model['Mdefault'] = pygsti.obj.ComputationalBasisPOVM(2, 'chp')\n",
-    "\n",
-    "# circ = pygsti.obj.Circuit([])\n",
-    "# tensorprep2_model.probabilities(circ)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#prep11noise_model._print_gpindices() # This one works great\n",
-    "#tensorprep2_model._print_gpindices() # This one doesn't\n",
-    "# the ComposedSPAMVec underneath doesn't know about it's gpindices"
+    "circ = pygsti.circuits.Circuit([])\n",
+    "prep11noise_model.probabilities(circ)"
    ]
   },
   {
@@ -388,43 +657,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('00',), 0.13999999999999999),\n",
+       "                  (('01',), 0.8600000000000005)])"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "#Initialize an empty Model object\n",
-    "#povm01_model = pygsti.objects.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
+    "povm01_model = pygsti.models.ExplicitOpModel(['Q0', 'Q1'], simulator=sim, evotype='chp')\n",
     "\n",
     "# Make a measurement with a bitflip error on qubit 1\n",
-    "#povm01_model['rho0'] = pygsti.obj.ComputationalSPAMVec([0, 0], 'chp')\n",
-    "#povm01_model['Mdefault'] = pygsti.obj.ComposedPOVM(make_2Q_op('Gi', 'Gxpi'), )\n",
-    "#povm01_model['Gi', 'Q0'] = StaticStandardOp('Gi', 'chp')\n",
-    "#povm01_model['Gi', 'Q1'] = StaticStandardOp('Gi', 'chp')\n",
+    "povm01_model.preps['rho0'] = pygsti.modelmembers.states.ComputationalBasisState([0, 1], evotype='chp')\n",
+    "povm01_model.povms['Mdefault'] = pygsti.modelmembers.povms.ComposedPOVM(\n",
+    "    make_2Q_op('Gi', 'Gxpi2'),\n",
+    "    pygsti.modelmembers.povms.ComputationalBasisPOVM(2, evotype='chp'),\n",
+    "    mx_basis='pp')\n",
     "\n",
-    "#circ = pygsti.obj.Circuit([])\n",
-    "#povm01_model.probabilities(circ)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Try marginalized on qubit 0 (should stay in 0 state)\n",
-    "#circ = pygsti.obj.Circuit([('Gi', 'Q0')])\n",
-    "#povm01_model.probabilities(circ)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Try marginalized on qubit 1 (should flip to 1 state due to readout error)\n",
-    "#circ = pygsti.obj.Circuit([('Gi', 'Q1')])\n",
-    "#povm01_model.probabilities(circ)"
+    "povm01_model._primitive_povm_label_dict['Mdefault'] = povm01_model['Mdefault']\n",
+    "\n",
+    "circ = pygsti.circuits.Circuit([])\n",
+    "povm01_model.probabilities(circ)"
    ]
   },
   {
@@ -436,13 +698,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Step 1: Define stochastic Pauli noise operators\n",
     "# Note that the probabilities here are the \"error rates\" that would be model parameters (currently just static)\n",
-    "noise_1q = StochasticNoiseOp(1, evotype='chp', initial_rates=[0.1, 0.01, 0.01], seed_or_state=2021)\n",
+    "noise_1q = StochasticNoiseOp(1, basis='pp', evotype='chp', initial_rates=[0.1, 0.01, 0.01], seed_or_state=2021)\n",
     "\n",
     "# Also need two-qubit version\n",
     "# Here we just make it independent stochastic Pauli noise\n",
@@ -451,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -488,9 +750,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State prep building blocks (.prep_blks):\n",
+      " layers :  rho0\n",
+      "\n",
+      "POVM building blocks (.povm_blks):\n",
+      " layers :  M0\n",
+      "\n",
+      "Operation building blocks (.operation_blks):\n",
+      " gates :  Gi, Gx, Gy, Gcnot\n",
+      " layers :  {auto_global_idle}, Gi:0, Gi:1, Gi:2, Gi:3, Gx:0, Gx:1, Gx:2, Gx:3, Gy:0, Gy:1, Gy:2, Gy:3, Gcnot:0:1, Gcnot:1:2, Gcnot:2:3\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Step 4: Profit?? Worked way too quickly...\n",
     "def print_implicit_model_blocks(mdl, showSPAM=False):\n",
@@ -515,27 +794,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computational Z-basis state vec for 4 qubits w/z-values: [0 0 0 0]\n"
+     ]
+    }
+   ],
    "source": [
     "print(ln_model.prep_blks['layers']['rho0'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "Factor 1:\n",
+      "Stochastic noise operation map with state space = QubitSpace((0,)), num params = 3\n",
+      "Rates: [0.1  0.01 0.01]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(ln_model.operation_blks['gates']['Gx'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedded operation with full dimension 256 and state space QubitSpace((0, 1, 2, 3))\n",
+      " that embeds the following 16-dimensional operation into acting on the (1, 2) space\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gcnot and evotype chp\n",
+      "Factor 1:\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace((0, 1))\n",
+      " that embeds the following 4-dimensional operation into acting on the (0,) space\n",
+      "Stochastic noise operation map with state space = QubitSpace((0,)), num params = 3\n",
+      "Rates: [0.1  0.01 0.01]\n",
+      "Factor 1:\n",
+      "Embedded operation with full dimension 16 and state space QubitSpace((0, 1))\n",
+      " that embeds the following 4-dimensional operation into acting on the (1,) space\n",
+      "Stochastic noise operation map with state space = QubitSpace((0,)), num params = 3\n",
+      "Rates: [0.1  0.01 0.01]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "Gcnot_layer_op = ln_model.operation_blks['layers']['Gcnot', 1, 2]\n",
     "print(ln_model.operation_blks['layers']['Gcnot', 1, 2])"
@@ -543,9 +869,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0000',), 0.10999999999999999),\n",
+       "                  (('0100',), 0.8900000000000006)])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Step 5: Actually run circuits with local noise model\n",
     "circ = pygsti.circuits.Circuit([('Gx', 1)], num_lines=4)\n",
@@ -554,9 +892,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0000',), 0.10999999999999999),\n",
+       "                  (('0110',), 0.6900000000000004),\n",
+       "                  (('0010',), 0.09999999999999999),\n",
+       "                  (('0100',), 0.09999999999999999)])"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit([('Gx', 1), ('Gcnot', 1, 2)], num_lines=4)\n",
     "ln_model.probabilities(circ)"
@@ -564,7 +916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +925,7 @@
     "rates_2q = [0.01,]*15\n",
     "rates_2q[pp.labels.index('XX')] = 0.1 # Set XX to much higher\n",
     "\n",
-    "noise_2q_correlated = StochasticNoiseOp(2, evotype='chp', initial_rates=rates_2q, seed_or_state=2021)\n",
+    "noise_2q_correlated = StochasticNoiseOp(2, basis='pp', evotype='chp', initial_rates=rates_2q, seed_or_state=2021)\n",
     "\n",
     "gatedict = {}\n",
     "gatedict['Gi'] = noise_1q\n",
@@ -585,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,9 +953,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Embedded operation with full dimension 256 and state space QubitSpace((0, 1, 2, 3))\n",
+      " that embeds the following 16-dimensional operation into acting on the (1, 2) space\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gcnot and evotype chp\n",
+      "Factor 1:\n",
+      "Stochastic noise operation map with state space = QubitSpace((0, 1)), num params = 15\n",
+      "Rates: [0.01 0.01 0.01 0.01 0.01 0.1  0.01 0.01 0.01 0.01 0.01 0.01 0.01 0.01\n",
+      " 0.01]\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# Now the CNOT gates have a 2-qubit stochastic gate instead of independent 1-qubit ones\n",
     "print(ln_model_corr.operation_blks['layers']['Gcnot', 1, 2])"
@@ -611,9 +980,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0100',), 0.8900000000000006),\n",
+       "                  (('0000',), 0.10999999999999999)])"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit([('Gx', 1)], num_lines=4)\n",
     "ln_model_corr.probabilities(circ)"
@@ -621,9 +1002,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0110',), 0.7200000000000004),\n",
+       "                  (('0000',), 0.18000000000000002),\n",
+       "                  (('0010',), 0.05),\n",
+       "                  (('0100',), 0.05)])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit([('Gx', 1), ('Gcnot', 1, 2)], num_lines=4)\n",
     "ln_model_corr.probabilities(circ)"
@@ -638,9 +1033,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "State prep building blocks (.prep_blks):\n",
+      " layers :  rho0\n",
+      "\n",
+      "POVM building blocks (.povm_blks):\n",
+      " layers :  Mdefault\n",
+      "\n",
+      "Operation building blocks (.operation_blks):\n",
+      " gates :  Gi, Gxpi, Gypi, Gcnot\n",
+      " layers :  {auto_global_idle}, Gi:0, Gi:1, Gi:2, Gi:3, Gxpi:0, Gxpi:1, Gxpi:2, Gxpi:3, Gypi:0, Gypi:1, Gypi:2, Gypi:3, Gcnot:0:1, Gcnot:1:2, Gcnot:2:3\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import pygsti.models.modelconstruction as mc\n",
     "\n",
@@ -660,9 +1072,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gate Gi\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gi and evotype chp\n",
+      "Factor 1:\n",
+      "Depolarize noise operation map with dim = 4, num params = 1\n",
+      "Strength: [0.1]\n",
+      "\n",
+      "\n",
+      "Gate Gxpi\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gxpi and evotype chp\n",
+      "Factor 1:\n",
+      "Depolarize noise operation map with dim = 4, num params = 1\n",
+      "Strength: [0.1]\n",
+      "\n",
+      "\n",
+      "Gate Gypi\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gypi and evotype chp\n",
+      "Factor 1:\n",
+      "Stochastic noise operation map with state space = QubitSpace((0,)), num params = 3\n",
+      "Rates: [0.1 0.1 0.1]\n",
+      "\n",
+      "\n",
+      "Gate Gcnot\n",
+      "Composed operation of 2 factors:\n",
+      "Factor 0:\n",
+      "StaticStandardOp with name Gcnot and evotype chp\n",
+      "Factor 1:\n",
+      "Stochastic noise operation map with state space = QubitSpace((0, 1)), num params = 15\n",
+      "Rates: [0.01 0.01 0.01 0.01 0.01 0.1  0.01 0.01 0.01 0.01 0.01 0.01 0.01 0.01\n",
+      " 0.01]\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "for name, gate in ctf_model.operation_blks['gates'].items():\n",
     "    print(f'Gate {name}')\n",
@@ -672,9 +1128,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0100',), 0.9400000000000006),\n",
+       "                  (('0000',), 0.060000000000000005)])"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit([('Gxpi', 1)], num_lines=4)\n",
     "ctf_model.probabilities(circ)"
@@ -682,9 +1150,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0000',), 0.13999999999999999),\n",
+       "                  (('0110',), 0.7600000000000005),\n",
+       "                  (('0010',), 0.05),\n",
+       "                  (('0100',), 0.05)])"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "circ = pygsti.circuits.Circuit([('Gxpi', 1), ('Gcnot', 1, 2)], num_lines=4)\n",
     "ctf_model.probabilities(circ)"
@@ -692,9 +1174,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('00',), 0.13999999999999999),\n",
+       "                  (('11',), 0.7600000000000005),\n",
+       "                  (('01',), 0.05),\n",
+       "                  (('10',), 0.05)])"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Marginalized POVMs now work!\n",
     "circ = pygsti.circuits.Circuit([('Gxpi', 1), ('Gcnot', 1, 2)])\n",
@@ -703,25 +1199,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Let's try a model with only readout error\n",
-    "# TODO: This is broken with chp_str no targets change, will fix with other CHP issues later\n",
-    "#ctf_prep_model = mc.create_crosstalk_free_model(pspec,\n",
-    "#    stochastic_error_probs={'prep': [0.3, 0.0, 0.0]}, # 30% X error on prep\n",
-    "#    simulator=sim, evotype='chp')"
+    "sim = pygsti.forwardsims.CHPForwardSimulator(chpexe, shots=1000) # Bump up shots for better noise resolution\n",
+    "\n",
+    "ctf_povm_model = mc.create_crosstalk_free_model(pspec,\n",
+    "    stochastic_error_probs={'povm': [0.05, 0.0, 0.0]}, # 5% X error on prep\n",
+    "    simulator=sim, evotype='chp')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutcomeLabelDict([(('0000',), 0.8040000000000006),\n",
+       "                  (('0010',), 0.04500000000000003),\n",
+       "                  (('1000',), 0.04400000000000003),\n",
+       "                  (('0001',), 0.05000000000000004),\n",
+       "                  (('0011',), 0.005),\n",
+       "                  (('0100',), 0.046000000000000034),\n",
+       "                  (('1100',), 0.002),\n",
+       "                  (('1010',), 0.002),\n",
+       "                  (('1001',), 0.001),\n",
+       "                  (('0110',), 0.001)])"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#circ = pygsti.circuits.Circuit([])\n",
-    "#ctf_prep_model.probabilities(circ)"
+    "circ = pygsti.circuits.Circuit([])\n",
+    "ctf_povm_model.probabilities(circ) # Expect about 80% all 0, 5% on weight one errors, 0.25% on weight 2, etc."
    ]
   },
   {
@@ -734,9 +1251,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (pygsti -e install)",
    "language": "python",
-   "name": "python3"
+   "name": "pygsti"
   },
   "language_info": {
    "codemirror_mode": {
@@ -748,7 +1265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/pygsti/evotypes/chp/opreps.py
+++ b/pygsti/evotypes/chp/opreps.py
@@ -86,7 +86,7 @@ class OpRepComposed(OpRep):
     def chp_ops(self, seed_or_state=None):
         ops = []
         for factor in self.factor_reps:
-            ops.extend(factor.chp_ops)
+            ops.extend(factor.chp_ops(seed_or_state=seed_or_state))
 
         return ops
 
@@ -116,7 +116,6 @@ class OpRepEmbedded(OpRep):
         chp_ops = [_update_chp_op(op, self.embedded_to_local_qubit_indices) for op in self.embedded_rep.chp_ops()]
         super(OpRepEmbedded, self).__init__(chp_ops, state_space)
 
-    @property
     def chp_ops(self, seed_or_state=None):
         return [_update_chp_op(op, self.embedded_to_local_qubit_indices) for op in self.embedded_rep.chp_ops(seed_or_state=seed_or_state)]
 
@@ -185,7 +184,7 @@ class OpRepStochastic(OpRep):
 
         # If final entry, no operation selected
         if index == self.basis.size - 1:
-            return ''
+            return []
 
         rep = self.stochastic_superop_reps[index]
-        return rep.chp_ops
+        return rep.chp_ops()

--- a/pygsti/evotypes/chp/opreps.py
+++ b/pygsti/evotypes/chp/opreps.py
@@ -34,12 +34,11 @@ class OpRep(_basereps.OpRep):
     def num_qubits(self):
         return self.state_space.num_qubits
 
-    @property
-    def chp_ops(self):
+    def chp_ops(self, seed_or_state=None):
         return self.base_chp_ops
 
-    def chp_str(self):
-        op_str = '\n'.join(self.chp_ops)
+    def chp_str(self, seed_or_state=None):
+        op_str = '\n'.join(self.chp_ops(seed_or_state=seed_or_state))
         if len(op_str) > 0: op_str += '\n'
         return op_str
 
@@ -84,8 +83,7 @@ class OpRepComposed(OpRep):
     def reinit_factor_op_reps(self, factor_op_reps):
         self.factors_reps = factor_op_reps
 
-    @property
-    def chp_ops(self):
+    def chp_ops(self, seed_or_state=None):
         ops = []
         for factor in self.factor_reps:
             ops.extend(factor.chp_ops)
@@ -115,12 +113,12 @@ class OpRepEmbedded(OpRep):
         self.embedded_to_local_qubit_indices = {str(i): str(j) for i, j in enumerate(qubit_indices)}
 
         # TODO: This doesn't work as nicely for the stochastic op, where chp_ops can be reset between chp_str calls
-        chp_ops = [_update_chp_op(op, self.embedded_to_local_qubit_indices) for op in self.embedded_rep.chp_ops]
+        chp_ops = [_update_chp_op(op, self.embedded_to_local_qubit_indices) for op in self.embedded_rep.chp_ops()]
         super(OpRepEmbedded, self).__init__(chp_ops, state_space)
 
     @property
-    def chp_ops(self):
-        return [_update_chp_op(op, self.embedded_to_local_qubit_indices) for op in self.embedded_rep.chp_ops]
+    def chp_ops(self, seed_or_state=None):
+        return [_update_chp_op(op, self.embedded_to_local_qubit_indices) for op in self.embedded_rep.chp_ops(seed_or_state=seed_or_state)]
 
 
 class OpRepRepeated(OpRep):
@@ -128,7 +126,7 @@ class OpRepRepeated(OpRep):
         state_space = _StateSpace.cast(state_space)
         self.repeated_rep = rep_to_repeat
         self.num_repetitions = num_repetitions
-        super(OpRepRepeated, self).__init__(self.repeated_rep.chp_ops * self.num_repetitions, state_space)
+        super(OpRepRepeated, self).__init__(self.repeated_rep.chp_ops() * self.num_repetitions, state_space)
 
 
 class OpRepStochastic(OpRep):
@@ -136,7 +134,7 @@ class OpRepStochastic(OpRep):
     def __init__(self, basis, rate_poly_dicts, initial_rates, seed_or_state, state_space):
 
         self.basis = basis
-        assert (basis.name == 'pp'), "Only Pauli basis is allowed for 'chp' evotype"
+        assert (basis.name in ['pp', 'PP']), "Only Pauli basis is allowed for 'chp' evotype"
 
         if isinstance(seed_or_state, _RandomState):
             self.rand_state = seed_or_state
@@ -171,11 +169,19 @@ class OpRepStochastic(OpRep):
     def update_rates(self, rates):
         self.rates[:] = rates
 
-    @property
-    def chp_ops(self):
+    def chp_ops(self, seed_or_state=None):
+        # Optionally override RNG for this call
+        if seed_or_state is not None:
+            if isinstance(seed_or_state, _np.random.RandomState):
+                rand_state = seed_or_state
+            else:
+                rand_state = _np.random.RandomState(seed_or_state)
+        else:
+            rand_state = self.rand_state
+        
         rates = self.rates
         all_rates = [*rates, 1.0 - sum(rates)]  # Include identity so that probabilities are 1
-        index = self.rand_state.choice(self.basis.size, p=all_rates)
+        index = rand_state.choice(self.basis.size, p=all_rates)
 
         # If final entry, no operation selected
         if index == self.basis.size - 1:

--- a/pygsti/evotypes/chp/statereps.py
+++ b/pygsti/evotypes/chp/statereps.py
@@ -13,19 +13,22 @@ State representations for "stabilizer_slow" evolution type.
 
 from .. import basereps as _basereps
 from pygsti.baseobjs.statespace import StateSpace as _StateSpace
+from pygsti.tools import internalgates as _itgs
 
 
 def _update_chp_op(chp_op, old_to_new_qubit_index):
     if old_to_new_qubit_index is None:
         return chp_op
     else:
-        return ''.join([(old_to_new_qubit_index[c] if c in old_to_new_qubit_index else c)
-                        for c in chp_op])  # replaces, e.g. 'h 0' -> 'h 5'
+        new_op = chp_op.split()[0]
+        for qubit in chp_op.split()[1:]:
+            new_op += ' ' + old_to_new_qubit_index.get(qubit, qubit)
+        return new_op
 
 
 class StateRep(_basereps.StateRep):
     def __init__(self, chp_ops, state_space):
-        self.chp_ops = chp_ops
+        self.base_chp_ops = chp_ops
         self.state_space = _StateSpace.cast(state_space)
 
         assert(self.state_space.num_qubits >= 0), 'State space for "chp" evotype must consist entirely of qubits!'
@@ -37,27 +40,28 @@ class StateRep(_basereps.StateRep):
     def num_qubits(self):
         return self.state_space.num_qubits
 
-    def chp_str(self, target_labels=None):
-        if target_labels is not None:
-            assert(len(target_labels) == self.num_qubits), \
-                "Got {0} target labels instead of required {1}".format(len(target_labels), self.num_qubits)
+    def chp_ops(self, seed_or_state=None):
+        return self.base_chp_ops
 
-            # maps 0-based local op qubit index -> global qubit index
-            global_target_index = {str(i): str(self.qubit_label_to_index[lbl]) for i, lbl in enumerate(target_labels)}
-            op_str = '\n'.join(map(lambda op: _update_chp_op(op, global_target_index), self.chp_ops))
-        else:
-            op_str = '\n'.join(self.chp_ops)
+    def chp_str(self, seed_or_state=None):
+        op_str = '\n'.join(self.chp_ops(seed_or_state=seed_or_state))
+        if len(op_str) > 0: op_str += '\n'
         return op_str
 
     def copy(self):
-        return StateRep(self.chp_ops, self.state_space)
+        return StateRep(self.base_chp_ops, self.state_space)
 
 
 class StateRepComputational(StateRep):
     def __init__(self, zvals, basis, state_space):
-        assert(all([x == 0 for x in zvals])), "Temporarily you can only specify the all-zeros state - TODO"
-        self.basis = basis
+        assert (basis.name in ['pp', 'PP']), "Only Pauli basis is allowed for 'chp' evotype"
+
         chp_ops = []
+        x_ops = _itgs.standard_gatenames_chp_conversions()['Gxpi']
+        for i, zval in enumerate(zvals):
+            if zval:
+                chp_ops.extend([_update_chp_op(x_op, {'0': str(i)}) for x_op in x_ops])
+        
         super(StateRepComputational, self).__init__(chp_ops, state_space)
 
 
@@ -69,21 +73,25 @@ class StateRepComposed(StateRep):
         self.reps_have_changed()
 
     def reps_have_changed(self):
-        self.chp_ops = self.state_rep.chp_ops + self.op_rep.chp_ops
+        self.base_chp_ops = self.state_rep.chp_ops() + self.op_rep.chp_ops()
+    
+    def chp_ops(self, seed_or_state=None):
+        return self.state_rep.chp_ops(seed_or_state=seed_or_state) \
+            + self.op_rep.chp_ops(seed_or_state=seed_or_state)
 
-
-class StateRepTensorProduct(StateRep):
-    def __init__(self, factor_state_reps, state_space):
-        self.factor_reps = factor_state_reps
-        super(StateRepTensorProduct, self).__init__([], state_space)
-        self.reps_have_changed()
-
-    def reps_have_changed(self):
-        chp_ops = []
-        current_iqubit = 0
-        for factor in self.factor_reps:
-            local_to_tp_index = {str(iloc): str(itp) for iloc, itp in
-                                 enumerate(range(current_iqubit, current_iqubit + factor.num_qubits))}
-            chp_ops.extend([_update_chp_op(op, local_to_tp_index) for op in self.chp_ops])
-            current_iqubit += factor.num_qubits
-        self.chp_ops = chp_ops
+# TODO: Untested, only support computational and composed for now
+#class StateRepTensorProduct(StateRep):
+#    def __init__(self, factor_state_reps, state_space):
+#        self.factor_reps = factor_state_reps
+#        super(StateRepTensorProduct, self).__init__([], state_space)
+#        self.reps_have_changed()
+#
+#    def reps_have_changed(self):
+#        chp_ops = []
+#        current_iqubit = 0
+#        for factor in self.factor_reps:
+#            local_to_tp_index = {str(iloc): str(itp) for iloc, itp in
+#                                 enumerate(range(current_iqubit, current_iqubit + factor.num_qubits))}
+#            chp_ops.extend([_update_chp_op(op, local_to_tp_index) for op in self.chp_ops])
+#            current_iqubit += factor.num_qubits
+#        self.chp_ops = chp_ops

--- a/pygsti/forwardsims/weakforwardsim.py
+++ b/pygsti/forwardsims/weakforwardsim.py
@@ -82,7 +82,7 @@ class WeakForwardSimulator(_ForwardSimulator):
             for i in range(self.shots):
                 rand_state = _np.random.RandomState(self.base_seed + i)
 
-                outcome = self._compute_circuit_outcome_for_shot(circuit, resource_alloc, time, rand_state)
+                outcome = self._compute_circuit_outcome_for_shot(circuit, None, time, rand_state)
                 if outcome in probs:
                     probs[outcome] += 1.0 / self.shots
                 else:
@@ -119,9 +119,6 @@ class WeakForwardSimulator(_ForwardSimulator):
 
             # Distribute final probabilities
             probs = comm.bcast(probs, root=0)
-        
-        # Update seed for next run
-        self.base_seed += self.shots
 
         return probs
 

--- a/pygsti/forwardsims/weakforwardsim.py
+++ b/pygsti/forwardsims/weakforwardsim.py
@@ -10,6 +10,9 @@ Defines the WeakForwardSimulator calculator class
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+import numpy as _np
+import time as _time
+
 from pygsti.forwardsims.forwardsim import ForwardSimulator as _ForwardSimulator
 from pygsti.baseobjs import outcomelabeldict as _ld
 
@@ -24,7 +27,7 @@ class WeakForwardSimulator(_ForwardSimulator):
     function of ForwardSimulators.
     """
 
-    def __init__(self, shots, model=None):
+    def __init__(self, shots, model=None, base_seed=None):
         """
         Construct a new WeakForwardSimulator object.
 
@@ -34,11 +37,17 @@ class WeakForwardSimulator(_ForwardSimulator):
             Number of times to run each circuit to obtain an approximate probability
         model : Model
             Optional parent Model to be stored with the Simulator
+        base_seed: int, optional
+            Base seed for RNG of probabilitic operations during circuit simulation.
+            Incremented for every shot such that deterministic seeding behavior can be
+            carried out with both serial or MPI execution.
+            If not provided, falls back to using time.time() to get a valid seed.
         """
         self.shots = shots
+        self.base_seed = base_seed if base_seed is not None else int(_time.time())
         super().__init__(model)
 
-    def _compute_circuit_outcome_for_shot(self, spc_circuit, resource_alloc, time=None):
+    def _compute_circuit_outcome_for_shot(self, spc_circuit, resource_alloc, time=None, rand_state=None):
         """Compute outcome for a single shot of a circuit.
 
         Parameters
@@ -54,6 +63,9 @@ class WeakForwardSimulator(_ForwardSimulator):
         time : float, optional
             The *start* time at which `circuit` is evaluated.
 
+        rand_state: RandomState, optional
+            RNG object to use for probabilistic operations
+
         Returns
         -------
         outcome_label: tuple
@@ -64,13 +76,52 @@ class WeakForwardSimulator(_ForwardSimulator):
     def _compute_sparse_circuit_outcome_probabilities(self, circuit, resource_alloc, time=None):
         probs = _ld.OutcomeLabelDict()
 
-        # TODO: For parallelization, block over this for loop
-        for _ in range(self.shots):
-            outcome = self._compute_circuit_outcome_for_shot(circuit, resource_alloc, time)
-            if outcome in probs:
-                probs[outcome] += 1.0 / self.shots
-            else:
-                probs[outcome] = 1.0 / self.shots
+        comm = None if resource_alloc is None else resource_alloc.comm
+        if comm is None:
+            # No MPI, just serial execution
+            for i in range(self.shots):
+                rand_state = _np.random.RandomState(self.base_seed + i)
+
+                outcome = self._compute_circuit_outcome_for_shot(circuit, resource_alloc, time, rand_state)
+                if outcome in probs:
+                    probs[outcome] += 1.0 / self.shots
+                else:
+                    probs[outcome] = 1.0 / self.shots   
+        else:
+            # Have a comm, so use MPI to parallelize over shots
+            rank = comm.Get_rank()
+            size = comm.Get_size()
+
+            shots_per_rank = self.shots // size
+            remainder = self.shots % size
+            # Take care of any leftover shots
+            if rank < remainder:
+                shots_per_rank += 1
+
+            # Calculate how many shots other ranks are computing so we get the correct seed offset
+            seed_offset = shots_per_rank * rank + min(rank, remainder)
+
+            # Each rank runs their set of shots (with no resource alloc since we are using it at this level)
+            outcomes_per_rank = []
+            for i in range(shots_per_rank):
+                rand_state = _np.random.RandomState(self.base_seed + seed_offset + i)
+                outcomes_per_rank.append(self._compute_circuit_outcome_for_shot(circuit, None, time, rand_state))
+
+            # Collect all outcomes
+            outcomes = comm.gather(outcomes_per_rank, root=0)
+            if rank == 0:
+                for opr in outcomes:
+                    for outcome in opr:
+                        if outcome in probs:
+                            probs[outcome] += 1.0 / self.shots
+                        else:
+                            probs[outcome] = 1.0 / self.shots
+
+            # Distribute final probabilities
+            probs = comm.bcast(probs, root=0)
+        
+        # Update seed for next run
+        self.base_seed += self.shots
 
         return probs
 

--- a/pygsti/forwardsims/weakforwardsim.py
+++ b/pygsti/forwardsims/weakforwardsim.py
@@ -120,6 +120,9 @@ class WeakForwardSimulator(_ForwardSimulator):
             # Distribute final probabilities
             probs = comm.bcast(probs, root=0)
 
+        # Update seed so subsequent circuits have different RNG
+        self.base_seed += self.shots
+
         return probs
 
     # For WeakForwardSimulator, provide "bulk" interface based on the sparse interface

--- a/pygsti/modelmembers/operations/opfactory.py
+++ b/pygsti/modelmembers/operations/opfactory.py
@@ -493,7 +493,7 @@ class EmbeddingOpFactory(OpFactory):
             Can be any type of operation, e.g. a LinearOperator, State,
             Instrument, or POVM, depending on the label requested.
         """
-        assert(sslbls is not None), ("EmbeddedOpFactory objects should be asked to create "
+        assert(sslbls is not None), ("EmbeddingOpFactory objects should be asked to create "
                                      "operations with specific `sslbls`")
         assert(self.num_target_labels is None or len(sslbls) == self.num_target_labels), \
             ("EmbeddingFactory.create_op called with the wrong number (%s) of target labels!"
@@ -502,7 +502,7 @@ class EmbeddingOpFactory(OpFactory):
             raise ValueError("Not allowed to embed onto sslbls=" + str(sslbls))
 
         if self.embeds_factory:
-            op = self.embedded_factory_or_op.create_op(args, None)  # Note: will have its gpindices set already
+            op = self.embedded_factory_or_op.create_op(args, sslbls)  # Note: will have its gpindices set already
         else:
             op = self.embedded_factory_or_op
         embedded_op = _EmbeddedOp(self.state_space, sslbls, op)

--- a/pygsti/modelmembers/operations/opfactory.py
+++ b/pygsti/modelmembers/operations/opfactory.py
@@ -502,7 +502,7 @@ class EmbeddingOpFactory(OpFactory):
             raise ValueError("Not allowed to embed onto sslbls=" + str(sslbls))
 
         if self.embeds_factory:
-            op = self.embedded_factory_or_op.create_op(args, sslbls)  # Note: will have its gpindices set already
+            op = self.embedded_factory_or_op.create_op(args, None)  # Note: will have its gpindices set already
         else:
             op = self.embedded_factory_or_op
         embedded_op = _EmbeddedOp(self.state_space, sslbls, op)


### PR DESCRIPTION
Three major things are done here:

1. This takes the important bugfixes of the chp-many-qubit-fixes branch and ports them to a post 0.9.10 pyGSTi.
2. The chp_ops property in the OpReps is turned into a method to make it easier to consistently pass RNG in from the WeakForwardSimulator.
3. The CHPForwardSimulator is cleaned up. In particular, state/povm handling is streamlined.