### PR TITLE
Feature fpr algorithm performance

### DIFF
--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1510,7 +1510,8 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
         printer.log('Index of best update fiducial : %d'%(idx_current_best_update), 3)
         
         #check whether we have found an acceptable reduced set of fiducials.
-        if (nNeededPairs>=min_pairs_needed) and (current_best_score.minor < inv_trace_tol*inv_trace_complete):
+        if (nNeededPairs>=min_pairs_needed) and (current_best_score.minor < inv_trace_tol*inv_trace_complete)\
+            and (current_best_score.major <= -gsGerm.num_params):
             break
 
     #Get list of pairs as tuples for printing & returning

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -16,6 +16,7 @@ import random as _random
 
 import numpy as _np
 import scipy.special as _spspecial
+import scipy.linalg as _sla
 
 from math import ceil
 import time
@@ -29,6 +30,11 @@ from pygsti.tools import apply_aliases_to_circuits as _apply_aliases_to_circuits
 from pygsti.tools import remove_duplicates as _remove_duplicates
 from pygsti.tools import slicetools as _slct
 from pygsti.tools.legacytools import deprecate as _deprecated_fn
+
+from pygsti.algorithms.germselection import construct_update_cache, minamide_style_inverse_trace, compact_EVD, compact_EVD_via_SVD
+from pygsti.algorithms import scoring as _scoring
+
+from pygsti.tools.matrixtools import print_mx
 
 import warnings
 
@@ -298,7 +304,6 @@ def find_sufficient_fiducial_pairs(target_model, prep_fiducials, meas_fiducials,
                       for iEStr in range(nEStrs)]
     return listOfAllPairs
 
-#@_deprecated_fn('find_sufficient_fiducial_pairs_per_germ_power')
 def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_fiducials,
                                             germs, pre_povm_tuples="first",
                                             search_mode="random", constrain_to_tp=True,
@@ -533,7 +538,179 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
             pairListDict[germ] = goodPairList  # add to final list of per-germ pairs
 
     return pairListDict
+    
+def find_sufficient_fiducial_pairs_per_germ_greedy(target_model, prep_fiducials, meas_fiducials,
+                                                germs, pre_povm_tuples="first", constrain_to_tp=True,
+                                                inv_trace_tol= 10, initial_seed_mode='random',
+                                                evd_tol=1e-10, sensitivity_threshold=1e-10, seed=None ,verbosity=0, check_complete_fid_set=True,
+                                                mem_limit=None):
+    """
+    Finds a per-germ set of fiducial pairs that are amplificationally complete.
 
+    A "standard" set of GST circuits consists of all circuits of the form:
+
+    statePrep + prepFiducial + germPower + measureFiducial + measurement
+
+    This set is typically over-complete, and it is possible to restrict the
+    (prepFiducial, measureFiducial) pairs to a subset of all the possible
+    pairs given the separate `prep_fiducials` and `meas_fiducials` lists.  This function
+    attempts to find sets of fiducial pairs, one set per germ, that still
+    amplify all of the model's parameters (i.e. is "amplificationally
+    complete").  For each germ, a fiducial pair set is found that amplifies
+    all of the "parameters" (really linear combinations of them) that the
+    particular germ amplifies.
+
+    To test whether a set of fiducial pairs satisfies this condition, the
+    sum of projectors `P_i = dot(J_i,J_i^T)`, where `J_i` is a matrix of the
+    derivatives of each of the selected (prepFiducial+germ+effectFiducial)
+    sequence probabilities with respect to the i-th germ eigenvalue (or
+    more generally, amplified parameter), is computed.  If the fiducial-pair
+    set is sufficient, the rank of the resulting sum (an operator) will be
+    equal to the total (maximal) number of parameters the germ can amplify.
+
+    Parameters
+    ----------
+    target_model : Model
+        The target model used to determine amplificational completeness.
+
+    prep_fiducials : list of Circuits
+        Fiducial circuits used to construct an informationally complete
+        effective preparation.
+
+    meas_fiducials : list of Circuits
+        Fiducial circuits used to construct an informationally complete
+        effective measurement.
+
+    germs : list of Circuits
+        The germ circuits that are repeated to amplify errors.
+
+    pre_povm_tuples : list or "first", optional
+        A list of `(prepLabel, povmLabel)` tuples to consider when
+        checking for completeness.  Usually this should be left as the special
+        (and default) value "first", which considers the first prep and POVM
+        contained in `target_model`.
+
+    search_mode : {"sequential","random"}, optional
+        If "sequential", then all potential fiducial pair sets of a given length
+        are considered in sequence (per germ) before moving to sets of a larger
+        size.  This can take a long time when there are many possible fiducial
+        pairs.  If "random", then only `n_random` randomly chosen fiducial pair
+        sets are considered for each set size before the set is enlarged.
+
+    constrain_to_tp : bool, optional
+        Whether or not to consider non-TP parameters the the germs amplify.  If
+        the fiducal pairs will be used in a GST estimation where the model is
+        constrained to being trace-preserving (TP), this should be set to True.
+
+    n_random : int, optional
+        The number of random-pair-sets to consider for a given set size.
+        
+    min_iterations : int, optional
+        A minimum number of candidate fiducial sets to try for a given
+        set size before allowing the search to exit early in the event
+        an acceptable candidate solution has already been found.
+        
+    base_loweig_tol : float, optional (default 1e-1)
+        A relative threshold value for determining if a fiducial set
+        is an acceptable candidate solution. The tolerance value indicates
+        the decrease in the magnitude of the smallest eigenvalue of
+        the Jacobian we're will to accept relative to that of the full
+        fiducial set.
+
+    seed : int, optional
+        The seed to use for generating random-pair-sets.
+
+    verbosity : int, optional
+        How much detail to print to stdout.
+       
+    num_soln_returned : int, optional
+        The number of candidate solutions to return for each run of the fiducial pair search.
+        
+    type_soln_returned : str, optional
+        Which type of criteria to use when selecting which of potentially many candidate fiducial pairs to search through.
+        Currently only "best" supported which returns the num_soln_returned best candidates as measured by minimum eigenvalue.
+        
+    retry_for_smaller : bool, optional
+        If true then a second search is performed seeded by the candidate solution sets found in the first pass.
+        The search routine then randomly subsamples sets of fiducial pairs from these candidate solutions to see if
+        a smaller subset will suffice.
+
+    mem_limit : int, optional
+        A memory limit in bytes.
+
+    Returns
+    -------
+    dict
+        A dictionary whose keys are the germ circuits and whose values are
+        lists of (iRhoFid,iMeasFid) tuples of integers, each specifying the
+        list of fiducial pairs for a particular germ (indices are into
+        `prep_fiducials` and `meas_fiducials`).
+    """
+
+    printer = _baseobjs.VerbosityPrinter.create_printer(verbosity)
+
+    if pre_povm_tuples == "first":
+        firstRho = list(target_model.preps.keys())[0]
+        firstPOVM = list(target_model.povms.keys())[0]
+        pre_povm_tuples = [(firstRho, firstPOVM)]
+    
+    #brief intercession to calculate the number of degrees of freedom for the povm.
+    num_effects= len(list(target_model.povms[pre_povm_tuples[0][1]].keys()))
+    dof_per_povm= num_effects-1
+    
+    #debugging
+    #print('Number of DoF for POVM: ', dof_per_povm)
+       
+    pre_povm_tuples = [(_circuits.Circuit((prepLbl,)), _circuits.Circuit((povmLbl,)))
+                       for prepLbl, povmLbl in pre_povm_tuples]
+    
+
+    pairListDict = {}  # dict of lists of 2-tuples: one pair list per germ
+    
+    printer.log("------  Per Germ (L=1) Fiducial Pair Reduction --------")
+    with printer.progress_logging(1):
+        for i, germ in enumerate(germs):
+        
+            #debugging
+            #print('Current Germ: ', germ)
+
+            #Create a new model containing static target gates and a
+            # special "germ" gate that is parameterized only by it's
+            # eigenvalues (and relevant off-diagonal elements)
+            gsGerm = target_model.copy()
+            gsGerm.set_all_parameterizations("static")
+            germMx = gsGerm.sim.product(germ)
+            gsGerm.operations["Ggerm"] = _EigenvalueParamDenseOp(
+                germMx, True, constrain_to_tp)
+
+            printer.show_progress(i, len(germs),
+                                  suffix='-- %s germ (%d params)' %
+                                  (repr(germ), gsGerm.num_params))
+            #Debugging
+            #print(gsGerm.operations["Ggerm"].evals)
+            #print(gsGerm.operations["Ggerm"].params)
+
+            #Determine which fiducial-pair indices to iterate over
+            #initial run
+            candidate_solution_list, best_score = _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm_tuples,
+                                                                    gsGerm, 1, mem_limit,
+                                                                    printer, seed, dof_per_povm,
+                                                                    inv_trace_tol, initial_seed_mode=initial_seed_mode,
+                                                                    check_complete_fid_set=check_complete_fid_set, evd_tol=evd_tol,
+                                                                    sensitivity_threshold=sensitivity_threshold)
+            
+            #print some output about the minimum eigenvalue acheived.
+            printer.log('Score Achieved: ' + str(best_score), 2)
+            
+            try:
+                assert(candidate_solution_list is not None)
+            except AssertionError as err:
+                print('Failed to find an acceptable fiducial set for germ power pair: ', germ)
+                print(err)
+
+            pairListDict[germ] = candidate_solution_list  # add to final list of per-germ pairs
+
+    return pairListDict
 
 def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, meas_fiducials,
                                                   germs, max_lengths,
@@ -1311,3 +1488,334 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
         print('Failed to find a sufficient fiducial set.')
     printer.log('Exiting _get_per_germ_power_fidpairs', 4)
     return goodPairList, bestFirstEval
