### PR TITLE
Fixed bug in circuit mirroring for cz(theta) circuits

### DIFF
--- a/pygsti/algorithms/mirroring.py
+++ b/pygsti/algorithms/mirroring.py
@@ -295,8 +295,8 @@ def create_mirror_circuit(circ, pspec, circ_type='clifford+zxzxz'):
                                         correction_angles[q2] += -1 * theta
                     else:
                         quasi_inv_layer.append(_lbl.Label(compute_gate_inverse(g)))
-                    #add to circuit
-                    mc.append([quasi_inv_layer])
+                #add to circuit
+                mc.append([quasi_inv_layer])
 
             #increment position in circuit
             d_ind += 1


### PR DESCRIPTION
Fixed a bug in circuit mirroring of circuits containing Gczr(theta) gates, which created incorrect mirror circuits whenever there were parallel two-qubit gates in a layer. Created non-definite-outcome circuits, so will have created obviously faulty data for anyone who used it.