### PR TITLE
Feature Entanglement Fidelity Speedup and Bugfix

### DIFF
--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -708,7 +708,10 @@ def unitarity(a, mx_basis="gm"):
         B = _bt.change_basis(a, mx_basis, "gm")  # everything should be able to be put in the "gm" basis
 
     unital = B[1:d**2, 1:d**2]
-    u = _np.trace(_np.dot(_np.conj(_np.transpose(unital)), unital)) / (d**2 - 1)
+    #old version
+    #u = _np.trace(_np.dot(_np.conj(_np.transpose(unital)), unital)) / (d**2 - 1)
+    #new version
+    u= _np.einsum('ij,ji->', unital.conjugate().T, unital ) / (d**2 - 1)
     return u
 
 


### PR DESCRIPTION
Some requests were made to look into making the calculation of the entanglement fidelity faster. This version speeds up the calculation when using TP process matrices, and when the target is unitary. Same formula as before for this case, but this uses the magic that is Numpy's einsum to calculate the trace by only constructing the diagonal of the requisite matrix product. In practice I found this to be 130-280X faster than the previous implementation, depending on the number of qubits.

I have also added optional flags that allow a user to manually specify whether the inputs are TP and unitary to short circuit the built in tests, which add time since the unitarity check at least involves doing a full matrix multiplication. Code still falls back to the built in tests when these flags aren't specified.

Also adds a minor bugfix to the TP check code to fix one of the ranges. This typo was causing the TP check to always fail which means that the fast implementation for the special case described above was never invoked and we were always falling back to the use of the Jamiolkowski isomorphism (which is orders of magnitude slower).

As a BOGO special I also used the same einsum trick to speedup the unitarity calculation. Not requested, but I noticed it'd apply there too.