+    
+
+#New greedy-style FPR algorithm:
+# Helper function for per_germ and per_germ_power FPR
+# This version uses a greedy style algorithm and an
+# alternative objective function which leverages the performance enhancements
+# utilized for the germ selection algorithm using low-rank updates.
+def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm_tuples,
+                                 gsGerm, power, mem_limit, printer, seed, dof_per_povm,
+                                 inv_trace_tol=10, initial_seed_mode= 'random',
+                                 check_complete_fid_set= True, evd_tol=1e-10, sensitivity_threshold= 1e-10):
+    #Get dP-matrix for full set of fiducials, where
+    # P_ij = <E_i|germ^exp|rho_j>, i = composite EVec & fiducial index,
+    #   j is similar, and derivs are wrt the "eigenvalues" of the germ
+    #  (i.e. the parameters of the gsGerm model).
+    
+    printer.log('Entered helper function _get_per_germ_power_fidpairs_greedy', 3)
+    
+    #debugging
+    #print('pre-povm-tuples: ', pre_povm_tuples)
+    
+    # nRhoStrs, nEStrs = len(prep_fiducials), len(meas_fiducials)
+    nEStrs = len(meas_fiducials)
+    nPossiblePairs = len(prep_fiducials) * len(meas_fiducials)
+    
+    allPairIndices = list(range(nPossiblePairs))
+    
+    #debugging
+    printer.log('Number of possible pairs: %d'%(nPossiblePairs), 4)
+
+    #Determine which fiducial-pair indices to iterate over
+    goodPairList = None; bestFirstEval = []; bestPairs = {}
+    #loops over a number of pairs between min_pairs_needed and up to and not including the number of possible pairs
+    
+    min_pairs_needed= ceil((gsGerm.num_params/(nPossiblePairs*dof_per_povm))*nPossiblePairs)
+    printer.log('Minimum Number of Pairs Needed for this Germ: %d'%(min_pairs_needed), 2)
+    
+
+    lst = _gsc.create_circuits(
+        "pp[0]+f0+germ*power+f1+pp[1]", f0=prep_fiducials, f1=meas_fiducials,
+        germ=_circuits.Circuit('Ggerm'), pp=pre_povm_tuples, power=power,
+        order=('f0', 'f1', 'pp'))
+    #debugging
+    #print('List of circuits: ', lst)
+
+    resource_alloc = _baseobjs.ResourceAllocation(comm=None, mem_limit=mem_limit)
+    layout = gsGerm.sim.create_layout(lst, None, resource_alloc, array_types=('ep',), verbosity=0)
+
+    #debugging:
+    #print('Num Prep Fids: ', len(prep_fiducials))
+    #print('Num Measurement Fids: ', len(meas_fiducials))
+
+    elIndicesForPair = [[] for i in range(len(prep_fiducials) * len(meas_fiducials))]
+    nPrepPOVM = len(pre_povm_tuples)
+    for k in range(len(prep_fiducials) * len(meas_fiducials)):
+        for o in range(k * nPrepPOVM, (k + 1) * nPrepPOVM):
+            # "original" indices into lst for k-th fiducial pair
+            elIndicesForPair[k].extend(_slct.to_array(layout.indices_for_index(o)))
+    
+    printer.log('Constructing Jacobian for Full Fiducial Set' , 3)
+    
+    local_dPall = layout.allocate_local_array('ep', 'd')
+    gsGerm.sim.bulk_fill_dprobs(local_dPall, layout, None)  # num_els x num_params
+    dPall = local_dPall.copy()  # local == global (no layout.gather required) b/c we used comm=None above
+    layout.free_local_array(local_dPall)  # not needed - local_dPall isn't shared (comm=None)
+    
+    printer.log('Calculating Inverse Trace of Full Fiducial Set', 3)
+    
+    # Construct sum of projectors onto the directions (1D spaces)
+    # corresponding to varying each parameter (~eigenvalue) of the
+    # germ.  If the set of fiducials is sufficient, then the rank of
+    # the resulting operator will equal the number of parameters,
+    # indicating that the P matrix is (independently) sensitive to
+    # each of the germ parameters (~eigenvalues), which is *all* we
+    # want sensitivity to.
+    RANK_TOL = 1e-7 #HARDCODED
+    #rank = _np.linalg.matrix_rank(_np.dot(dPall, dPall.T), RANK_TOL)
+    
+    if check_complete_fid_set:
+        spectrum_full_fid_set= _np.abs(_np.linalg.eigvalsh(_np.dot(dPall, dPall.T)))
+        
+        #use the spectrum to calculate the rank instead.
+        rank= _np.count_nonzero(spectrum_full_fid_set>RANK_TOL)
+    
+        if rank < gsGerm.num_params:  # full fiducial set should work!
+            #print(rank)
+            raise ValueError("Incomplete fiducial-pair set!")
+    
+        spectrum_full_fid_set= list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dPall, dPall.T)))))
+        
+        imin_full_fid_set = len(spectrum_full_fid_set) - gsGerm.num_params
+        condition_full_fid_set = spectrum_full_fid_set[-1] / spectrum_full_fid_set[imin_full_fid_set] if (spectrum_full_fid_set[imin_full_fid_set] > 0) else _np.inf
+        
+        
+        #debugging
+        printer.log('J J^T Rank Full Fiducial Set: %d' % rank, 2)
+        printer.log('Num Parameters (should equal above rank): %d' % (gsGerm.num_params), 2)
+        printer.log('Full Fiducial Set Min Eigenvalue: %f' % (spectrum_full_fid_set[imin_full_fid_set]), 2)
+        printer.log('Full Fiducial Set Max Eigenvalue: %f' % (spectrum_full_fid_set[-1]), 2)
+        printer.log('Full Fiducial Set Condition Number: %f' % (condition_full_fid_set), 2)
+    
+    inv_trace_complete= _np.trace(_np.linalg.pinv(dPall.T@dPall))
+    
+    printer.log('Full Fiducial Set Inverse Trace: %f' % (inv_trace_complete), 2)
+    
+    #It can happen that there are fiducial pairs which are entirely insensitive to any
+    #of the kite parameters, which show up as sets of empty rows in the jacobian.
+    #We should identify which fiducial pairs those are and remove them from the 
+    #search space.
+    printer.log('Removing useless fidcuial pairs with trivial sensitivity to the germ kite parameters. Sensitivity threshold is %.3f'%(sensitivity_threshold), 3)
+    printer.log('Number of fiducial pairs before filtering trivial ones: %d' %(len(allPairIndices)), 3)
+    cleaned_pair_indices_list= filter_useless_fid_pairs(allPairIndices, elIndicesForPair, dPall)
+    printer.log('Number of fiducial pairs after filtering trivial ones: %d' %(len(cleaned_pair_indices_list)), 3)
+    #Change the value of nPossiblePairs to reflect the filtered list
+    nPossiblePairs= len(cleaned_pair_indices_list)
+    
+    #Below will take a *subset* of the rows in dPall
+    # depending on which (of all possible) fiducial pairs
+    # are being considered.
+    
+    rng= _np.random.default_rng(seed=seed)
+    
+    #Need to choose how to initially seed a set of candidate fiducials.
+    #I can think of two ways atm, one is to seed it with a random set of
+    #fiducial pairs of size min_pairs_needed, the other is to run
+    #the greedy search all the way from zero.
+    
+    #If random, pick a random set of fiducial pairs to start the search with:
+    if initial_seed_mode=='random':
+        initial_fiducial_set= list(_random_combination(cleaned_pair_indices_list, min_pairs_needed))
+        initial_pair_count= min_pairs_needed
+    #if starting from zero then we'll change min_pairs_needed to zero and set the initial_fiducial_set
+    #to None (may not be needed, will remove the placeholder value later if that is the case). May also
+    #need some special logic to handle the very first step of the search.
+    elif initial_seed_mode=='greedy':
+        initial_fiducial_set=None
+        initial_pair_count=0
+    
+    printer.log('Initial fiducial set: ' + str(initial_fiducial_set), 3)
+    
+    current_best_fiducial_list= initial_fiducial_set
+    
+    printer.log('Building Compact EVD Cache For Fiducial Updates', 3)
+    #build a compact evd cache for the pairs we are iterating over too.
+    fiducial_update_EVD_cache= construct_compact_evd_cache(cleaned_pair_indices_list, dPall,
+                                                            elIndicesForPair, 
+                                                            eigenvalue_tolerance=evd_tol)
+                                                            
+    #print('fiducial_update_EVD_cache: ', fiducial_update_EVD_cache)                                                        
+    
+    #debugging:
+    #print('Initial Seed Fiducial Set: ', current_best_fiducial_list)
+    
+    for nNeededPairs in range(initial_pair_count, nPossiblePairs):
+        if nNeededPairs < min_pairs_needed:
+            printer.log("Searching for the best initial set of %d pairs. Need %d pairs for the initial set." %
+                    (nNeededPairs+1, min_pairs_needed), 2)
+        else:
+            printer.log("Beginning search for a good set of %d pairs" %
+                        (nNeededPairs), 2)
+            printer.log("    Inverse trace must be <= %g times more than the value for the full fiducial set" %
+                        (inv_trace_tol),2)
+            
+        #The pairs we want to iterate over in the upcoming greedy search are those
+        #in the set difference of allPairIndices-current_best_fiducial_list
+        if current_best_fiducial_list is None:
+            pairIndicesToIterateOver = cleaned_pair_indices_list
+            current_best_jacobian= None
+        else:
+            pairIndicesToIterateOver = list(set(cleaned_pair_indices_list)-set(current_best_fiducial_list))
+            current_best_jacobian= _np.take(dPall, _np.concatenate([elIndicesForPair[i] for i in current_best_fiducial_list]), axis=0)
+            #take the gramian of this jacobian.
+            current_best_jacobian= current_best_jacobian.T@current_best_jacobian
+            current_best_inv_trace = _np.trace(_np.linalg.pinv(current_best_jacobian))
+         
+        #Construct the update cache for the current_best_fiducial_list's jacobian.
+        if current_best_jacobian is not None:
+            update_cache= construct_update_cache(current_best_jacobian, evd_tol=evd_tol)
+            current_best_rank= len(update_cache[0])
+            #debugging
+            #print('Shape current_best_jacobian: ', current_best_jacobian.shape)
+            #print('Update Cache: ', update_cache)
+            #make a CompositeScore object for the current best fiducial set.
+            current_best_score= _scoring.CompositeScore(-current_best_rank, current_best_inv_trace, current_best_rank)
+            
+            
+        else:
+            update_cache= None  
+            current_best_score= None
+                                                                
+        #print('Fiducial Update EVD Cache: ', fiducial_update_EVD_cache)
+            
+        #debugging
+        printer.log('Initial Score: ' + str(current_best_score), 3)
+        
+        
+        for pairIndexToTest in pairIndicesToIterateOver:
+            
+            
+            printer.log('Tested Index: %d' %(pairIndexToTest), 4)
+            
+            # Same computation of rank as above, but with only a
+            # subset of the total fiducial pairs.
+            elementIndicesToTest = elIndicesForPair[pairIndexToTest]
+            update_to_test = _np.take(dPall, elementIndicesToTest, axis=0)  # subset_of_num_elements x num_params
+            
+            #debugging:
+            #print('Update being tested: ', update_to_test)
+            #print('Shape of update tested: ', update_to_test.shape)
+            
+            #We need some logic to handle the case where we are starting from scratch
+            #and don't have an initial current_best_jacobian.
+            if (initial_pair_count==0) and (nNeededPairs==0) and (current_best_jacobian is None):
+                updated_pinv, updated_rank= _sla.pinv(update_to_test.T@update_to_test, return_rank=True)
+                updated_inv_trace= _np.trace(updated_pinv)
+                current_best_score =  _scoring.CompositeScore(-updated_rank, updated_inv_trace, updated_rank)
+                idx_current_best_update = pairIndexToTest
+            elif (initial_pair_count==0) and (nNeededPairs==0) and (current_best_jacobian is not None):
+                updated_pinv, updated_rank= _sla.pinv(update_to_test.T@update_to_test, return_rank=True)
+                updated_inv_trace= _np.trace(updated_pinv)
+                updated_score =  _scoring.CompositeScore(-updated_rank, updated_inv_trace, updated_rank)
+                if updated_score < current_best_score:
+                    current_best_inv_trace= inv_trace_to_test
+                    idx_current_best_update = pairIndexToTest
+            #otherwise we already have an initial Jacobian and should use the standard update logic.
+            else:
+                #print('Update from EVD cache: ', fiducial_update_EVD_cache[pairIndexToTest])
+                updated_inv_trace, updated_rank, _ = minamide_style_inverse_trace(fiducial_update_EVD_cache[pairIndexToTest], 
+                                                                 update_cache[0], update_cache[1], 
+                                                                 update_cache[2], False)                                       
+                #debugging
+                #test_index_list = current_best_fiducial_list.copy()
+                #test_index_list.append(pairIndexToTest)
+                #direct_element_test = _np.concatenate([elIndicesForPair[i] for i in test_index_list])
+                #direct_jacobian_test = _np.take(dPall, direct_element_test, axis=0)  # subset_of_num_elements x num_params# subset_of_num_elements x num_params
+            
+                #updated_inv_trace_direct= _np.trace(_np.linalg.pinv(direct_jacobian_test.T@direct_jacobian_test))
+                
+                #print('updated inv trace: ', updated_inv_trace)
+                #print('updated inv trace direct: ', updated_inv_trace_direct)
+                
+                #updated_spectrum= _np.linalg.eigvalsh(direct_jacobian_test.T@direct_jacobian_test)
+                #print('Updated spectrum: ', updated_spectrum[updated_spectrum>1e-10] )
+                #print('Original spectrum: ', update_cache[0])
+                
+                #Compare the matrices from doing the additive update to the append based update
+                #and confirm they give the same thing.
+                #print('Norm between direct Jacobian and additive update Jacobian: ', _np.linalg.norm((direct_jacobian_test.T@direct_jacobian_test) - (current_best_jacobian + update_to_test.T@update_to_test)))
+                
+                #print('Norm between update_to_test.T@update_to_test and fiducial_update_EVD_cache[pairIndexToTest]@fiducial_update_EVD_cache[pairIndexToTest].T: ',
+                #      _np.linalg.norm(update_to_test.T@update_to_test-fiducial_update_EVD_cache[pairIndexToTest]@fiducial_update_EVD_cache[pairIndexToTest].T))
+                
+                #print('Rank Minamide: ', updated_rank) 
+                #print('Rank Directly Updated Jacobian: ', _np.linalg.matrix_rank(direct_jacobian_test.T@direct_jacobian_test))
+                
+                #print('Rank of tested update: ', _np.linalg.matrix_rank(update_to_test))
+                
+                #Construct a composite score object where the major score is
+                #the rank of the updated jacobian and the minor score is
+                #the inverse trace.
+                
+                updated_score= _scoring.CompositeScore(-updated_rank, updated_inv_trace, updated_rank)
+                
+                printer.log('Updated Score: '+ str(updated_score), 3)
+                
+                if updated_score < current_best_score:
+                    current_best_score=updated_score
+                    idx_current_best_update= pairIndexToTest
+        
+        #Add the best index found to the list for current_best_fiducial_list (or initialize it if this list isn't set yet).
+        if current_best_fiducial_list is None:
+            current_best_fiducial_list= [idx_current_best_update]
+        else:
+            current_best_fiducial_list.append(idx_current_best_update)
+            
+        printer.log('Index of best update fiducial : %d'%(idx_current_best_update), 3)
+        
+        #check whether we have found an acceptable reduced set of fiducials.
+        if (nNeededPairs>=min_pairs_needed) and (current_best_score.minor < inv_trace_tol*inv_trace_complete):
+            break
+
+    #Get list of pairs as tuples for printing & returning
+    goodPairList = []
+    for i in current_best_fiducial_list:
+        prepfid_index = i // nEStrs; iEStr = i - prepfid_index * nEStrs
+        goodPairList.append((prepfid_index, iEStr))        
+                    
+    #debugging
+    if goodPairList is None:
+        print('Failed to find a sufficient fiducial set.')
+    printer.log('Exiting _get_per_germ_power_fidpairs_greedy', 4)
+    return goodPairList, current_best_score
+
+    
+#helper function for building a compact evd cache:
+def construct_compact_evd_cache(fiducial_indices, complete_jacobian, element_map, eigenvalue_tolerance=1e-10):
+    sqrteU_dict = {}
+    
+    #print('Complete Jacobian Shape: ', complete_jacobian.shape)
+    #print('Complete Jacobian: ')
+    #print_mx(complete_jacobian)
+    
+    for fid_index in fiducial_indices:
+        fid_element_indices = element_map[fid_index]
+        fid_jacobian_components = _np.take(complete_jacobian, fid_element_indices, axis=0)
+        #print('fid_jacobian_components: ') 
+        #print_mx(fid_jacobian_components)
+        e, U = compact_EVD(fid_jacobian_components.T@fid_jacobian_components, eigenvalue_tolerance)
+        #print('eigenvalues: ', e)
+        #print('U: ', U)
+        sqrteU_dict[fid_index]= U@_np.diag(_np.sqrt(e))  
+    return sqrteU_dict    
+    
+    
+#helper function for removing fiducial pairs which are entirely insensitive to the kite
+#parameters from the search space:
+def filter_useless_fid_pairs(fiducial_indices, element_map, complete_jacobian, sensitivity_threshold= 1e-10):
+    
+    #loop through the list of fiducial pair indices and extract the components of the jacobian for
+    #that fiducial pair. The take the norm of that matrix and check if it is sufficiently larger 
+    #than the sensitivity threshold to determine if it is zero (numpy used Frobenius by default).
+    useful_fiducial_indices=[]
+    for fid_index in fiducial_indices:
+        fid_element_indices = element_map[fid_index]
+        fid_jacobian_components = _np.take(complete_jacobian, fid_element_indices, axis=0)
+        if _np.linalg.norm(fid_jacobian_components)>sensitivity_threshold:
+            useful_fiducial_indices.append(fid_index)
+        else:
+            continue
+    #return the list of fiducial pair indices with non-trivial frobenius norm.
+    return useful_fiducial_indices

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -423,9 +423,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
     #brief intercession to calculate the number of degrees of freedom for the povm.
     num_effects= len(list(target_model.povms[pre_povm_tuples[0][1]].keys()))
     dof_per_povm= num_effects-1
