### PR TITLE
Bugfix matrixmod2 determinism

### DIFF
--- a/pygsti/algorithms/randomcircuit.py
+++ b/pygsti/algorithms/randomcircuit.py
@@ -1557,7 +1557,6 @@ def create_direct_rb_circuit(pspec, clifford_compilations, length, qubit_labels=
             assert(bit == 0), "Ideal output is not the all 0s computational basis state!"
         idealout.append(int(measurement_out[1]))
     idealout = tuple(idealout)
-    full_circuit.done_editing()
 
     if not partitioned: outcircuit = full_circuit
     else:


### PR DESCRIPTION
**Adds the ability to seed Clifford compilations used in RB so deterministic behavior results**

Plumbs a `RandomState` object through functions in `compilers.py` and `matrixmod2.py` so that the randomness used therein can be seeded properly.  This PR also removes a duplicate `done_editing` call in `randomcircuit.py` that I stumbled upon as I was making the main updates.

I think (& hope) that this PR may fix a long-standing issue of the pyGSTi unit tests occasionally failing because of an RB circuit mismatch.  This erroring could be "fixed" by simply rerunning the unit tests again, which was suspicious and unnerving. 