-    
-    #debugging
-    #print('Number of DoF for POVM: ', dof_per_povm)
        
     pre_povm_tuples = [(_circuits.Circuit((prepLbl,)), _circuits.Circuit((povmLbl,)))
                        for prepLbl, povmLbl in pre_povm_tuples]
@@ -446,10 +443,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
     printer.log("------  Per Germ (L=1) Fiducial Pair Reduction --------")
     with printer.progress_logging(1):
         for i, germ in enumerate(germs):
-        
-            #debugging
-            #print('Current Germ: ', germ)
-
             #Create a new model containing static target gates and a
             # special "germ" gate that is parameterized only by it's
             # eigenvalues (and relevant off-diagonal elements)
@@ -462,9 +455,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
             printer.show_progress(i, len(germs),
                                   suffix='-- %s germ (%d params)' %
                                   (repr(germ), gsGerm.num_params))
-            #Debugging
-            #print(gsGerm.operations["Ggerm"].evals)
-            #print(gsGerm.operations["Ggerm"].params)
 
             #Determine which fiducial-pair indices to iterate over
             #initial run
@@ -474,7 +464,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
                                                                     min_iterations, base_loweig_tol, candidate_set_seed=None,
                                                                     num_soln_returned=num_soln_returned, type_soln_returned=type_soln_returned)
                                                                    
-            
             #the algorithm isn't guaranteed to actually find the requested number of solutions, so check how many there actually are
             #by checking the length of the list of returned eigenvalues. 
             actual_num_soln_returned= len(bestFirstEval)
@@ -483,7 +472,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
             
             #The goodPairList is now a dictionary with the keys corresponding to the minimum eigenvalue of the candidate solution.
             #iterate through the values of the dictionary.
-            
             if retry_for_smaller:
             
                 printer.log('Resampling from returned solutions to search for smaller sets.',2)
@@ -492,7 +480,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
                 
                 updated_solns=[]
                 for candidate_solution in candidate_solution_list.values():
-                
                     #now do a seeded run for each of the candidate solutions returned in the initial run:
                     #for these internal runs just return a single solution. 
                     reducedPairlist, bestFirstEval = _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples,
@@ -502,12 +489,9 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
                                                                             num_soln_returned= 1, type_soln_returned='best')
                     #This should now return a dictionary with a single entry. Append that entry to a running list which we'll process at the end.
                     updated_solns.append(list(reducedPairlist.values())[0])
-                
-                #debugging:
-                printer.log('Finished resampling from returned solutions to search for smaller sets.',2)
-                
 
-                
+                printer.log('Finished resampling from returned solutions to search for smaller sets.',2)
+
                 #At the very worst we should find that the updated solutions are the same length as the original candidate we seeded with
                 #(in fact, it would just return the seed in that case). So we should be able to just check for which of the lists of fiducial pairs is shortest.
                 solution_lengths= [len(fid_pair_list) for fid_pair_list in updated_solns]
@@ -520,7 +504,6 @@ def find_sufficient_fiducial_pairs_per_germ(target_model, prep_fiducials, meas_f
                 #print some output about the minimum eigenvalue acheived.
                 printer.log('Minimum Eigenvalue Achieved: %f' %(bestFirstEval[0]), 3)
 
-                
             else:
                 #take the first entry of the candidate solution list if there is more than one.
                 goodPairList= list(candidate_solution_list.values())[0]
@@ -657,23 +640,15 @@ def find_sufficient_fiducial_pairs_per_germ_greedy(target_model, prep_fiducials,
     #brief intercession to calculate the number of degrees of freedom for the povm.
     num_effects= len(list(target_model.povms[pre_povm_tuples[0][1]].keys()))
     dof_per_povm= num_effects-1
-    
-    #debugging
-    #print('Number of DoF for POVM: ', dof_per_povm)
        
     pre_povm_tuples = [(_circuits.Circuit((prepLbl,)), _circuits.Circuit((povmLbl,)))
                        for prepLbl, povmLbl in pre_povm_tuples]
-    
 
     pairListDict = {}  # dict of lists of 2-tuples: one pair list per germ
     
     printer.log("------  Per Germ (L=1) Fiducial Pair Reduction --------")
     with printer.progress_logging(1):
         for i, germ in enumerate(germs):
-        
-            #debugging
-            #print('Current Germ: ', germ)
-
             #Create a new model containing static target gates and a
             # special "germ" gate that is parameterized only by it's
             # eigenvalues (and relevant off-diagonal elements)
@@ -686,9 +661,6 @@ def find_sufficient_fiducial_pairs_per_germ_greedy(target_model, prep_fiducials,
             printer.show_progress(i, len(germs),
                                   suffix='-- %s germ (%d params)' %
                                   (repr(germ), gsGerm.num_params))
-            #Debugging
-            #print(gsGerm.operations["Ggerm"].evals)
-            #print(gsGerm.operations["Ggerm"].params)
 
             #Determine which fiducial-pair indices to iterate over
             #initial run
@@ -826,36 +798,15 @@ def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, 
         `prep_fiducials` and `meas_fiducials`).
     """
     
-    #debugging
-    #print('--------------User Input Parameters-------------')
-    #print('Target Model: ', target_model)
-    #print('Prep Fiducials: ', prep_fiducials)
-    #print('Measurement Fiducials: ', meas_fiducials)
-    #print('Germs: ', germs)
-    #print('Max Lengths: ', max_lengths)
-    #print('pre_povm_tuples: ', pre_povm_tuples)
-    #print('Search Mode: ', search_mode)
-    #print('Truncation Scheme: ', trunc_scheme)
-    #print('Number of Random Iterations?: ', n_random)
-    #print('RNG Seed: ', seed)
-    #print('Verbosity: ', verbosity)
-    #print('Memory Limit: ', mem_limit)
-    
-
     printer = _baseobjs.VerbosityPrinter.create_printer(verbosity)
 
     if pre_povm_tuples == "first":
         firstRho = list(target_model.preps.keys())[0]
         firstPOVM = list(target_model.povms.keys())[0]
         pre_povm_tuples = [(firstRho, firstPOVM)]
-        
-        #debugging
-        #print('First Rho: ', firstRho)
-        #print('First POVM: ', firstPOVM)
+
     pre_povm_tuples = [(_circuits.Circuit((prepLbl,)), _circuits.Circuit((povmLbl,)))
                        for prepLbl, povmLbl in pre_povm_tuples]
-    #debugging
-    #print('pre_povm_tuples: ', pre_povm_tuples)
     pairListDict = {}  # dict of lists of 2-tuples: one pair list per germ
     low_eigvals = {}
     #base_loweig_threshold = 1e-2  # HARDCODED
@@ -875,13 +826,7 @@ def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, 
     with printer.progress_logging(1):
         for i, germ_power in enumerate(_itertools.product(germs, max_lengths)):
             germ, L = germ_power
-            
-            #debugging
-            print('Current Germ: ', germ)
-            print('Current Power: ', L)
-
             # TODO: Could check for when we become identity and skip rest
-
             #Create a new model containing static target gates and a
             # special "germ" gate that is parameterized only by it's
             # eigenvalues (and relevant off-diagonal elements)
@@ -889,30 +834,19 @@ def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, 
             gsGerm.set_all_parameterizations("static")
             germMx = gsGerm.sim.product(germ)
             
-            #debugging
-            #print('Current Germ Matrix: ', germMx)
-            
             gsGerm.operations["Ggerm"] = _EigenvalueParamDenseOp(
                 germMx, True, constrain_to_tp)
-                
-            #debugging
-            #print('Current Germ EigenvalueParamDenseOp: ', gsGerm.operations["Ggerm"])
 
             # SS: Difference from _per_germ version
             if trunc_scheme == "whole germ powers":
                 power = _gsc.repeat_count_with_max_length(germ, L)
-  
-                #debugging
-                print('Truncated Power: ', power)
-                
+ 
             # TODO: Truncation doesn't work nicely with a single "germ"
             #elif trunc_scheme == "truncated germ powers":
             #    germPowerCirc = _gsc.repeat_and_truncate(germ, L)
             elif trunc_scheme == "length as exponent":
                 power = L
-                
-                #debugging
-                print('Truncated Power: ', power)
+
             else:
                 raise ValueError("Truncation scheme %s not allowed" % trunc_scheme)
 
@@ -926,9 +860,6 @@ def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, 
             printer.show_progress(i, len(germs) * len(max_lengths),
                                   suffix='-- %s germ, %d L (%d params)' %
                                   (repr(germ), L, gsGerm.num_params))
-            #Debugging
-            #print('Current Germ Eigenvals: ', gsGerm.operations["Ggerm"].evals)
-            #print('Current Germ Parameters: ', gsGerm.operations["Ggerm"].params)
 
             #Determine which fiducial-pair indices to iterate over
             #TODO: Evaluate the value of the minimum number of iterations before the algorithm for
@@ -938,33 +869,6 @@ def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, 
             #also assert that the number of iterations is less than the number of random samples
             if search_mode=='random':
                 assert(min_iterations<=n_random)
-            #debugging
-            #print('Minimum Iterations: ', min_iterations)
-            
-            #condition_number_threshold = 1e6  # HARDCODED
-            #debugging
-            #print('Condition Number Threshold: ', condition_number_threshold)
-            
-            
-            #if germ in low_eigvals:
-                #debugging
-                #print('Germ in dictionary low_eigvals')
-                #largest_past_L = max([l for l in low_eigvals[germ].keys()])
-                #debugging
-                #print('Largest past length for which germ was in low_eigvals: ', largest_past_L)
-                #past_low_eigval = low_eigvals[germ][largest_past_L]
-                #debugging
-                #print('Eigenvalue at that past length: ', past_low_eigval)
-                #with the switch to a relative scaling based off of the full
-                #fiducial set, skip this adjustment to the eigenvalue acceptance threshold.
-                #lowest_eigenval_threshold = 0.8 * past_low_eigval * (L / largest_past_L)**2
-                #debugging
-                #print('Lowest Eigenvalue Threshold: ', lowest_eigenval_threshold)
-                # Above gives expected increase in sensitivity (0.8 b/c this is just approximate, based on J.T*J)
-            #else:
-                #lowest_eigenval_threshold = base_loweig_threshold
-                #debugging
-                #print('Lowest Eigenvalue Threshold: ', lowest_eigenval_threshold)
                 
             #if there is a candidate fiducial seed set pass that in, otherwise pass in None.
             if per_germ_candidate_set is not None:
@@ -978,19 +882,9 @@ def find_sufficient_fiducial_pairs_per_germ_power(target_model, prep_fiducials, 
                                                                 min_iterations, base_loweig_tol, candidate_set_seed,
                                                                 num_soln_returned=1, type_soln_returned='best')
                                                                 
-                                                                
-            
             #This should now return a dictionary with a single entry. pull that entry out.
             goodPairList= list(goodPairList.values())[0]
             
-            #debugging
-            #print('Current goodPairList: ', goodPairList)
-            #print('Current Low Eigenvalue: ', low_eigval)
-            #if germ not in low_eigvals:
-            #    low_eigvals[germ] = {}
-            #low_eigvals[germ][L] = low_eigval
-            #debugging
-            #print('Current Low Eigenvals Dictionary: ', low_eigvals)
             try:
                 assert(goodPairList is not None)
             except AssertionError as err:
@@ -1135,9 +1029,6 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
     #  (i.e. the parameters of the gsGerm model).
     
     printer.log('Entered helper function _get_per_germ_power_fidpairs', 3)
-    
-    #debugging
-    #print('pre-povm-tuples: ', pre_povm_tuples)
 
     # nRhoStrs, nEStrs = len(prep_fiducials), len(meas_fiducials)
     nEStrs = len(meas_fiducials)
@@ -1145,7 +1036,6 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
     
     allPairIndices = list(range(nPossiblePairs))
     
-    #debugging
     printer.log('Number of possible pairs: %d'%(nPossiblePairs), 4)
 
     #Determine which fiducial-pair indices to iterate over
@@ -1159,15 +1049,9 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
         "pp[0]+f0+germ*power+f1+pp[1]", f0=prep_fiducials, f1=meas_fiducials,
         germ=_circuits.Circuit('Ggerm'), pp=pre_povm_tuples, power=power,
         order=('f0', 'f1', 'pp'))
-    #debugging
-    #print('List of circuits: ', lst)
 
     resource_alloc = _baseobjs.ResourceAllocation(comm=None, mem_limit=mem_limit)
     layout = gsGerm.sim.create_layout(lst, None, resource_alloc, array_types=('ep',), verbosity=0)
-
-    #debugging:
-    #print('Num Prep Fids: ', len(prep_fiducials))
-    #print('Num Measurement Fids: ', len(meas_fiducials))
 
     elIndicesForPair = [[] for i in range(len(prep_fiducials) * len(meas_fiducials))]
     nPrepPOVM = len(pre_povm_tuples)
@@ -1200,7 +1084,6 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
     rank= _np.count_nonzero(spectrum_full_fid_set>RANK_TOL)
     
     if rank < gsGerm.num_params:  # full fiducial set should work!
-        #print(rank)
         raise ValueError("Incomplete fiducial-pair set!")
     
     spectrum_full_fid_set= list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dPall, dPall.T)))))
@@ -1208,21 +1091,11 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
     imin_full_fid_set = len(spectrum_full_fid_set) - gsGerm.num_params
     condition_full_fid_set = spectrum_full_fid_set[-1] / spectrum_full_fid_set[imin_full_fid_set] if (spectrum_full_fid_set[imin_full_fid_set] > 0) else _np.inf
     
-    end=time.time()
-    print('Elapsed Time ', end-start )
-    
-    
-    #debugging
     printer.log('J J^T Rank Full Fiducial Set: %d' % rank, 2)
     printer.log('Num Parameters (should equal above rank): %d' % (gsGerm.num_params), 2)
     printer.log('Full Fiducial Set Min Eigenvalue: %f' % (spectrum_full_fid_set[imin_full_fid_set]), 2)
     printer.log('Full Fiducial Set Max Eigenvalue: %f' % (spectrum_full_fid_set[-1]), 2)
     printer.log('Full Fiducial Set Condition Number: %f' % (condition_full_fid_set), 2)
-    #print('Complete Spectrum of Full Fiducial Set: ', spectrum_full_fid_set[imin_full_fid_set:])
-    
-            
-    #debugging
-    #print('J J^T Spectrum: ', spectrum)
 
     #Below will take a *subset* of the rows in dPall
     # depending on which (of all possible) fiducial pairs
@@ -1236,7 +1109,6 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
     found_from_seed_set=False
     
     if candidate_set_seed is not None:
-        #debugging
         printer.log('Searching from among subsets of the candidate seed set.', 3)
         size_candidate_set= len(candidate_set_seed)
         for nNeededPairs in range(min_pairs_needed, size_candidate_set+1):
@@ -1245,15 +1117,11 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
             printer.log("  Low eigenvalue must be >= %g relative to the values of the full fiducial set" %
                         (lowest_eigenval_tol),3)
         
-            #debugging
             printer.log('Searching for a good set with this many pairs: %d' % (nNeededPairs), 4)
-            
             
             #We'll ignore the search mode argument and just focus on sampling random subsets of the candidate seed set.
             nTotalPairCombos = _nCr(size_candidate_set, nNeededPairs)
             
-            #debugging
-            #print('Number of total possible pair combos we could test: ', nTotalPairCombos)
             #convert the candidate_set_seed which is a list of pairs of indices to an equivalent linear index.
             #Should be lin_idx= prep_idx+num_meas+meas_idx
             linearized_candidate_seed_set=[]
@@ -1265,14 +1133,10 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                 #this will return numpy int64 values. we want standard python integers for the sake of serialization.
                 #cast these values back.
                 pairIndicesToIterateOver= [ [int(value) for value in nppairindexlist] for nppairindexlist in pairIndicesToIterateOver ]
-                #debugging
-                #print('Iterating over less than this because n_random is less.')
             else:
                 pairIndicesToIterateOver = _itertools.combinations(linearized_candidate_seed_set, nNeededPairs)
                 
             for i, pairIndicesToTest in enumerate(pairIndicesToIterateOver, start=1):
-                #debugging
-                #print('Current pair indices being tested: ', pairIndicesToTest)
                 
                 #Get list of pairs as tuples for printing & returning
                 pairList = []
@@ -1282,20 +1146,12 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                 
                 # Same computation of rank as above, but with only a
                 # subset of the total fiducial pairs.
-                #debugging
-                #print('pairIndicesToTest: ',pairIndicesToTest)
                 elementIndicesToTest = _np.concatenate([elIndicesForPair[i] for i in pairIndicesToTest])
                 dP = _np.take(dPall, elementIndicesToTest, axis=0)  # subset_of_num_elements x num_params
                 spectrum = list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dP, dP.T)))))
-                
-                
                 imin = len(spectrum) - gsGerm.num_params
                 
-                
-                #condition = spectrum[-1] / spectrum[imin] if (spectrum[imin] > 0) else _np.inf
-                
-                if (spectrum[imin] >= (lowest_eigenval_tol*spectrum_full_fid_set[imin_full_fid_set])): #and condition <= (condition_number_tol*condition_full_fid_set)):
-                    
+                if (spectrum[imin] >= (lowest_eigenval_tol*spectrum_full_fid_set[imin_full_fid_set])):
                     #if the list for bestFirstEval is empty or else we haven't hit the number of solutions to return
                     #yet then we'll append the value to the list and sort it regardless of the value. Otherwise
                     #we need to evaluate whether to swap out one of the elements of the list or not.
@@ -1328,26 +1184,15 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                         #may implement other things later on.
                         else:
                             raise NotImplementedError('Only option currently implemented for type_soln_returned is \"best\".')
-                            
-                #TODO: Fix the loggin function call below. Doesn't like that these quantities are now lists.
-                #printer.log("Pair list %s ==> min/max eval = %g/%g"
-                #            % (" ".join(map(str, pairList)), spectrum[imin], spectrum[-1]), 3)
 
                 if i >= min_iterations and len(bestFirstEval)>=num_soln_returned:
-                #debugging
                     printer.log('we have looked long enough and have found the requested number of acceptable solutions from among the candidate seed set.', 3)
                     found_from_seed_set=True
                     break  # we've looked long enough and have found an acceptable solution
 
             if any([eigval >= (lowest_eigenval_tol*spectrum_full_fid_set[imin_full_fid_set]) for eigval in bestFirstEval]):
-                #debugging
                 printer.log('Found at least one good set of pairs from within the seed set with length %d:' % (nNeededPairs), 3)
                 found_from_seed_set=True
-                #print('The good pairs list is: ', bestPairs)
-                
-                #TODO: Fix the loggin function call below. Doesn't like that these quantities are now lists.
-                #printer.log("Found a good set of %d pairs (lowest eigval = %g): %s" %
-                #            (nNeededPairs, bestFirstEval, " ".join(map(str, pairList))), 2)
                 goodPairList = bestPairs
                 break
         if found_from_seed_set==False:
@@ -1362,41 +1207,23 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
             printer.log("  Low eigenvalue must be >= %g relative to the values of the full fiducial set" %
                         (lowest_eigenval_tol),2)
             
-            #debugging
             printer.log('Searching for a good set with this many pairs: %d' % (nNeededPairs), 4)
-            #print('Set must have and eigenvalue and condition number greater than and less than respectively: ', lowest_eigenval_threshold, condition_number_threshold)
 
             if search_mode == "sequential":
-                #debugging
                 printer.log("Performing sequential search", 3)
                 pairIndicesToIterateOver = _itertools.combinations(allPairIndices, nNeededPairs)
 
             elif search_mode == "random":
-                #debugging
-                #print("Performing random search")
                 _random.seed(seed)  # ok if seed is None
                 nTotalPairCombos = _nCr(len(allPairIndices), nNeededPairs)
-                #debugging
-                #print('Number of total possible pair combos we could test: ', nTotalPairCombos)
+
                 if n_random < nTotalPairCombos:
                     pairIndicesToIterateOver = [_random_combination(
                         allPairIndices, nNeededPairs) for i in range(n_random)]
-                    #debugging
-                    #print('Iterating over less than this because n_random is less.')
                 else:
-                    pairIndicesToIterateOver = _itertools.combinations(allPairIndices, nNeededPairs)
-                    
-                #debugging
-                #print('Actual pairs to iterate over: ', pairIndicesToIterateOver)
-            #debugging
-            #print('Testing phase')
+                    pairIndicesToIterateOver = _itertools.combinations(allPairIndices, nNeededPairs) 
             
-            
-            
-            for i, pairIndicesToTest in enumerate(pairIndicesToIterateOver, start=1):
-                #debugging
-                #print('Current pair indices being tested: ', pairIndicesToTest)
-                
+            for i, pairIndicesToTest in enumerate(pairIndicesToIterateOver, start=1):                
                 #Get list of pairs as tuples for printing & returning
                 pairList = []
                 for i in pairIndicesToTest:
@@ -1405,15 +1232,11 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                 
                 # Same computation of rank as above, but with only a
                 # subset of the total fiducial pairs.
-                #debugging
-                #print('pairIndicesToTest: ',pairIndicesToTest)
                 elementIndicesToTest = _np.concatenate([elIndicesForPair[i] for i in pairIndicesToTest])
                 dP = _np.take(dPall, elementIndicesToTest, axis=0)  # subset_of_num_elements x num_params
                 spectrum = list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dP, dP.T)))))
                 
                 imin = len(spectrum) - gsGerm.num_params
-                
-                #condition = spectrum[-1] / spectrum[imin] if (spectrum[imin] > 0) else _np.inf
                 
                 if (spectrum[imin] >= (lowest_eigenval_tol*spectrum_full_fid_set[imin_full_fid_set])):# and condition <= (condition_number_tol*condition_full_fid_set)):
                     
@@ -1464,28 +1287,15 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                         else:
                             raise NotImplementedError('Only option currently implemented for type_soln_returned is \"best\".')
 
-                #TODO: Fix the logging function call below. Doesn't like that these quantities are now lists.
-                #printer.log("Pair list %s ==> min/max eval = %g/%g"
-                #            % (" ".join(map(str, pairList)), spectrum[imin], spectrum[-1]), 3)
-
                 if i >= min_iterations and len(bestFirstEval)>=num_soln_returned:
-                #debugging
                     printer.log('we have looked long enough and have found the requested number of acceptable solutions.', 3)
                     break  # we've looked long enough and have found an acceptable solution
 
             if any([eigval >= (lowest_eigenval_tol*spectrum_full_fid_set[imin_full_fid_set]) for eigval in bestFirstEval]):
-                #debugging
-                printer.log('Found at least one good set of pairs with length: %d' % (nNeededPairs), 3)
-                #print('The good pairs list is: ', bestPairs)
-                
-                #TODO: Fix the loggin function call below. Doesn't like that these quantities are now lists.
-                #printer.log("Found a good set of %d pairs (lowest eigval = %g): %s" %
-                #            (nNeededPairs, bestFirstEval, " ".join(map(str, pairList))), 2)
                 goodPairList = bestPairs
                 break
-    #debugging
     if goodPairList is None:
-        print('Failed to find a sufficient fiducial set.')
+        printer.log('Failed to find a sufficient fiducial set.',1)
     printer.log('Exiting _get_per_germ_power_fidpairs', 4)
     return goodPairList, bestFirstEval
     
@@ -1505,17 +1315,12 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
     #  (i.e. the parameters of the gsGerm model).
     
     printer.log('Entered helper function _get_per_germ_power_fidpairs_greedy', 3)
-    
-    #debugging
-    #print('pre-povm-tuples: ', pre_povm_tuples)
-    
-    # nRhoStrs, nEStrs = len(prep_fiducials), len(meas_fiducials)
+
     nEStrs = len(meas_fiducials)
     nPossiblePairs = len(prep_fiducials) * len(meas_fiducials)
     
     allPairIndices = list(range(nPossiblePairs))
-    
-    #debugging
+
     printer.log('Number of possible pairs: %d'%(nPossiblePairs), 4)
 
     #Determine which fiducial-pair indices to iterate over
@@ -1525,20 +1330,13 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
     min_pairs_needed= ceil((gsGerm.num_params/(nPossiblePairs*dof_per_povm))*nPossiblePairs)
     printer.log('Minimum Number of Pairs Needed for this Germ: %d'%(min_pairs_needed), 2)
     
-
     lst = _gsc.create_circuits(
         "pp[0]+f0+germ*power+f1+pp[1]", f0=prep_fiducials, f1=meas_fiducials,
         germ=_circuits.Circuit('Ggerm'), pp=pre_povm_tuples, power=power,
         order=('f0', 'f1', 'pp'))
-    #debugging
-    #print('List of circuits: ', lst)
 
     resource_alloc = _baseobjs.ResourceAllocation(comm=None, mem_limit=mem_limit)
     layout = gsGerm.sim.create_layout(lst, None, resource_alloc, array_types=('ep',), verbosity=0)
-
-    #debugging:
-    #print('Num Prep Fids: ', len(prep_fiducials))
-    #print('Num Measurement Fids: ', len(meas_fiducials))
 
     elIndicesForPair = [[] for i in range(len(prep_fiducials) * len(meas_fiducials))]
     nPrepPOVM = len(pre_povm_tuples)
@@ -1573,7 +1371,6 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
         rank= _np.count_nonzero(spectrum_full_fid_set>RANK_TOL)
     
         if rank < gsGerm.num_params:  # full fiducial set should work!
-            #print(rank)
             raise ValueError("Incomplete fiducial-pair set!")
     
         spectrum_full_fid_set= list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dPall, dPall.T)))))
@@ -1581,8 +1378,6 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
         imin_full_fid_set = len(spectrum_full_fid_set) - gsGerm.num_params
         condition_full_fid_set = spectrum_full_fid_set[-1] / spectrum_full_fid_set[imin_full_fid_set] if (spectrum_full_fid_set[imin_full_fid_set] > 0) else _np.inf
         
-        
-        #debugging
         printer.log('J J^T Rank Full Fiducial Set: %d' % rank, 2)
         printer.log('Num Parameters (should equal above rank): %d' % (gsGerm.num_params), 2)
         printer.log('Full Fiducial Set Min Eigenvalue: %f' % (spectrum_full_fid_set[imin_full_fid_set]), 2)
@@ -1631,11 +1426,6 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
     fiducial_update_EVD_cache= construct_compact_evd_cache(cleaned_pair_indices_list, dPall,
                                                             elIndicesForPair, 
                                                             eigenvalue_tolerance=evd_tol)
-                                                            
-    #print('fiducial_update_EVD_cache: ', fiducial_update_EVD_cache)                                                        
-    
-    #debugging:
-    #print('Initial Seed Fiducial Set: ', current_best_fiducial_list)
     
     for nNeededPairs in range(initial_pair_count, nPossiblePairs):
         if nNeededPairs < min_pairs_needed:
@@ -1663,36 +1453,23 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
         if current_best_jacobian is not None:
             update_cache= construct_update_cache(current_best_jacobian, evd_tol=evd_tol)
             current_best_rank= len(update_cache[0])
-            #debugging
-            #print('Shape current_best_jacobian: ', current_best_jacobian.shape)
-            #print('Update Cache: ', update_cache)
+
             #make a CompositeScore object for the current best fiducial set.
             current_best_score= _scoring.CompositeScore(-current_best_rank, current_best_inv_trace, current_best_rank)
-            
             
         else:
             update_cache= None  
             current_best_score= None
-                                                                
-        #print('Fiducial Update EVD Cache: ', fiducial_update_EVD_cache)
-            
-        #debugging
+
         printer.log('Initial Score: ' + str(current_best_score), 3)
         
-        
-        for pairIndexToTest in pairIndicesToIterateOver:
-            
-            
+        for pairIndexToTest in pairIndicesToIterateOver:    
             printer.log('Tested Index: %d' %(pairIndexToTest), 4)
             
             # Same computation of rank as above, but with only a
             # subset of the total fiducial pairs.
             elementIndicesToTest = elIndicesForPair[pairIndexToTest]
             update_to_test = _np.take(dPall, elementIndicesToTest, axis=0)  # subset_of_num_elements x num_params
-            
-            #debugging:
-            #print('Update being tested: ', update_to_test)
-            #print('Shape of update tested: ', update_to_test.shape)
             
             #We need some logic to handle the case where we are starting from scratch
             #and don't have an initial current_best_jacobian.
@@ -1710,41 +1487,12 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
                     idx_current_best_update = pairIndexToTest
             #otherwise we already have an initial Jacobian and should use the standard update logic.
             else:
-                #print('Update from EVD cache: ', fiducial_update_EVD_cache[pairIndexToTest])
                 updated_inv_trace, updated_rank, _ = minamide_style_inverse_trace(fiducial_update_EVD_cache[pairIndexToTest], 
                                                                  update_cache[0], update_cache[1], 
-                                                                 update_cache[2], False)                                       
-                #debugging
-                #test_index_list = current_best_fiducial_list.copy()
-                #test_index_list.append(pairIndexToTest)
-                #direct_element_test = _np.concatenate([elIndicesForPair[i] for i in test_index_list])
-                #direct_jacobian_test = _np.take(dPall, direct_element_test, axis=0)  # subset_of_num_elements x num_params# subset_of_num_elements x num_params
-            
-                #updated_inv_trace_direct= _np.trace(_np.linalg.pinv(direct_jacobian_test.T@direct_jacobian_test))
-                
-                #print('updated inv trace: ', updated_inv_trace)
-                #print('updated inv trace direct: ', updated_inv_trace_direct)
-                
-                #updated_spectrum= _np.linalg.eigvalsh(direct_jacobian_test.T@direct_jacobian_test)
-                #print('Updated spectrum: ', updated_spectrum[updated_spectrum>1e-10] )
-                #print('Original spectrum: ', update_cache[0])
-                
-                #Compare the matrices from doing the additive update to the append based update
-                #and confirm they give the same thing.
-                #print('Norm between direct Jacobian and additive update Jacobian: ', _np.linalg.norm((direct_jacobian_test.T@direct_jacobian_test) - (current_best_jacobian + update_to_test.T@update_to_test)))
-                
-                #print('Norm between update_to_test.T@update_to_test and fiducial_update_EVD_cache[pairIndexToTest]@fiducial_update_EVD_cache[pairIndexToTest].T: ',
-                #      _np.linalg.norm(update_to_test.T@update_to_test-fiducial_update_EVD_cache[pairIndexToTest]@fiducial_update_EVD_cache[pairIndexToTest].T))
-                
-                #print('Rank Minamide: ', updated_rank) 
-                #print('Rank Directly Updated Jacobian: ', _np.linalg.matrix_rank(direct_jacobian_test.T@direct_jacobian_test))
-                
-                #print('Rank of tested update: ', _np.linalg.matrix_rank(update_to_test))
-                
+                                                                 update_cache[2], False)
                 #Construct a composite score object where the major score is
                 #the rank of the updated jacobian and the minor score is
                 #the inverse trace.
-                
                 updated_score= _scoring.CompositeScore(-updated_rank, updated_inv_trace, updated_rank)
                 
                 printer.log('Updated Score: '+ str(updated_score), 3)
@@ -1771,9 +1519,8 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
         prepfid_index = i // nEStrs; iEStr = i - prepfid_index * nEStrs
         goodPairList.append((prepfid_index, iEStr))        
                     
-    #debugging
     if goodPairList is None:
-        print('Failed to find a sufficient fiducial set.')
+        printer.log('Failed to find a sufficient fiducial set.',1)
     printer.log('Exiting _get_per_germ_power_fidpairs_greedy', 4)
     return goodPairList, current_best_score
 
@@ -1782,18 +1529,10 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
 def construct_compact_evd_cache(fiducial_indices, complete_jacobian, element_map, eigenvalue_tolerance=1e-10):
     sqrteU_dict = {}
     
-    #print('Complete Jacobian Shape: ', complete_jacobian.shape)
-    #print('Complete Jacobian: ')
-    #print_mx(complete_jacobian)
-    
     for fid_index in fiducial_indices:
         fid_element_indices = element_map[fid_index]
         fid_jacobian_components = _np.take(complete_jacobian, fid_element_indices, axis=0)
-        #print('fid_jacobian_components: ') 
-        #print_mx(fid_jacobian_components)
         e, U = compact_EVD(fid_jacobian_components.T@fid_jacobian_components, eigenvalue_tolerance)
-        #print('eigenvalues: ', e)
-        #print('U: ', U)
         sqrteU_dict[fid_index]= U@_np.diag(_np.sqrt(e))  
     return sqrteU_dict    
     

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1019,7 +1019,7 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
     RANK_TOL = 1e-7 #HARDCODED
     #rank = _np.linalg.matrix_rank(_np.dot(dPall, dPall.T), RANK_TOL)
     
-    spectrum_full_fid_set= _np.abs(_np.linalg.eigvals(_np.dot(dPall, dPall.T)))
+    spectrum_full_fid_set= _np.abs(_np.linalg.eigvalsh(_np.dot(dPall, dPall.T)))
     
     #use the spectrum to calculate the rank instead.
     rank= _np.count_nonzero(spectrum_full_fid_set>RANK_TOL)
@@ -1028,7 +1028,7 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
         #print(rank)
         raise ValueError("Incomplete fiducial-pair set!")
     
-    spectrum_full_fid_set= list(sorted(_np.abs(_np.linalg.eigvals(_np.dot(dPall, dPall.T)))))
+    spectrum_full_fid_set= list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dPall, dPall.T)))))
     
     imin_full_fid_set = len(spectrum_full_fid_set) - gsGerm.num_params
     condition_full_fid_set = spectrum_full_fid_set[-1] / spectrum_full_fid_set[imin_full_fid_set] if (spectrum_full_fid_set[imin_full_fid_set] > 0) else _np.inf
@@ -1108,7 +1108,7 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                 #print('pairIndicesToTest: ',pairIndicesToTest)
                 elementIndicesToTest = _np.concatenate([elIndicesForPair[i] for i in pairIndicesToTest])
                 dP = _np.take(dPall, elementIndicesToTest, axis=0)  # subset_of_num_elements x num_params
-                spectrum = list(sorted(_np.abs(_np.linalg.eigvals(_np.dot(dP, dP.T)))))
+                spectrum = list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dP, dP.T)))))
                 
                 
                 imin = len(spectrum) - gsGerm.num_params
@@ -1231,7 +1231,7 @@ def _get_per_germ_power_fidpairs(prep_fiducials, meas_fiducials, pre_povm_tuples
                 #print('pairIndicesToTest: ',pairIndicesToTest)
                 elementIndicesToTest = _np.concatenate([elIndicesForPair[i] for i in pairIndicesToTest])
                 dP = _np.take(dPall, elementIndicesToTest, axis=0)  # subset_of_num_elements x num_params
-                spectrum = list(sorted(_np.abs(_np.linalg.eigvals(_np.dot(dP, dP.T)))))
+                spectrum = list(sorted(_np.abs(_np.linalg.eigvalsh(_np.dot(dP, dP.T)))))
                 
                 imin = len(spectrum) - gsGerm.num_params
                 

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1604,12 +1604,6 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
     #Change the value of nPossiblePairs to reflect the filtered list
     nPossiblePairs= len(cleaned_pair_indices_list)
     
-    #Below will take a *subset* of the rows in dPall
-    # depending on which (of all possible) fiducial pairs
-    # are being considered.
-    
-    rng= _np.random.default_rng(seed=seed)
-    
     #Need to choose how to initially seed a set of candidate fiducials.
     #I can think of two ways atm, one is to seed it with a random set of
     #fiducial pairs of size min_pairs_needed, the other is to run
@@ -1617,6 +1611,8 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
     
     #If random, pick a random set of fiducial pairs to start the search with:
     if initial_seed_mode=='random':
+        #set the seed for the prng:
+        _random.seed(seed)
         initial_fiducial_set= list(_random_combination(cleaned_pair_indices_list, min_pairs_needed))
         initial_pair_count= min_pairs_needed
     #if starting from zero then we'll change min_pairs_needed to zero and set the initial_fiducial_set

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1483,7 +1483,7 @@ def _get_per_germ_power_fidpairs_greedy(prep_fiducials, meas_fiducials, pre_povm
                 updated_inv_trace= _np.trace(updated_pinv)
                 updated_score =  _scoring.CompositeScore(-updated_rank, updated_inv_trace, updated_rank)
                 if updated_score < current_best_score:
-                    current_best_inv_trace= inv_trace_to_test
+                    current_best_score= updated_score
                     idx_current_best_update = pairIndexToTest
             #otherwise we already have an initial Jacobian and should use the standard update logic.
             else:

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -255,7 +255,7 @@ def find_germs(target_model, randomize=True, randomization_strength=1e-2,
         for key in default_kwargs:
             if key not in algorithm_kwargs:
                 algorithm_kwargs[key] = default_kwargs[key]
-        germList = find_germs_breadthfirst_rev1(model_list=modelList,
+        germList = find_germs_breadthfirst_greedy(model_list=modelList,
                                            **algorithm_kwargs)
         if germList is not None:
             #TODO: We should already know the value of this from
@@ -2614,8 +2614,197 @@ def drop_random_germs(candidate_list, rand_frac, target_model, keep_bare=True, s
         updated_candidate_list= [candidate_list[i] for i in indices_to_keep]
         
     return updated_candidate_list
-        
-    
+  
+##-------------Low-Rank Update Theory--------------##
+#What follows is a brief overview of the theory for the use of low-rank updates with greedy search. 
+#The purpose of this is to explain the linear algebra, and not the germ selection theory.
+#So I'll be sloppy and refer to the existence of various jacobians generically without 
+#explaining how these arise or why they are the jacobians we care about.
+
+#The goal of germ selection and other experimental designates problems is to select a set of germs, 
+#or fiducial pairs or whatever with a jacobian J that satisfies some criterion.
+#We can choose to work in terms of the Jacobian directly, or in terms of one of the gramians of the Jacobian 
+#(J^T@J or J@J^T depending on what is most appropriate).
+
+#For germ selection there are 2-main objective functions that are used. Both are based on a connection
+#between the gramian of a jacobian and covariance. So both objective functions can be viewed as alternative
+#ways to guarantee the covariance in the parameters for an estimate generated from an experiment design
+#isn't relatively small. (See this stackexchange thread for more on that connection https://stats.stackexchange.com/questions/231868/relation-between-covariance-matrix-and-jacobian-in-nonlinear-least-squares)
+#This first objective function aims to maximize the minimum eigenvalue of the jacobian's gramian, or 
+#equivalently minimize the maximum eigenvalue of the inverse. This is called 'worst' in pygsti. The other option,
+#which is the default, is to minimize the sum of the reciprocals of the eigenvalues of the gramian of 
+#the jacobian. This is called 'all' and corresponds roughly, but not exactly, to minimizing the average
+#covariance. Going forward I will refer to this as the psuedoinverse-trace (since that is indeed what it is).
+
+#We haven't fully figured out how to low-rank updatify the 'worst' objective function (there are a few
+#half-baked ideas based on used iterative methods we might try to make fully baked if there is a demand
+#down the line). So the remaining will focus on speeding up the evaluation of the 'all' objective function.
+
+#What does each step in the greedy search algorithm for this problem look like.
+#At the start of each iteration we have some current jacobian for the current set of germs that
+#we've chosen to include in our set that we'll denote J. At each iteration we also have some list 
+#of candidate germs to select from among for the next germ to add to our. Each of these  
+#candidate germs likewise has a jacobian associated with it that we'll denote by A_i.
+#I'll be referring the the A_i matrices (and interchangeably their gramians) as 'updates'.
+
+#We want to know how each of these updates would change the psuedoinverse-trace (and also rank)
+#of the jacobian for the current set of germs were it to be added and then select the germ
+#that improves the psuedoinverse-trace (and rank) the most in a greedy fashion. That is, for each
+#of the updates we want to calculate the psuedoinverse-trace of the matrix J'_i:
+
+#pinvtrace(J'_i)= pinvtrace(J^T@J + A_i^T@A_i)
+
+#Here are the critical observations that allow us to significantly speed things up:
+#   1. For each iteration of the greedy search algorithm the matrix J is fixed.
+#   2. The update matrices are relatively low-rank. For case of germ selection
+#      each of the A_i matrices is d**4 X N_p where d is the dimension of the system's_list
+#      underlying Hilbert space and N_p is the number of parameters of a gate set 
+#      (technically the number of non-SPAM parameters). Subsequantly the maximum rank of
+#      A_i is d**4, but it is typically a good deal less in practice. 
+#      In traditional settings it is always the case that N_p >= d**4 and typically 
+#      N_p >> rank(d**4).
+#   3. We're almost always working from some initial fixed set of germs that we'll
+#      be constructing our solution from, so the set of matrices {A_i} is essentially
+#      fixed (only getting smaller as we add germs to the solution set) and so all of these
+#      matrices can be computed ahead of time and cached in some way.
+
+#Before explaining what is actually done, a quick diversion. The most famous example
+#of using low-rank updates comes from the 'Woodbury matrix identity' 
+#(AKA, matrix inversion lemma or Sherman–Morrison–Woodbury formula).
+#This identity says:
+
+#(A + UCV)^-1 = A^-1 - A^-1 U(C^-1 + V A^1 U)^-1 V A^-1
+
+#A, U, C and V are assumed to be conformable (so all of the matrix multiplications work). 
+#A is (n,n), C is (k,k), U is (n,k) and V is (k,n).
+
+#How is this useful? This formula gives us a way to update the inverse of 
+#some matrix A given some additive update UCV. Suppose we already knew what A^-1 was somehow,
+#then we could replace the inversion of an (n,n) matrix with the inversion of 2 (k,k) matrices
+#and some matrix multiplication and addition. Moreover, suppose that C was a diagonal matrix,
+#then we could do the inversion in linear time which is basically free and effectively only have
+#the cost of inverting (C^-1 + V A^1 U) to worry about. If k<<n and it is the case that we already
+#knew A^-1 then this is a clear and significant win.
+
+#Obviously this result requires that the matrix we are updating have a well defined inverse and
+#so is full-rank (ditto for C). If this were the case then this would solve our problem.
+#At the start of each iteration we pre-compute the inverse of J^T@J once and then use the formula
+#to calculate the updated inverse after adding A_i^T@A_i. Since J^T@J isn't full-rank, however,
+#we need a version of this that works for the psuedoinverse instead (simply replacing the inverses
+#with psuedoinverses in the woodbury formula doesn't work except in a couple special cases that we 
+#won't satisfy). 
+
+#For this we'll combine results from 2 papers. The first is from Matthew Brand titled:
+#Fast Low-Rank Modifications of the Thin Singular Value Decomposition 
+#(https://www.merl.com/publications/docs/TR2006-059.pdf)
+#and the second is from Nariyasu Minamide titled:
+#An Extension of the Matrix Inversion Lemma
+#(https://epubs.siam.org/doi/pdf/10.1137/0606038)
+
+
+#The problem that Brand's paper solves is the following:
+#Let X be some matrix. X has an SVD X=USV^T. Let AB^T be some low-rank additive update.
+#What is the updated SVD of X+AB^T? The main result we use comes from equation 3 which
+#gives a new matrix K which has the same spectrum as X+AB^T:
+
+# K= [[S 0],[0 0]] + [[U^T A],[R_A]] [[V^T B], [R_B]]^T
+
+#Where R_A = P^T(I-UU^T)A. P is an orthogonal basis for the column space of 
+#(I-UU^T)A, the component of A that is orthogonal to U. R_B is defined analogously
+#but swapping U->V and A->B.
+
+#K won't have the same psuedoinverse as the matrix we care about, but since K has the same spectrum 
+#it will also have the same psuedoinverse-trace as the matrix we care about. So, for the next stage
+#we can instead proceed with respect to K. Since K has a nice block structure this will simplify
+#the application of the result from minamide's paper. 
+
+#This actually simplifies a bit, since all of the matrices we'll be working with are gramians
+#they will all be diagonalizable. As such, we can replace the SVD of X above with the eigenvalue
+#decomposition X=UEU^T. Moreover, for the update AB^T we'll be using a rank-decomposition
+#of the updates and so these with be of the form AA^T. As such, the K matrix will simplify to:
+
+# K= [[E 0],[0 0]] + [[U^T A],[R_A]] [[U^T A], [R_A]]^T
+
+#The relevant result from Minamide is from theorem 2.1 which states:
+#let H= S+\Phi\Phi^\dagger where S is an (n,n) hermitian matrix and \Phi is an (n,m) matrix with
+#potentially complex entries. If S is non-negative, letting ^+ denote psuedoinversion we then have:
+
+#H^+ = {I-(\Phi^\dagger T)^+ \Phi^\dagger} S^+ {I-\Phi (T \Phi)^+} +
+#      (\Phi^\dagger T)^+(T \Phi)^+ -
+#      {I-(\Phi^\dagger T)^+ \Phi^\dagger} (S^+ \Phi B D^-1 B \Phi^\dagger S^+)  {I-\Phi (T \Phi)^+}
+
+#Where B= I- (T \Phi)^+(T \Phi), D= I + B \Phi^\dagger S^+ \Phi B.
+#T is a projector onto the orthogonal complement of the column space of S. i.e. T= I- S^+S= I-SS^+.
+
+#The K matrix we defined above satisfies the requirements to use the minamide result where mapping between
+#the two notations we let:
+#S=[[E 0],[0 0]] and \Phi= [[U^T A],[R_A]] (Note that since gramians are PSD S is nonnegative as required).
+
+#The expression above looks pretty monstrous, but the block structure we have from switching to working with K
+#simplifies things considerably. Plugging everything into Minamide's threorem and working
+#through a few pages of tedious linear algebra gives us the following result:
+
+#H^+ = [[H_00, H_01], [H_10 H_11]]
+
+#H_00= E^+U^T A \alpha A^T U E^+ 
+#H_11 = (R_A^T)^+ A^T U E^+ U^T A R_A^+ + (R_A^+)^T R_A^+ - (R_A^T)^+ A^T U E^+ U^T A \alpha A^T U E^+ U^T A R_A^+
+#H_01= E^+ U^T A R_A^+ - E^+ U^T A \alpha A^T E^+ U^T A R_A^+
+#H_10 = H_01^T (~90% sure of this last line, turns out we won't actually care either way since we don't need the off-diagonals)
+
+#\alpha= B D^-1 B^+ = B D^-1 B =  (I-R_A^+ R_A) [(I + (I-R_A^+ R_A)(A^T U E^+ U^T A)(I-R_A^+ R_A))^-1] (I-R_A^+ R_A)
+
+#This is still ugly, but:
+
+#   1. We only care about the trace of H^+, so we don't ever need to calculate the off-diagonal blocks H_01 and H_10.
+#      Just the diagonal blocks H_00 and H_11.
+#   2. Within H_00 and H_11 there is a lot of structure. All of the products are symmetric and so we only need to calculate half
+#      each term. There are a lot of repeated subexpressions so with some caching of intermediate expressions there are a lot fewer
+#      matmuls to do overall.
+#   3. Most of these matrices are small with at least one of the dimensions given by the rank of the update
+#      so even with a bunch of matmuls to do they run pretty quickly.
+
+#There are a few more tricks to keep in mind that are used to accelerate the calculation even more 
+#(and without knowing about makes the implementation details harder to parse).
+
+#   1. The psuedoinverse of a diagonal matrix is simply a diagonal matrix with the non-zero diagonal
+#      entries inverted, so no need for a costly SVD (which is how numpy internally implements pinv)
+#   2. The since it is diagonal the matrix multiplications involving E^+ can be done in quadratic time since all we need to do is 
+#      rescale the rows of the other matrix be the appropriate diagonal element. In numpy this can be done using element-wise multiplication
+#      between a 1D vector with the diagonal elements of E^+ and the target matrix. Numpy automatically uses broadcasting for this so it is
+#      very fast.
+#   3. For the purposes of calculating the trace we don't need all of the elements of H_00 and H_11, just the diagonals.
+#      We can use numpy's einsum to evaluate the final (and largest/most expensive) matrix multiplication in such as
+#      way that only the diagonal elements are calculated/returned, and which can be done in just quadratic time.
+#   4. A bunch of numpy methods can detect when they should expect to have a symmetric output and use a faster code path
+#      in this case that avoids calculating known duplicate entries. So, whenever possible we'll be making sure our subexpressions
+#      are collected in such a way as to leverage the symmetry. This also applies to einsum, which is significantly when it detects
+#      symmetric inputs, so we'll also try to symmetrize the inputs to einsum when possible (when you see Cholesky decompositions appear
+#      out of nowhere that is why).
+
+
+#Future Performance Enhancements:
+#Inventory of possible future perofrmance enhancements.
+#   1. At the start of each iteration we compute a so-called 'update cache'. This is really just the eigenvalues and eigenvectors
+#      for the jacobian of our current candidate set as well as the projector onto the orthogonal complement of U's column space.
+#      This is calculated in the standard way using eigh. We could in principle use the second half of the Matthew Brand result
+#      and use low-rank update methods to update the eigenvalues and eigenvectors using whatever final update we selected at the previous
+#      greedy search iteration. This still requires doing an actual eigenvalue decomposition on the K matrix we construct, though, so
+#      what will happen is that this will be very fast for the earlier iterations where both the jacobian for the current solution set and the
+#      updates are both small, but will give us diminishing returns as the Jacobian for the current solution set approaches being full-rank.
+#      We could always use some heuristic to swap between the two approaches once the rank is past some threshold, though. For 3-qubit+ 
+#      systems profiling suggests that constructing the update cache takes nearly the same amount of time as running through hundreds of
+#      low-rank updates, so this could be a source of pretty large speedups. Vauge numerical stability concerns (and currently being fast enough)
+#      are the main reasons we haven't already done so.
+#   2. Better search space pruning. We can do a better job at identifying useless germs and not including them in future iterations.
+#      We currently have an option called 'force_rank_increase' that is plumbed in. This is currently used to short-circuit the low-rank
+#      update tests early when it detects complete overlap with existing amplified directions in parameter space, but we aren't currently 
+#      using that information to then skip that germ in subsequent iterations. Doing so would speed things up when that option was turned on.
+#   3. A decent chunk of time for the low-rank updates is doing a rank-revealing QR decomposition. We learned recently from Riley Murray that these
+#      are a good deal slower than a standard un-pivoted QR decomposition. There are algorithms for doing this using randomized linear algebra
+#      that are accurate to machine precision and nearly as fast as the standard QR decomposition.
+
+##------------Low-Rank Update Related Functions-----------------##
+
 #new function that computes the J^T J matrices but then returns the result in the form of the 
 #compact EVD in order to save on memory.    
 def _compute_bulk_twirled_ddd_compact(model, germs_list, eps,
@@ -3126,7 +3315,12 @@ def minamide_style_inverse_trace(update, orig_e, U, proj_U, force_rank_increase=
             print('central_mat shape: ', central_mat.shape)
         #now calculate the diagonal elements of pinv_E_beta@central_mat@pinv_E_beta.T
         
-        #Take the cholesky decomposition of the central matrix:
+        #Take the cholesky decomposition of the central matrix
+        #The purpose of this cholesky decomposition is entirely to accelerate
+        #the subsequent einsum call. Using einsum to calculate the diagonal elements
+        #of a product of matrices of the form A@A.T is significantly faster than
+        #doing so for a product of matrices of the form A@B@A.T
+        
         try:
             central_mat_chol= _np.linalg.cholesky(central_mat)
             cholesky_success=True
@@ -3224,7 +3418,7 @@ def minamide_style_inverse_trace(update, orig_e, U, proj_U, force_rank_increase=
 #updates to speed the calculation of eigenvalues for additive
 #updates.
     
-def find_germs_breadthfirst_rev1(model_list, germs_list, randomize=True,
+def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
                             randomization_strength=1e-3, num_copies=None, seed=0,
                             op_penalty=0, score_func='all', tol=1e-6, threshold=1e6,
                             check=False, force="singletons", pretest=True, mem_limit=None,

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -165,9 +165,10 @@ def find_germs(target_model, randomize=True, randomization_strength=1e-2,
             availableGermsList.extend(_circuits.list_all_circuits_without_powers_and_cycles(
                 gates, max_length=germLength))
         else:
-            seed = None if candidate_seed is None else candidate_seed + germLength
+            if (candidate_seed is None) and (seed is not None):
+                candidate_seed=seed
             availableGermsList.extend(_circuits.list_random_circuits_onelen(
-                gates, germLength, count, seed=seed))
+                gates, germLength, count, seed=candidate_seed))
 
     printer.log('Initial Length Available Germ List: '+ str(len(availableGermsList)), 1)
 

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -196,6 +196,11 @@ def find_germs(target_model, randomize=True, randomization_strength=1e-2,
         if not (float_type is _np.cdouble or float_type is _np.csingle):
             print(float_type.dtype)
             raise ValueError('Unless working with (known) real-valued quantities only, please select an appropriate complex numpy dtype (either cdouble or csingle).')
+    else:
+        if not (float_type is _np.double or float_type is _np.single):
+            print(float_type.dtype)
+            raise ValueError('When assuming real-valued quantities, please select a real-values numpy dtype (either double or single).')
+        
     
     #How many bytes per float?
     FLOATSIZE= float_type(0).itemsize

--- a/test/test_packages/algorithmsb/testGermSelection.py
+++ b/test/test_packages/algorithmsb/testGermSelection.py
@@ -67,7 +67,7 @@ class GermSelectionTestCase(AlgorithmTestCase):
         pygsti.alg.find_germs_breadthfirst(gatesetNeighborhood, superGermSet,
                                            randomize=False, seed=2014, score_func='all',
                                            threshold=threshold, verbosity=1, op_penalty=1.0,
-                                           mem_limit=1024000)
+                                           mem_limit=2*1024000)
                                            
 
     def test_germsel_low_rank(self):


### PR DESCRIPTION
This branch introduces a new greedy search algorithm for performing per-germ FPR. This algorithm leverages the same low-rank update machinery used to generate speedups for germ selection. Due to the nature of the low-rank updates used, this utilizes an objective function based on the trace of the psuedo-inverse of a candidate fiducial set's Jacobian instead of the minimum eigenvalue (these should largely track with each other though). In the course of developing this a number of edge cases were revealed in the low-rank update code which didn't arise when testing germ selection. These have been patched, and as a nice side-effect the fixes actually result in a modest performance boost for germ selection too.

Smaller changes included in the branch include:

- bugfixes for numpy data type handling
- bugfixes for leaky RNG seed plumbing
- implementation of a simple trick for SVDs of gramians that speeds up the construction of EVD caches
- Mass expunging of debugging and print statements that are no longer needed
