### PR TITLE
Feature mongodb serialization

### DIFF
--- a/pygsti/baseobjs/__init__.py
+++ b/pygsti/baseobjs/__init__.py
@@ -16,6 +16,7 @@ from .profiler import Profiler
 from .basis import Basis, BuiltinBasis, ExplicitBasis, TensorProdBasis, DirectSumBasis
 from .label import Label, CircuitLabel
 from .nicelyserializable import NicelySerializable
+from .mongoserializable import MongoSerializable
 from .outcomelabeldict import OutcomeLabelDict
 from .statespace import StateSpace, QubitSpace, ExplicitStateSpace
 from .resourceallocation import ResourceAllocation

--- a/pygsti/baseobjs/mongoserializable.py
+++ b/pygsti/baseobjs/mongoserializable.py
@@ -1,0 +1,103 @@
+"""
+Defines the MongoSerializable class
+"""
+#***************************************************************************************************
+# Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+# Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain rights
+# in this software.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
+#***************************************************************************************************
+from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
+
+
+class MongoSerializable(_NicelySerializable):
+    """
+    An extension of NicelySerializable for that need to perform special MongoDB serialization.
+
+    An interface that allows an object to save large chunks of data using, e.g.,
+    MongoDB's GridFS system, when serializing it as a json-able object for storage
+    in a MongoDB database.
+    """
+    @classmethod
+    def from_mongodb_serialization(cls, state, mongodb):
+        """
+        Create and initialize an object from a "nice" serialization and a auxiliary MongoDB instance.
+
+        A "nice" serialization here means one that is compatible with common text file formats, namely
+        JSON (e.g. that dictionary keys must be strings).  This serialization should have been created
+        by a prior call to `to_mongodb_serialization` using a reference to the same MongoDB database
+        as was used to serialize the object.
+
+        The `state` argument is typically a dictionary containing 'module' and 'state' keys specifying
+        the type of object that should be created.  This type must be this class or a subclass of it.
+
+        Parameters
+        ----------
+        state : object
+            An object, usually a dictionary, representing the object to de-serialize.
+
+        mongodb_database : pymongo.database.Database
+            An MongoDB instance that may optionally hold auxiliary data associated with the
+            object but too large or complex to include in the "nice" serialization itself.
+
+        Returns
+        -------
+        object
+        """
+        # Implementation note:
+        # This method is similar to _from_nice_serialization, but will defer to the method of a derived class
+        # when once is specified in the state dictionary.  This method should thus be used when de-serializing
+        # using a potential base class, i.e.  BaseClass._from_nice_serialization_base(state).
+        # (This method should rarely need to be overridden in derived (sub) classes.)
+        if isinstance(state, dict) and state['module'] == cls.__module__ and state['class'] == cls.__name__:
+            # then the state is actually for this class and we should call its _from_nice_serialization method:
+            return cls._from_mongodb_serialization(state, mongodb)
+        else:
+            # otherwise, this call functions as a base class call that defers to the correct derived class
+            return MongoSerializable._from_mongodb_serialization.__func__(cls, state, mongodb)
+
+    def to_mongodb_serialization(self, mongodb):
+        """
+        Serialize this object in a "nice" way, with the optional help of an auxiliary MongoDB instance.
+
+        "Nice" here means that the resulting serialized form is compatible with common text formats,
+        namely JSON.  Object components that are especially large or awkward can be stored
+        within the provided MongoDB database, and links/ids of the stored documents included in the
+        returned serialization.
+
+        Parameters
+        ----------
+        mongodb_database : pymongo.database.Database
+            An auxiliary MongoDB instance to optionally place data within (see above).
+
+        Returns
+        -------
+        object
+            Usually a dictionary representing the serialized object, but may also be another native
+            Python type, e.g. a string or list.
+        """
+        return self._to_mongodb_serialization(mongodb)
+
+    @classmethod
+    def _from_mongodb_serialization(cls, state, mongodb):
+        c = cls._state_class(state)
+        if not issubclass(c, cls):
+            raise ValueError("Class '%s' is trying to load a serialized '%s' object (not a subclass)!"
+                             % (cls.__module__ + '.' + cls.__name__, state['module'] + '.' + state['class']))
+        implementing_cls = cls
+        for candidate_cls in c.__mro__:
+            if '_from_mongodb_serialization' in candidate_cls.__dict__:
+                implementing_cls = candidate_cls; break
+
+        if implementing_cls == cls:  # then there's no actual derived-class implementation to call!
+            raise NotImplementedError("Class '%s' doesn't implement _from_mongodb_serialization!"
+                                      % str(state['module'] + '.' + state['class']))
+        else:
+            return c._from_mongodb_serialization(state, mongodb)
+
+    def _to_mongodb_serialization(self, mongodb):
+        #Call base class (*not* self.to_nice_serialization) here since this
+        # should just behave like the base to_nice_serialization, putting class & module name into a state
+        return _NicelySerializable._to_nice_serialization(self)

--- a/pygsti/io/__init__.py
+++ b/pygsti/io/__init__.py
@@ -18,3 +18,4 @@ from .readers import *
 from .metadir import *
 from .stdinput import *
 from .writers import *
+from .mongodb import *

--- a/pygsti/io/metadir.py
+++ b/pygsti/io/metadir.py
@@ -525,7 +525,7 @@ def write_obj_to_meta_based_dir(obj, dirname, auxfile_types_member, omit_attribu
         vals = obj.__dict__
         auxtypes = obj.__dict__[auxfile_types_member]
 
-    return write_meta_based_dir(dirname, vals, auxtypes, init_meta=meta)
+    write_meta_based_dir(dirname, vals, auxtypes, init_meta=meta)
 
 
 def _read_json_or_pkl_files_to_dict(dirname):

--- a/pygsti/io/mongodb.py
+++ b/pygsti/io/mongodb.py
@@ -1,0 +1,881 @@
+"""
+Serialization routines to/from a MongoDB database
+"""
+#***************************************************************************************************
+# Copyright 2015, 2019 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+# Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain rights
+# in this software.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
+#***************************************************************************************************
+
+
+import pickle as _pickle
+import warnings as _warnings
+import numpy as _np
+
+from pygsti.circuits.circuit import Circuit as _Circuit
+from pygsti.data.dataset import DataSet as _DataSet
+
+from pygsti.io import stdinput as _stdinput
+from pygsti.io import readers as _load
+#from pygsti.io import writers as _write
+from pygsti.io.metadir import _check_jsonable, _full_class_name, _to_jsonable, _from_jsonable, _class_for_name
+from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
+from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
+
+
+def load_from_mongodb(root_mongo_collection, doc_id, auxfile_types_member='auxfile_types',
+                      ignore_meta=('_id', 'type',), separate_auxfiletypes=False,
+                      quick_load=False):
+    """
+    Load the contents of a MongoDB document into a dict.
+
+    The de-serialization possibly uses metadata within to root document to describe
+    how associated data is stored in other collections.
+
+    Parameters
+    ----------
+    root_mongo_collection : pymongo.collection.Collection
+        The root MongoDB collection to load data from.  (Sub-collections are read
+        from as needed.)
+
+    doc_id : object
+        The identifier, usually a `bson.objectid.ObjectId` or string, of the
+        root document to load from the database.
+
+    auxfile_types_member : str, optional
+        The key within the root document that is used to describe how other
+        members have been serialized into documents.  Unless you know what you're
+        doing, leave this as the default.
+
+    ignore_meta : tuple, optional
+        Keys within the root document that should be ignored, i.e. not loaded into
+        elements of the returned dict.  By default, `"_id"` and `"type"` are in this
+        category because they give the database id and a class name to be built,
+        respectively, and are not needed in the constructed dictionary.  Unless
+        you know what you're doing, leave this as the default.
+
+    separate_auxfiletypes : bool, optional
+        If True, then return the `auxfile_types_member` element (a dict
+        describing how quantities that aren't in root document have been
+        serialized) as a separate return value, instead of placing it
+        within the returned dict.
+
+    quick_load : bool, optional
+        Setting this to True skips the loading of members that may take
+        a long time to load, namely those in separate files whose files are
+        large.  When the loading of an attribute is skipped, it is set to `None`.
+
+    Returns
+    -------
+    loaded_qtys : dict
+        A dictionary of the quantities in 'meta.json' plus any loaded
+        from the auxiliary files.
+    auxfile_types : dict
+        Only returned as a separate value when `separate_auxfiletypes=True`.
+        A dict describing how members of `loaded_qtys` that weren't loaded
+        directly from the root document were serialized.
+    """
+    doc = root_mongo_collection.find_one({'_id': doc_id})
+    ret = {}
+
+    for key, val in doc.items():
+        if key in ignore_meta: continue
+        ret[key] = val
+
+    for key, typ in doc[auxfile_types_member].items():
+        if key in ignore_meta: continue  # don't load -> members items in ignore_meta
+
+        bLoaded, val = _load_subcollection_member(root_mongo_collection, doc_id, key, typ,
+                                                  doc.get(key, None), quick_load)
+        if bLoaded:
+            ret[key] = val
+        elif val is True:  # val is value of whether to set value to None
+            ret[key] = None  # Note: could just have bLoaded be True in this case and val=None
+
+    if separate_auxfiletypes:
+        del ret[auxfile_types_member]
+        return ret, doc[auxfile_types_member]
+    else:
+        return ret
+
+
+def _load_subcollection_member(root_mongo_collection, parent_id, member_name, typ, metadata, quick_load):
+    from pymongo import ASCENDING, DESCENDING
+    subtypes = typ.split(':')
+    cur_typ = subtypes[0]
+    next_typ = ':'.join(subtypes[1:])
+
+    # In FUTURE maybe we can implement "quick loading" from a MongoDB, but currently `quick_load` does nothing
+    #max_size = quick_load if isinstance(quick_load, int) else QUICK_LOAD_MAX_SIZE
+    #def should_skip_loading(path):
+    #    return quick_load and (path.stat().st_size >= max_size)
+
+    if cur_typ == 'list':
+        if metadata is None:  # signals that value is None, otherwise would at least be an empty list
+            val = None
+        else:
+            val = []
+            for i, meta in enumerate(metadata):
+                membernm_so_far = member_name + str(i)
+                bLoaded, el = _load_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
+                                                         next_typ, meta, quick_load)
+                if bLoaded:
+                    val.append(el)
+                else:
+                    break
+
+    elif cur_typ == 'dict':
+        if metadata is None:  # signals that value is None, otherwise would at least be an empty list
+            val = None
+        else:
+            keys = list(metadata.keys())  # sort?
+            val = {}
+            for k in keys:
+                membernm_so_far = member_name + "_" + k
+                meta = metadata.get(k, None)
+                bLoaded, v = _load_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
+                                                        next_typ, meta, quick_load)
+                if bLoaded:
+                    val[k] = v
+                else:
+                    raise ValueError("Failed to load dictionary key " + str(k))
+
+    elif cur_typ == 'fancykeydict':
+        if metadata is None:  # signals that value is None, otherwise would at least be an empty list
+            val = None
+        else:
+            keymeta_pairs = list(metadata)  # should be a list of (key, metadata_for_value) pairs
+            val = {}
+            for i, (k, meta) in enumerate(keymeta_pairs):
+                membernm_so_far = member_name + "_kvpair" + str(i)
+                bLoaded, el = _load_subcollection_member(root_mongo_collection, membernm_so_far,
+                                                         next_typ, meta, quick_load)
+                if bLoaded:
+                    if isinstance(k, list): k = tuple(k)  # convert list-type keys -> tuples
+                    val[k] = el
+                else:
+                    raise ValueError("Failed to load %d-th dictionary key: %s" % (i, str(k)))
+
+    elif cur_typ in ('text-circuit-lists', 'protocolobj', 'list-of-protocolobjs', 'dict-of-resultsobjs'):
+        raise ValueError("Cannot (and should never need to!) load from deprecated aux-file formats.")
+
+    else:
+        val = None  # the default value to load, which is left unchanged if there's no record
+
+        if cur_typ == 'none':  # member is serialized separatey and shouldn't be touched
+            return False, False  # explicitly don't load or set value (so set_to_None=False)
+
+        #if should_skip_loading(pth):
+        #    val = None  # load 'None' instead of actual data (skip loading this file)
+
+        if cur_typ == 'reset':  # 'reset' doesn't write and loads in as None
+            val = None  # no file exists for this member
+        elif cur_typ == 'text-circuit-list':
+            coll = root_mongo_collection['pygsti_circuits']
+            circuit_strs = []
+            for i, cdoc in enumerate(coll.find({'parent': parent_id,
+                                                'member_name': member_name}).sort('index', ASCENDING)):
+                assert(cdoc['auxfile_type'] == cur_typ)
+                assert(cdoc['index'] == i)
+                circuit_strs.append(cdoc['circuit_str'])
+            val = _load.convert_strings_to_circuits(circuit_strs)
+
+        elif cur_typ == 'dir-serialized-object':
+            coll = root_mongo_collection['pygsti_objects']
+            link_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+            if link_doc is not None:
+                assert(link_doc['auxfile_type'] == cur_typ)
+                standalone_id = link_doc['standalone_object_id']
+    
+                coll = root_mongo_collection['pygsti_standalone_objects']
+                obj_doc = coll.find_one({'_id': standalone_id}, ['type'])
+                val = _class_for_name(obj_doc['type']).from_mongodb(coll, standalone_id, quick_load=quick_load)
+
+        elif cur_typ == 'partialdir-serialized-object':
+            coll = root_mongo_collection['pygsti_objects']
+            link_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+
+            if link_doc is not None:
+                assert(link_doc['auxfile_type'] == cur_typ)
+                standalone_id = link_doc['standalone_object_id']
+    
+                coll = root_mongo_collection['pygsti_standalone_objects']
+                obj_doc = coll.find_one({'_id': standalone_id}, ['type'])
+                val = _class_for_name(obj_doc['type'])._from_mongodb_partial(coll, standalone_id, quick_load=quick_load)
+
+        elif cur_typ == 'serialized-object':
+            coll = root_mongo_collection['pygsti_objects']
+            obj_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+            if obj_doc is not None:
+                assert(obj_doc['auxfile_type'] == cur_typ)
+                val = _NicelySerializable.from_nice_serialization(obj_doc['object'])
+
+        elif cur_typ == 'circuit-str-json':
+            coll = root_mongo_collection['pygsti_circuits']
+            circuit_strs = []
+            for i, cdoc in enumerate(coll.find({'parent': parent_id,
+                                                'member_name': member_name}).sort('index', ASCENDING)):
+                assert(cdoc['auxfile_type'] == cur_typ)
+                assert(cdoc['index'] == i)
+                circuit_strs.append(cdoc['circuit_str'])
+            val = _load.convert_strings_to_circuits(circuit_strs)
+
+        elif typ == 'numpy-array':
+            coll = root_mongo_collection['pygsti_numpy_arrays']
+            array_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+            if array_doc is not None:
+                assert(array_doc['auxfile_type'] == cur_typ)
+                val = _pickle.loads(array_doc['numpy_array'])
+
+        elif typ == 'json':
+            coll = root_mongo_collection['pygsti_objects']
+            obj_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+            if obj_doc is not None:
+                assert(obj_doc['auxfile_type'] == typ)
+                val = obj_doc['object']
+
+        elif typ == 'pickle':
+            coll = root_mongo_collection['pygsti_objects']
+            obj_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+            if obj_doc is not None:
+                assert(obj_doc['auxfile_type'] == typ)
+                val = _pickle.loads(obj_doc['object'])
+
+        else:
+            raise ValueError("Invalid aux-file type: %s" % typ)
+
+    return True, val  # loading successful - 2nd element is value loaded
+
+
+def write_obj_to_mongodb(obj, root_mongo_collection, doc_id, auxfile_types_member, omit_attributes=(),
+                         additional_meta=None, session=None):
+    meta = {'type': _full_class_name(obj)}
+    if additional_meta is not None: meta.update(additional_meta)
+
+    if len(omit_attributes) > 0:
+        vals = obj.__dict__.copy()
+        auxtypes = obj.__dict__[auxfile_types_member].copy() if (auxfile_types_member is not None) else {}
+        for o in omit_attributes:
+            if o in vals: del vals[o]
+            if o in auxtypes: del auxtypes[o]
+    else:
+        vals = obj.__dict__
+        auxtypes = obj.__dict__[auxfile_types_member] if (auxfile_types_member is not None) else {}
+
+    write_to_mongodb(root_mongo_collection, doc_id, vals, auxtypes, init_meta=meta, session=session)
+
+
+def write_to_mongodb(root_mongo_collection, doc_id, valuedict, auxfile_types=None, init_meta=None, session=None):
+    """
+    Write a dictionary of quantities to a MongoDB database, potentially as multiple documents.
+
+    Write the dictionary by placing everything in `valuedict` into a root document except for
+    special key/value pairs ("special" usually because they lend themselves to
+    an non-JSON format or they can be particularly large and may exceed MongoDB's maximum
+    document size) which are placed in "auxiliary" documents formatted according to
+    `auxfile_types` (which itself is saved in the root document).
+
+    Parameters
+    ----------
+    root_mongo_collection : pymongo.collection.Collection
+        The root MongoDB collection to write data to.  Sub-collections are created
+        and written to as needed.
+
+    doc_id : object
+        The identifier, usually a `bson.objectid.ObjectId` or string, of the
+        root document to store in the database.
+
+    valuedict : dict
+        The dictionary of values to serialize to disk.
+
+    auxfile_types : dict, optional
+        A dictionary whose keys are a subset of the keys of `valuedict`,
+        and whose values are known "aux-file" types.  `auxfile_types[key]`
+        says that `valuedict[key]` should be serialized into a separate
+        document with the given format rather than be included directly in
+        the root document.  If None, this dictionary is assumed to be
+        `valuedict['auxfile_types']`.
+
+    init_meta : dict, optional
+        A dictionary of "initial" meta-data to be included in the root document
+        (but that isn't in `valuedict`).  For example, the class name of an
+        object is often stored as in the "type" field of meta.json when the_model
+        objects .__dict__ is used as `valuedict`.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    None
+    """
+    from bson.objectid import ObjectId
+    to_insert = {}
+
+    if auxfile_types is None:  # Note: this case may never be used
+        auxfile_types = valuedict['auxfile_types']
+
+    if init_meta: to_insert.update(init_meta)
+    to_insert['auxfile_types'] = auxfile_types
+    to_insert['_id'] = doc_id if (doc_id is not None) else ObjectId()  # Note: may run into trouble if _id must be str
+
+    for key, val in valuedict.items():
+        if key in auxfile_types: continue  # member is serialized to a separate (sub-)collection
+        if isinstance(val, _VerbosityPrinter): val = val.verbosity  # HACK!!
+        to_insert[key] = val
+
+    for auxnm, typ in auxfile_types.items():
+        val = valuedict[auxnm]
+        try:
+            auxmeta = _write_subcollection_member(root_mongo_collection, doc_id, auxnm, typ, val, session)
+        except Exception as e:
+            _warnings.warn("FAILED to write aux file member %s w/format %s:" % (auxnm, typ))
+            raise e
+
+        if auxmeta is not None:
+            to_insert[auxnm] = auxmeta  # metadata about auxfile(s) for this auxnm
+
+    root_mongo_collection.insert_one(to_insert, session=session)
+
+# db  - root database; somewhat similar to an analysis root on disk
+# db.edesigns  - ionqanalysis.ExperimentDesign documents
+# db.edesigns.pygsti_edesigns  - pygsti experiment designs  -- could combine w/above
+# db.edesigns.pygsti_edesigns.circuits  - collection w/one document per circuit (but each needs an id to parent design)
+# db.datarecords
+# db.datarecords.pygsti_datasets  # combine with above?
+# db.datarecords.pygsti_datasets.datarows
+# If heirarchical, put sub-edesigns in same collection but with 'parent' link non-None
+
+
+def _write_subcollection_member(root_mongo_collection, parent_id, member_name, typ, val, session=None):
+    from bson.binary import Binary as _Binary
+    from bson.objectid import ObjectId
+    subtypes = typ.split(':')
+    cur_typ = subtypes[0]
+    next_typ = ':'.join(subtypes[1:])
+
+    if cur_typ == 'list':
+        if val is not None:
+            metadata = []
+            for i, el in enumerate(val):
+                membernm_so_far = member_name + str(i)
+                meta = _write_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
+                                                   next_typ, el, session)
+                metadata.append(meta)
+        else:
+            metadata = None
+
+    elif cur_typ == 'dict':
+        if val is not None:
+            metadata = {}
+            for k, v in val.items():
+                membernm_so_far = member_name + "_" + k
+                meta = _write_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
+                                                   next_typ, v, session)
+                metadata[k] = meta
+        else:
+            metadata = None
+
+    elif cur_typ == 'fancykeydict':
+        if val is not None:
+            metadata = []
+            for i, (k, v) in enumerate(val.items()):
+                membernm_so_far = member_name + "_kvpair" + str(i)
+                meta = _write_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
+                                                   next_typ, v, session)
+                metadata.append((k, meta))
+        else:
+            metadata = None
+
+    else:
+        #Simple types that just write the given file
+        metadata = None
+        #pth = root_dir / (filenm + ext)
+
+        if val is None:   # None values don't get written
+            pass
+        elif cur_typ in ('none', 'reset'):  # explicitly don't get written
+            pass
+        elif cur_typ == 'text-circuit-list':
+            coll = root_mongo_collection['pygsti_circuits']
+            for i, circuit in enumerate(val):
+                coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': cur_typ,
+                                 'index': i, 'circuit_str': circuit.str}, session=session)
+        elif cur_typ == 'dir-serialized-object':
+            coll = root_mongo_collection['pygsti_standalone_objects']
+            standalone_id = ObjectId()
+            val.write_to_mongodb(coll, standalone_id, session=session)
+
+            coll = root_mongo_collection['pygsti_objects']
+            coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': cur_typ,
+                             'standalone_object_id': standalone_id}, session=session)
+
+        elif cur_typ == 'partialdir-serialized-object':
+            coll = root_mongo_collection['pygsti_standalone_objects']
+            child_id = ObjectId()
+            val._write_partial_to_mongodb(coll, child_id, session=session)
+
+            coll = root_mongo_collection['pygsti_objects']
+            coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': cur_typ,
+                             'standalone_object_id': child_id}, session=session)
+
+        elif cur_typ == 'serialized-object':
+            assert(isinstance(val, _NicelySerializable)), \
+                "Non-nicely-serializable '%s' object given for a 'serialized-object' auxfile type!" % (str(type(val)))
+            jsonable = val.to_nice_serialization()
+            coll = root_mongo_collection['pygsti_objects']
+            coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': cur_typ,
+                             'object': jsonable}, session=session)
+
+        elif cur_typ == 'circuit-str-json':
+            coll = root_mongo_collection['pygsti_circuits']
+            for i, circuit in enumerate(val):
+                coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': cur_typ,
+                                 'index': i, 'circuit_str': circuit.str}, session=session)
+
+        elif cur_typ == 'numpy-array':
+            coll = root_mongo_collection['pygsti_numpy_arrays']
+            coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': cur_typ,
+                             'numpy_array': _Binary(_pickle.dumps(val, protocol=2), subtype=128)},
+                            session=session)
+
+        elif typ == 'json':
+            _check_jsonable(val)
+            coll = root_mongo_collection['pygsti_objects']
+            coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': typ, 'object': val},
+                            session=session)
+
+        elif typ == 'pickle':
+            coll = root_mongo_collection['pygsti_objects']
+            coll.insert_one({'parent': parent_id, 'member_name': member_name, 'auxfile_type': typ,
+                             'object': _Binary(_pickle.dumps(val, protocol=2), subtype=128)},
+                            session=session)
+
+        else:
+            raise ValueError("Invalid aux-file type: %s" % typ)
+
+    return metadata
+
+
+def remove_from_mongodb(root_mongo_collection, doc_id, auxfile_types_member='auxfile_types', session=None):
+    """
+    Remove a stored dictionary from a MongoDB database.
+
+    Removes the root document and any auxiliary documents.
+
+    Parameters
+    ----------
+    root_mongo_collection : pymongo.collection.Collection
+        The MongoDB collection of the root document to remove.
+
+    doc_id : object
+        The identifier, usually a `bson.objectid.ObjectId` or string, of the
+        root document.
+
+    auxfile_types_member : str, optional
+        The key within the root document that is used to describe how other
+        members have been serialized into documents.  Unless you know what you're
+        doing, leave this as the default.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    delete_count : int
+        The number of root records deleted (0 or 1)
+    """
+    doc = root_mongo_collection.find_one({'_id': doc_id}, [auxfile_types_member], session=session)
+    if doc is None:
+        return
+
+    #Remove any auxfile members that could have their own (different) ids
+    for key, typ in doc[auxfile_types_member].items():
+        if typ in ('dir-serialized-object', 'partialdir-serialized-object'):
+            # then this doc may have a different id that also needs to be deleted
+            aux_doc = root_mongo_collection[key].find_one({'parent': doc_id}, [], session=session)
+            remove_from_mongodb(root_mongo_collection[key], aux_doc['_id'], auxfile_types_member, session)
+
+    #Remove other auxfile documents and the original
+    for aux_subcollection_name in ('pygsti_objects', 'pygsti_circuits', 'pygsti_numpy_arrays'):
+        root_mongo_collection[aux_subcollection_name].delete_many({'parent': doc_id}, session=session)
+
+    return root_mongo_collection.delete_one({'_id': doc_id}, session=session)  # returns deleted count (0 or 1)
+
+
+def read_dict_from_mongodb(mongodb_collection, identifying_metadata):
+    """
+    Read a dictionary serialized via :function:`write_dict_to_mongodb` into a dictionary.
+
+    The elements of the constructed dictionary are stored as a separate documents in a
+    the specified MongoDB collection.
+
+    Parameters
+    ----------
+    mongodb_collection : pymongo.collection.Collection
+        the MongoDB collection to read from.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the dictionary being
+        retrieved.
+
+    Returns
+    -------
+    dict
+    """
+    from bson.binary import Binary as _Binary
+
+    ret = {}
+    for doc in mongodb_collection.find(identifying_metadata):
+        ret[doc['key']] = _pickle.loads(doc['value']) if isinstance(doc['value'], _Binary) \
+            else _from_jsonable(doc['value'])
+    return ret
+
+
+def write_dict_to_mongodb(d, mongodb_collection, identifying_metadata, session=None):
+    """
+    Write each element of `d` as a separate document in a MongoDB collection
+
+    A document corresponding to each (key, value) pair of `d` is created that contains:
+    1. the metadata identifying the collection (`identifying_metadata`)
+    2. the pair's key, stored under the key `"key"`
+    3. the pair's value, stored under the key `"value"`
+
+    If the element is json-able, it's value is written as a JSON-like dictionary.
+    If not, pickle is used to serialize the element and store it in a `bson.binary.Binary`
+    object within the database.
+
+    Parameters
+    ----------
+    d : dict
+        the dictionary of elements to serialize.
+
+    mongodb_collection : pymongo.collection.Collection
+        the MongoDB collection to write to.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the dictionary being
+        serialized.  This metadata should be saved for later retrieving
+        the elements of `d` from `mongodb_collection`.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    None
+    """
+    from bson.binary import Binary as _Binary
+
+    for key, val in d.items():
+        to_insert = identifying_metadata.copy()
+        to_insert['key'] = key
+        full_id = to_insert.copy()  # id metadata and key = full id which should be unique in collection
+        try:
+            val_to_insert = _to_jsonable(val)
+            _check_jsonable(val_to_insert)
+        except Exception as e:
+            _warnings.warn("Could not write %s key as jsonable (falling back on pickle format):\n" % key + str(e))
+            val_to_insert = _Binary(_pickle.dumps(val, protocol=2), subtype=128)
+
+        to_insert['value'] = val_to_insert
+        mongodb_collection.replace_one(full_id, to_insert, upsert=True, session=session)
+
+
+def remove_dict_from_mongodb(mongodb_collection, identifying_metadata, session=None):
+    """
+    Remove elements of (separate documents) of a dictionary stored in a MongoDB collection
+
+    Parameters
+    ----------
+    mongodb_collection : pymongo.collection.Collection
+        the MongoDB collection to remove documents from.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the dictionary being
+        serialized.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    None
+    """
+    return mongodb_collection.delete_many(identifying_metadata, session=session)
+
+
+def write_dataset_to_mongodb(dataset, mongodb_collection, identifying_metadata,
+                             circuits=None, outcome_label_order=None, with_times="auto",
+                             datarow_subcollection_name='pygsti_datarows', session=None):
+    """
+    Write a data set to a MongoDB database.
+
+    A single document is created in the given `mongodb_collection` representing
+    the entire dataset, and one document per data-row (circuit) is created in the
+    sub-collection of `mongodb_collection` named by `datarow_subollection_name`.
+
+    Parameters
+    ----------
+    dataset : DataSet
+        the dictionary of elements to serialize.
+
+    mongodb_collection : pymongo.collection.Collection
+        the MongoDB collection to write to.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the data set being
+        serialized.  This metadata should be saved for later retrieving
+        the elements of `d` from `mongodb_collection`.
+
+    circuits : list of Circuits, optional
+        The list of circuits to include in the written dataset.
+        If None, all circuits are output.
+
+    outcome_label_order : list, optional
+        A list of the outcome labels in dataset which specifies
+        the column order in the output file.
+
+    with_times : bool or "auto", optional
+        Whether to include (save) time-stamp information in output.  This
+        can only be True when `fixed_column_mode=False`.  `"auto"` will set
+        this to True if `fixed_column_mode=False` and `dataset` has data at
+        non-trivial (non-zero) times.
+
+    datarow_subcollection_name : str, optional
+        The name of the MongoDB subcollection that holds the written
+        data set's row data as one record per row.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    None
+    """
+    if circuits is not None:
+        if len(circuits) > 0 and not isinstance(circuits[0], _Circuit):
+            raise ValueError("Argument circuits must be a list of Circuit objects!")
+    else:
+        circuits = list(dataset.keys())
+
+    if outcome_label_order is not None:  # convert to tuples if needed
+        outcome_label_order = [(ol,) if isinstance(ol, str) else ol
+                               for ol in outcome_label_order]
+
+    outcomeLabels = dataset.outcome_labels
+    if outcome_label_order is not None:
+        assert(len(outcome_label_order) == len(outcomeLabels))
+        assert(all([ol in outcomeLabels for ol in outcome_label_order]))
+        assert(all([ol in outcome_label_order for ol in outcomeLabels]))
+        outcomeLabels = outcome_label_order
+        oli_map_data = {dataset.olIndex[ol]: i for i, ol in enumerate(outcomeLabels)}  # dataset -> stored indices
+
+        def oli_map(outcome_label_indices):
+            return [oli_map_data[i] for i in outcome_label_indices]
+    else:
+        def oli_map(outcome_label_indices):
+            return [i.item() for i in outcome_label_indices]  # converts numpy types -> native python types
+
+    dataset_doc = identifying_metadata.copy()
+    dataset_doc['outcomes'] = outcomeLabels
+    dataset_doc['comment'] = dataset.comment if hasattr(dataset, 'comment') else None
+    dataset_doc['datarow_subcollection_name'] = datarow_subcollection_name
+
+    if with_times == "auto":
+        trivial_times = dataset.has_trivial_timedependence
+    else:
+        trivial_times = not with_times
+
+    if '_id' in identifying_metadata:
+        dataset_id = identifying_metadata['_id']
+    else:
+        from bson.objectid import ObjectId as _ObjectId
+        existing_dataset_doc = mongodb_collection.find_one(identifying_metadata, session=session)
+        dataset_id = existing_dataset_doc._id if (existing_dataset_doc is not None) else _ObjectId()
+        identifying_metadata = identifying_metadata.copy()
+        identifying_metadata['_id'] = dataset_id  # be sure to query & replace the same ID below
+
+    mongodb_collection.replace_one(identifying_metadata, dataset_doc, upsert=True, session=session)
+    datarow_collection = mongodb_collection[datarow_subcollection_name]
+
+    for i, circuit in enumerate(circuits):  # circuit should be a Circuit object here
+        dataRow = dataset[circuit]
+        datarow_doc = {'index': i,
+                       'circuit': circuit.str,
+                       'parent': dataset_id,
+                       'outcome_indices': oli_map(dataRow.oli),
+                       'repetitions': [r.item() for r in dataRow.reps]  # converts numpy -> Python native types
+                       }
+
+        if trivial_times:  # ensure that "repetitions" are just "counts" in trivial-time case
+            assert(len(dataRow.oli) == len(set(dataRow.oli))), "Duplicate value in trivial-time data set row!"
+        else:
+            datarow_doc['times'] = list(dataRow.time)
+
+        if dataRow.aux:
+            datarow_doc['aux'] = dataRow.aux  # needs to be JSON-able!
+
+        datarow_collection.replace_one({'circuit': circuit.str, 'parent': dataset_id}, datarow_doc,
+                                       upsert=True, session=session)
+
+
+def remove_dataset_from_mongodb(mongodb_collection, identifying_metadata,
+                                datarow_subcollection_name='pygsti_datarows', session=None):
+    """
+    Remove (delete) a data set from a MongoDB database.
+
+    Parameters
+    ----------
+    mongodb_collection : pymongo.collection.Collection
+        the MongoDB collection to remove a data set from.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the data set being
+        serialized.
+
+    datarow_subcollection_name : str, optional
+        The name of the MongoDB subcollection that holds the
+        data set's row data.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    None
+    """
+    dataset_doc = mongodb_collection.find_one_and_delete(identifying_metadata, session=session)
+    mongodb_collection[datarow_subcollection_name].delete_many({'parent': dataset_doc['_id']}, session=session)
+
+
+def read_dataset_from_mongodb(mongodb_collection, identifying_metadata, collision_action="aggregate",
+                              record_zero_counts=False, with_times="auto", circuit_parse_cache=None, verbosity=1):
+    """
+    Load a DataSet from a MongoDB database.
+
+    Parameters
+    ----------
+    mongodb_collection : pymongo.collection.Collection
+        the MongoDB collection to read from.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the data set being
+        loaded.
+
+    collision_action : {"aggregate", "keepseparate"}
+        Specifies how duplicate circuits should be handled.  "aggregate"
+        adds duplicate-circuit counts, whereas "keepseparate" tags duplicate
+        circuits by setting their `.occurrence` IDs to sequential positive integers.
+
+    record_zero_counts : bool, optional
+        Whether zero-counts are actually recorded (stored) in the returned
+        DataSet.  If False, then zero counts are ignored, except for potentially
+        registering new outcome labels.
+
+    with_times : bool or "auto", optional
+        Whether to the time-stamped data format should be read in.  If
+        "auto", then the time-stamped format is allowed but not required on a
+        per-circuit basis (so the dataset can contain both formats).  Typically
+        you only need to set this to False when reading in a template file.
+
+    circuit_parse_cache : dict, optional
+        A dictionary mapping qubit string representations into created
+        :class:`Circuit` objects, which can improve performance by reducing
+        or eliminating the need to parse circuit strings.
+
+    verbosity : int, optional
+        If zero, no output is shown.  If greater than zero,
+        loading progress is shown.
+
+    Returns
+    -------
+    DataSet
+    """
+    from pymongo import ASCENDING, DESCENDING
+
+    dataset_doc = mongodb_collection.find_one(identifying_metadata)
+    if dataset_doc is None:
+        raise ValueError("Could not find a dataset with the given identifying metadata!")
+
+    datarow_subcollection_name = dataset_doc['datarow_subcollection_name']
+    outcomeLabels = dataset_doc['outcomes']
+
+    dataset = _DataSet(outcome_labels=outcomeLabels, collision_action=collision_action,
+                       comment=dataset_doc['comment'])
+    parser = _stdinput.StdInputParser()
+
+    datarow_collection = mongodb_collection[datarow_subcollection_name]
+    for i, datarow_doc in enumerate(datarow_collection.find({'parent': dataset_doc['_id']}).sort('index', ASCENDING)):
+        if i != datarow_doc['index']:
+            _warnings.warn("Data set's row data is incomplete! There seem to be missing rows.")
+
+        circuit = parser.parse_circuit(datarow_doc['circuit'], lookup={},  # allow a lookup to be passed?
+                                       create_subcircuits=not _Circuit.default_expand_subcircuits)
+
+        oliArray = _np.array(datarow_doc['outcome_indices'], dataset.oliType)
+        countArray = _np.array(datarow_doc['repetitions'], dataset.repType)
+        if 'times' not in datarow_doc:  # with_times can be False or 'auto'
+            if with_times is True:
+                raise ValueError("Circuit %d does not contain time information and 'with_times=True'" % i)
+            timeArray = _np.zeros(countArray.shape[0], dataset.timeType)
+        else:
+            if with_times is False:
+                raise ValueError("Circuit %d contains time information and 'with_times=False'" % i)
+            timeArray = _np.array(datarow_doc['time'], dataset.timeType)
+
+        dataset._add_raw_arrays(circuit, oliArray, timeArray, countArray,
+                                overwrite_existing=True,
+                                record_zero_counts=record_zero_counts,
+                                aux=datarow_doc.get('aux', {}))
+
+    dataset.done_adding_data()
+    return dataset
+
+
+def mongodb_collection_names(custom_collection_names=None):
+    """
+    Construct a dictionary listing the MongoDB collection names used by pyGSTi read/write methods.
+
+    The keys of the returned dictionary correspond to types or broader categories of
+    pyGSTi objects that can serialize themselves to a MongoDB instance.  The values give
+    the corresponding MongoDB collection name used by that type.
+
+    Use of such a dictionary is needed (as opposed to just giving each I/O call
+    a collection name, for instance) because pyGSTi I/O calls often read or write
+    a hierarchy of objects with different types (e.g., experiment designs, data sets,
+    and results).
+
+    Parameters
+    ----------
+    custom_collection_names : dict, optional
+        Overrides the default collection names.  The keys of this dictionary must be a
+        subset of the valid type-names (the keys of the return value when this argument is `None`).
+
+    Returns
+    -------
+    dict
+    """
+    collection_names = {'edesigns': 'pygsti_experiment_designs',
+                        'data': 'pygsti_protocol_data',
+                        'results': 'pygsti_protocol_results'}
+    if custom_collection_names is not None:
+        for k, v in custom_collection_names.items():
+            assert(k in collection_names), "%s is an invalid collection-type (key)!" % str(k)
+            collection_names[k] = v
+    return collection_names

--- a/pygsti/io/writers.py
+++ b/pygsti/io/writers.py
@@ -154,7 +154,7 @@ def write_dataset(filename, dataset, circuits=None,
     if fixed_column_mode is True:
         headerString += '## Columns = ' + ", ".join(["%s count" % _outcome_to_str(ol)
                                                      for ol in outcomeLabels]) + '\n'
-        assert(not (with_times is True)), "Cannot set `witTimes=True` when `fixed_column_mode=True`"
+        assert(not (with_times is True)), "Cannot set `withTimes=True` when `fixed_column_mode=True`"
     else:
         headerString += '## Outcomes = ' + ", ".join([_outcome_to_str(ol) for ol in outcomeLabels]) + '\n'
 

--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -281,7 +281,7 @@ class Estimate(object):
                                          session=session, overwrite_existing=overwrite_existing)
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb_collection, doc_id, custom_collection_names=None, session=None):
+    def remove_from_mongodb(cls, mongodb_collection, doc_id, session=None):
         """
         Remove an Estimate from a MongoDB database.
 

--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -104,8 +104,8 @@ class Estimate(object):
         Protocol
         """
         ret = cls.__new__(cls)
-        ret.__dict__.update(_io.load_from_mongodb(mongodb_collection, doc_id,
-                                                  'auxfile_types', quick_load=quick_load))
+        ret.__dict__.update(_io.read_auxtree_from_mongodb(mongodb_collection, doc_id,
+                                                          'auxfile_types', quick_load=quick_load))
         for crf in ret.confidence_region_factories.values():
             crf.set_parent(ret)  # re-link confidence_region_factories
         return ret
@@ -249,7 +249,7 @@ class Estimate(object):
         """
         _io.write_obj_to_meta_based_dir(self, dirname, 'auxfile_types')
 
-    def write_to_mongodb(self, mongodb_collection, doc_id=None, session=None):
+    def write_to_mongodb(self, mongodb_collection, doc_id=None, session=None, overwrite_existing=False):
         """
         Write this Estimate to a MongoDB database.
 
@@ -267,12 +267,18 @@ class Estimate(object):
             database. This can be used to implement transactions
             among other things.
 
+        overwrite_existing : bool, optional
+            Whether existing documents should be overwritten.  The default of `False` causes
+            a ValueError to be raised if a document with the given `doc_id` already exists.
+            Setting this to `True` mimics the behaviour of a typical filesystem, where writing
+            to a path can be done regardless of whether it already exists.
+
         Returns
         -------
         None
         """
-        _io.write_obj_to_mongodb(self, mongodb_collection, doc_id, 'auxfile_types',
-                                 session=session)
+        _io.write_obj_to_mongodb_auxtree(self, mongodb_collection, doc_id, 'auxfile_types',
+                                         session=session, overwrite_existing=overwrite_existing)
 
     @classmethod
     def remove_from_mongodb(cls, mongodb_collection, doc_id, custom_collection_names=None, session=None):
@@ -284,8 +290,8 @@ class Estimate(object):
         bool
             `True` if the specified experiment design was removed, `False` if it didn't exist.
         """
-        delcnt = _io.remove_from_mongodb(mongodb_collection, doc_id, 'auxfile_types',
-                                         session=session)
+        delcnt = _io.remove_auxtree_from_mongodb(mongodb_collection, doc_id, 'auxfile_types',
+                                                 session=session)
         return bool(delcnt == 1)
 
     def retrieve_start_model(self, goparams):

--- a/pygsti/protocols/protocol.py
+++ b/pygsti/protocols/protocol.py
@@ -2159,10 +2159,10 @@ class ProtocolData(_TreeNode):
 
         collection_names = _io.mongodb_collection_names(custom_collection_names)
 
-        #Write our class information to mongodb, even though we don't currently use this when loading (FUTURE work)
+        #Write our class information (*not* any member data, so include_attributes == ()) to mongodb,
+        # even though we don't currently use this when loading (FUTURE work)
         _io.write_obj_to_mongodb_auxtree(self, mongodb[collection_names['data']], doc_id,
-                                         auxfile_types_member=None,
-                                         omit_attributes=['edesign', 'dataset', '_passdatas', 'cache'],
+                                         auxfile_types_member=None, include_attributes=(),
                                          session=session, overwrite_existing=overwrite_existing)
 
         if parent is None:  # otherwise assume parent has already written edesign

--- a/pygsti/protocols/protocol.py
+++ b/pygsti/protocols/protocol.py
@@ -68,6 +68,33 @@ class Protocol(object):
         ret._init_unserialized_attributes()
         return ret
 
+    @classmethod
+    def from_mongodb(cls, mongodb_collection, doc_id, quick_load=False):
+        """
+        Initialize a new Protocol object from a Mongo database.
+
+        Parameters
+        ----------
+        mongodb_collection : pymongo.collection.Collection
+            The MongoDB collection to load data from.
+
+        doc_id : str
+            The user-defined identifier of the protocol object to load.
+
+        quick_load : bool, optional
+            Setting this to True skips the loading of components that may take
+            a long time to load.
+
+        Returns
+        -------
+        Protocol
+        """
+        ret = cls.__new__(cls)
+        ret.__dict__.update(_io.load_from_mongodb(mongodb_collection, doc_id,
+                                                  'auxfile_types', quick_load=quick_load))
+        ret._init_unserialized_attributes()
+        return ret
+
     def __init__(self, name=None):
         """
         Create a new Protocol object.
@@ -127,6 +154,45 @@ class Protocol(object):
         None
         """
         _io.write_obj_to_meta_based_dir(self, dirname, 'auxfile_types')
+
+    def write_to_mongodb(self, mongodb_collection, doc_id=None, session=None):
+        """
+        Write this Protocol to a MongoDB database.
+
+        Parameters
+        ----------
+        mongodb_collection : pymongo.collection.Collection
+            The MongoDB collection to write to.
+
+        doc_id : str, optional
+            The user-defined identifier of the Protocol to write.  Can be
+            left as `None` to generate a random identifier.
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions
+            among other things.
+
+        Returns
+        -------
+        None
+        """
+        _io.write_obj_to_mongodb(self, mongodb_collection, doc_id, 'auxfile_types',
+                                 session=session)
+
+    @classmethod
+    def remove_from_mongodb(cls, mongodb_collection, doc_id, custom_collection_names=None, session=None):
+        """
+        Remove a Protocol from a MongoDB database.
+
+        Returns
+        -------
+        bool
+            `True` if the specified experiment design was removed, `False` if it didn't exist.
+        """
+        delcnt = _io.remove_from_mongodb(mongodb_collection, doc_id, 'auxfile_types',
+                                         session=session)
+        return bool(delcnt == 1)
 
     def setup_nameddict(self, final_dict):
         """
@@ -580,6 +646,56 @@ class ExperimentDesign(_TreeNode):
         return ret
 
     @classmethod
+    def from_mongodb(cls, mongodb, doc_id, parent=None, name=None, quick_load=False, custom_collection_names=None):
+        """
+        Initialize a new ExperimentDesign object from a Mongo database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to load data from.
+
+        doc_id : str
+            The user-defined identifier of the experiment design to load.
+
+        parent : ExperimentDesign, optional
+            The parent design object, if there is one.  Primarily used
+            internally - if in doubt, leave this as `None`.
+
+        name : str, optional
+            The sub-name of the design object being loaded, i.e. the
+            key of this data object beneath `parent`.  Only used when
+            `parent` is not None.
+
+        quick_load : bool, optional
+            Setting this to True skips the loading of the potentially long
+            circuit lists.  This can be useful when loading takes a long time
+            and all the information of interest lies elsewhere, e.g. in an
+            encompassing results object.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different
+            types of pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
+            is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        Returns
+        -------
+        ExperimentDesign
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        ret = cls.__new__(cls)
+        ret.__dict__.update(_io.load_from_mongodb(mongodb[collection_names['edesigns']], doc_id,
+                                                  'auxfile_types', quick_load=quick_load))
+        ret._init_children_from_mongodb(mongodb, 'edesigns', doc_id, custom_collection_names, quick_load=quick_load)
+        ret._loaded_from = (mongodb, doc_id, custom_collection_names.copy()
+                            if (custom_collection_names is not None) else None)
+
+        #Fixes to JSON codec's conversion of tuples => lists
+        ret.qubit_labels = tuple(ret.qubit_labels) if isinstance(ret.qubit_labels, list) else ret.qubit_labels
+
+        return ret
+
+    @classmethod
     def from_edesign(cls, edesign):
         """
         Create an ExperimentDesign out of an existing experiment design.
@@ -842,12 +958,83 @@ class ExperimentDesign(_TreeNode):
         None
         """
         if dirname is None:
-            dirname = self._loaded_from
+            dirname = self._loaded_from if isinstance(self._loaded_from, str) else None
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
 
         _io.write_obj_to_meta_based_dir(self, _pathlib.Path(dirname) / 'edesign', 'auxfile_types')
+
         self._write_children(dirname)
         self._loaded_from = str(_pathlib.Path(dirname).absolute())  # for future writes
+
+    def write_to_mongodb(self, mongodb=None, doc_id=None, parent=None, custom_collection_names=None, session=None):
+        """
+        Write this experiment design to a MongoDB database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database, optional
+            The MongoDB instance to write data to.  Can be left as `None` if this
+            experiment design was initialized from a MongoDB, e.g. with
+            :function:`pygsti.io.read_edesign_from_mongodb`, in which case the same
+            database used for the initial read-in is used.
+
+        doc_id : str, optional
+            The user-defined identifier of the experiment design to write.  Can be
+            left as `None` if this experiment design was initialized from a MongoDB,
+            in which case the same document identifier that was used at read-in is used.
+
+        parent : ExperimentDesign, optional
+            The parent experiment design, when a parent is writing this
+            design as a sub-experiment-design.  Otherwise leave as None.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
+            is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions
+            among other things.
+
+        Returns
+        -------
+        None
+        """
+        loaded_from = self._loaded_from if isinstance(self._loaded_from, tuple) else None, None, None
+
+        if mongodb is None:
+            mongodb = loaded_from[0]
+            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
+
+        if doc_id is None:
+            doc_id = loaded_from[1]
+            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
+
+        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
+            custom_collection_names = loaded_from[2]  # override if inferring document id
+
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        _io.write_obj_to_mongodb(self, mongodb[collection_names['edesigns']], doc_id, 'auxfile_types',
+                                 session=session)
+        self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=True,
+                                        custom_collection_names=custom_collection_names, session=session)
+
+    @classmethod
+    def remove_from_mongodb(cls, mongodb, doc_id, custom_collection_names=None, session=None):
+        """
+        Remove an experiment design from a MongoDB database.
+
+        Returns
+        -------
+        bool
+            `True` if the specified experiment design was removed, `False` if it didn't exist.
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        cls._remove_children_from_mongodb(mongodb, 'edesigns', doc_id, custom_collection_names, session)
+        delcnt = _io.remove_from_mongodb(mongodb[collection_names['edesigns']], doc_id, 'auxfile_types',
+                                         session=session)
+        return bool(delcnt == 1)
 
     def setup_nameddict(self, final_dict):
         """
@@ -1581,6 +1768,8 @@ class ProtocolData(_TreeNode):
     passes : dict
         A dictionary of the data on a per-pass basis (works even it there's just one pass).
     """
+    COLL_DATASET = "pygsti_datasets"
+    COLL_CACHE = "pygsti_caches"
 
     @classmethod
     def from_dir(cls, dirname, parent=None, name=None, quick_load=False):
@@ -1599,7 +1788,7 @@ class ProtocolData(_TreeNode):
             Primarily used internally - if in doubt, leave this as `None`.
 
         name : str, optional
-            The sub-name of the design object being loaded, i.e. the
+            The sub-name of the object being loaded, i.e. the
             key of this data object beneath `parent`.  Only used when
             `parent` is not None.
 
@@ -1645,6 +1834,75 @@ class ProtocolData(_TreeNode):
 
         ret = cls(edesign, dataset, cache)
         ret._init_children(dirname, 'data', quick_load=quick_load)  # loads child nodes
+        return ret
+
+    @classmethod
+    def from_mongodb(cls, mongodb, doc_id, parent=None, name=None, quick_load=False, custom_collection_names=None):
+        """
+        Initialize a new ProtocolData object from a Mongo database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to load data from.
+
+        doc_id : str
+            The user-defined identifier of the protocol data to load.
+
+        parent : ProtocolData, optional
+            The parent data object, if there is one.  This is needed for
+            sub-data objects which reference/inherit their parent's dataset.
+            Primarily used internally - if in doubt, leave this as `None`.
+
+        name : str, optional
+            The sub-name of the object being loaded, i.e. the
+            key of this data object beneath `parent`.  Only used when
+            `parent` is not None.
+
+        quick_load : bool, optional
+            Setting this to True skips the loading of components that may take
+            a long time, e.g. the actual raw data set(s). This can be useful
+            when loading takes a long time and all the information of interest
+            lies elsewhere, e.g. in an encompassing results object.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects.  In this case, the `"edesigns"` and `"data"` keys of this dictionary
+            are relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        Returns
+        -------
+        ProtocolData
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        edesign = parent.edesign[name] if parent and name else \
+            _io.read_edesign_from_mongodb(mongodb, doc_id, quick_load, comm=None,
+                                          custom_collection_names=custom_collection_names)
+
+        if quick_load:
+            dataset = None  # don't load any dataset - just the cache (usually b/c loading is slow)
+        else:
+            #Load dataset or multidataset from database
+            ds_names = [ds_doc['name'] for ds_doc in mongodb[collection_names['data']][cls.COLL_DATASET].find(
+                {'protocoldata_parent': doc_id}, ['name'])]
+            if ds_names == [None]:
+                dataset = _io.read_dataset_from_mongodb(mongodb[collection_names['data']][cls.COLL_DATASET],
+                                                        {'name': None,
+                                                         'protocoldata_parent': doc_id})
+            else:
+                dataset = {}
+                for dsname in ds_names:
+                    dataset[dsname] = _io.read_dataset_from_mongodb(
+                        mongodb[collection_names['data'][cls.COLL_DATASET]],
+                        {'name': dsname,
+                         'protocoldata_parent': doc_id})
+
+        cache = _io.read_dict_from_mongodb(mongodb[collection_names['data']][cls.COLL_CACHE],
+                                           {'member': 'cache',
+                                            'protocoldata_parent': doc_id})
+
+        ret = cls(edesign, dataset, cache)
+        ret._init_children_from_mongodb(mongodb, 'data', doc_id, custom_collection_names, quick_load=quick_load)
         return ret
 
     def __init__(self, edesign, dataset=None, cache=None):
@@ -1802,7 +2060,7 @@ class ProtocolData(_TreeNode):
         None
         """
         if dirname is None:
-            dirname = self.edesign._loaded_from
+            dirname = self.edesign._loaded_from if isinstance(self.edesign._loaded_from, str) else None
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
         dirname = _pathlib.Path(dirname)
         data_dir = dirname / 'data'
@@ -1827,6 +2085,125 @@ class ProtocolData(_TreeNode):
             _io.write_dict_to_json_or_pkl_files(self.cache, data_dir / 'cache')
 
         self._write_children(dirname, write_subdir_json=False)  # writes sub-datas
+
+    def write_to_mongodb(self, mongodb, doc_id, parent=None, custom_collection_names=None, session=None):
+        """
+        Write this protocol data to a MongoDB database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database, optional
+            The MongoDB instance to write data to.  Can be left as `None` if this
+            protocol data was initialized from a MongoDB, e.g. with
+            :function:`pygsti.io.read_data_from_mongodb`, in which case the same
+            database used for the initial read-in is used.
+
+        doc_id : str, optional
+            The user-defined identifier of the protocol data to write.  Can be
+            left as `None` if this protocol data was initialized from a MongoDB,
+            in which case the same document identifier that was used at read-in is used.
+
+        parent : ProtocolData, optional
+            The parent protocol data, when a parent is writing this
+            data as a sub-protocol-data object.  Otherwise leave as None.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects.  In this case, the `"edesigns"` and `"data"` keys of this dictionary
+            are relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions
+            among other things.
+
+        Returns
+        -------
+        None
+        """
+        loaded_from = self.edesign._loaded_from if isinstance(self.edesign._loaded_from, tuple) else None, None, None
+
+        if mongodb is None:
+            mongodb = loaded_from[0]
+            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
+
+        if doc_id is None:
+            doc_id = loaded_from[1]
+            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
+
+        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
+            custom_collection_names = loaded_from[2]  # override if inferring document id
+
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+
+        #Write our class information to mongodb, even though we don't currently use this when loading (FUTURE work)
+        _io.write_obj_to_mongodb(self, mongodb[collection_names['data']], doc_id,
+                                 auxfile_types_member=None,
+                                 omit_attributes=['edesign', 'dataset', '_passdatas', 'cache'],
+                                 session=session)
+
+        if parent is None:  # otherwise assume parent has already written edesign
+            self.edesign.write_to_mongodb(mongodb, doc_id, None, custom_collection_names, session)
+
+        if self.dataset is not None:  # otherwise don't write any dataset
+            if parent and (self.dataset is parent.dataset):  # then no need to write any data
+                assert(mongodb[collection_names['data']][self.COLL_DATASET].count_documents(
+                    {'protocoldata_parent': doc_id}, session=session) == 0)
+            else:
+                if isinstance(self.dataset, (_data.MultiDataSet, dict)):
+                    for dsname, ds in self.dataset.items():
+                        _io.write_dataset_to_mongodb(ds, mongodb[collection_names['data']][self.COLL_DATASET],
+                                                     {'name': dsname,
+                                                      'protocoldata_parent': doc_id},
+                                                     session=session)
+                else:
+                    _io.write_dataset_to_mongodb(self.dataset, mongodb[collection_names['data']][self.COLL_DATASET],
+                                                 {'name': None,
+                                                  'protocoldata_parent': doc_id},
+                                                 session=session)
+
+        if self.cache:
+            _io.write_dict_to_mongodb(self.cache, mongodb[collection_names['data']][self.COLL_CACHE],
+                                      {'member': 'cache',
+                                       'protocoldata_parent': doc_id},
+                                      session=session)
+
+        self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=False,
+                                        custom_collection_names=custom_collection_names,
+                                        session=session)  # writes sub-datas
+
+    @classmethod
+    def remove_from_mongodb(cls, mongodb, doc_id, custom_collection_names=None, session=None):
+        """
+        Remove a protocol data object from a MongoDB database.
+
+        Returns
+        -------
+        bool
+            `True` if the specified data was removed, `False` if it didn't exist.
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        cls._remove_children_from_mongodb(mongodb, 'data', doc_id, custom_collection_names, session)
+
+        _io.remove_dict_from_mongodb(mongodb[collection_names['data']][cls.COLL_CACHE],
+                                     {'member': 'cache',
+                                      'protocoldata_parent': doc_id},
+                                     session=session)
+
+        for ds_doc in mongodb[collection_names['data']][cls.COLL_DATASET].find(
+                {'protocoldata_parent': doc_id}, ['name']):
+            _io.remove_dataset_from_mongodb(mongodb[collection_names['data']][cls.COLL_DATASET],
+                                            {'name': ds_doc['name'],
+                                             'protocoldata_parent': doc_id},
+                                            session=session)
+
+        # Perhaps parent has already done this, but try to remove edesign anyway
+        _io.remove_edesign_from_mongodb(mongodb, doc_id, custom_collection_names, session)
+
+        # Remove ProtocolData document itself
+        delcnt = _io.remove_from_mongodb(mongodb[collection_names['data']], doc_id, 'auxfile_types',
+                                         session=session)
+        return bool(delcnt == 1)
 
     def setup_nameddict(self, final_dict):
         """
@@ -1948,12 +2325,66 @@ class ProtocolResults(object):
     def _from_dir_partial(cls, dirname, quick_load=False, load_protocol=False):
         """
         Internal method for loading only the results-specific data, and not the `data` member.
-        This method may be used independently by derived ProtocolResults objecsts which contain
+        This method may be used independently by derived ProtocolResults objects which contain
         multiple sub-results (e.g. MultiPassResults)
         """
         ignore = ('type',) if load_protocol else ('type', 'protocol')
         ret = cls.__new__(cls)
         ret.__dict__.update(_io.load_meta_based_dir(dirname, 'auxfile_types', ignore, quick_load=quick_load))
+        return ret
+
+    @classmethod
+    def from_mongodb(cls, mongodb, doc_id, name, preloaded_data=None, quick_load=False, custom_collection_names=None):
+        """
+        Initialize a new ProtocolResults object from a Mongo database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to load data from.
+
+        doc_id : str
+            The user-defined identifier of the results *directory* containing the
+            results object to be loaded.
+
+        name : str
+            The name, within the directory given by `doc_id`, of the particular results
+            object to load (there can be multiple under a given `doc_id`).
+
+        quick_load : bool, optional
+            Setting this to True skips the loading of components that may take
+            a long time, e.g. the actual raw data set(s). This can be useful
+            when loading takes a long time and all the information of interest
+            lies elsewhere, e.g. in an encompassing results object.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects. Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        Returns
+        -------
+        ProtocolResults
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        result_id = doc_id + '/' + name  # derive_child_id_from_parent_id(doc_id, name)
+        ret = cls._from_mongodb_partial(mongodb[collection_names['results']], result_id, quick_load, load_protocol=True)
+        ret.data = preloaded_data if (preloaded_data is not None) else \
+            _io.read_data_from_mongodb(mongodb, doc_id, quick_load=quick_load,
+                                       custom_collection_names=custom_collection_names)
+        assert(ret.name == name), "ProtocolResults name inconsistency!"
+        return ret
+
+    @classmethod
+    def _from_mongodb_partial(cls, mongodb_collection, result_id, quick_load=False, load_protocol=False):
+        """
+        Internal method for loading only the results-specific data, and not the `data` member.
+        This method may be used independently by derived ProtocolResults objects which contain
+        multiple sub-results (e.g. MultiPassResults)
+        """
+        ignore = ('type',) if load_protocol else ('type', 'protocol')
+        ret = cls.__new__(cls)
+        ret.__dict__.update(_io.load_from_mongodb(mongodb_collection, result_id,
+                                                  'auxfile_types', ignore, quick_load=quick_load))
         return ret
 
     def __init__(self, data, protocol_instance):
@@ -2000,7 +2431,7 @@ class ProtocolResults(object):
         None
         """
         if dirname is None:
-            dirname = self.data.edesign._loaded_from
+            dirname = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, str) else None
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
 
         p = _pathlib.Path(dirname)
@@ -2022,6 +2453,95 @@ class ProtocolResults(object):
         """
         _io.write_obj_to_meta_based_dir(self, results_dir, 'auxfile_types',
                                         omit_attributes=() if write_protocol else ('protocol',))
+
+    def write_to_mongodb(self, mongodb=None, doc_id=None, data_already_written=False,
+                         custom_collection_names=None, session=None):
+        """
+        Write these protocol results to a MongoDB database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database, optional
+            The MongoDB instance to write data to.  Can be left as `None` if this
+            protocol data was initialized from a MongoDB, e.g. with
+            :function:`pygsti.io.read_results_from_mongodb`, in which case the same
+            database used for the initial read-in is used.
+
+        doc_id : str, optional
+            The user-defined identifier of the results *directory*. Can be
+            left as `None` if this protocol results object was initialized from a MongoDB,
+            in which case the same document identifier that was used at read-in is used.
+
+        data_already_written : bool, optional
+            Set this to True if you're sure the `.data` :class:`ProtocolData` object
+            within this results object has already been written to `mongodb`.  Leaving
+            this as the default is a safe option.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects. Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions
+            among other things.
+
+        Returns
+        -------
+        None
+        """
+        loaded_from = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, tuple) \
+            else None, None, None
+
+        if mongodb is None:
+            mongodb = loaded_from[0]
+            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
+
+        if doc_id is None:
+            doc_id = loaded_from[1]
+            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
+
+        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
+            custom_collection_names = loaded_from[2]  # override if inferring document id
+
+        #write edesign and data
+        if not data_already_written:
+            self.data.write_to_mongodb(mongodb, doc_id, custom_collection_names=custom_collection_names,
+                                       session=session)
+
+        #write qtys to results dir
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        result_id = doc_id + '/' + self.name  # derive_child_id_from_parent_id(doc_id, self.name)
+        self._write_partial_to_mongodb(mongodb[collection_names['results']], result_id, write_protocol=True,
+                                       additional_meta={'directory_id': doc_id},
+                                       session=session)
+
+    def _write_partial_to_mongodb(self, mongodb_collection, result_id, write_protocol=False,
+                                  additional_meta=None, session=None):
+        """
+        Internal method used to write the results-specific data to a MongoDB.
+        This method does not write the object's `data` member, which must be
+        serialized separately.
+        """
+        _io.write_obj_to_mongodb(self, mongodb_collection, result_id,
+                                 'auxfile_types', omit_attributes=() if write_protocol else ('protocol',),
+                                 additional_meta=additional_meta, session=session)
+
+    @classmethod
+    def remove_from_mongodb(cls, mongodb, doc_id, name, custom_collection_names=None, session=None):
+        """
+        Remove a :class:`ProtocolResults` object from a MongoDB database.
+
+        Returns
+        -------
+        bool
+            `True` if the specified data was removed, `False` if it didn't exist.
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        result_id = doc_id + '/' + name  # derive_child_id_from_parent_id(doc_id, name)
+        delcnt = _io.remove_from_mongodb(mongodb[collection_names['results']], result_id, 'auxfile_types',
+                                         session=session)
+        return bool(delcnt == 1)
 
     def to_nameddict(self):
         """
@@ -2291,6 +2811,67 @@ class ProtocolResultsDir(_TreeNode):
         ret._init_children(dirname, meta_subdir='results', quick_load=quick_load)
         return ret
 
+    @classmethod
+    def from_mongodb(cls, mongodb, doc_id, parent=None, name=None, preloaded_data=None, quick_load=False,
+                     custom_collection_names=None):
+        """
+        Initialize a new :class:`ProtocolResultsDir` object from a Mongo database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to load data from.
+
+        doc_id : str
+            The user-defined identifier of the protocol results directory to load.
+
+        parent : ProtocolData, optional
+            The parent data object, if there is one.  This is needed for
+            sub-results objects which reference/inherit their parent's dataset.
+            Primarily used internally - if in doubt, leave this as `None`.
+
+        name : str, optional
+            The sub-name of the object being loaded, i.e. the
+            key of this data object beneath `parent`.  Only used when
+            `parent` is not None.
+
+        preloaded_data : ProtocolData, optional
+            In the case that the :class:`ProtocolData` object for `doc_id`
+            is already loaded, it can be passed in here.  Otherwise leave this
+            as None and it will be loaded.
+
+        quick_load : bool, optional
+            Setting this to True skips the loading of components that may take
+            a long time, e.g. the actual raw data set(s). This can be useful
+            when loading takes a long time and all the information of interest
+            lies elsewhere, e.g. in an encompassing results object.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        Returns
+        -------
+        ProtocolResultsDir
+        """
+        data = parent.data[name] if (parent and name) else \
+            (preloaded_data if preloaded_data is not None else
+             _io.read_data_from_mongodb(mongodb, doc_id, quick_load=quick_load, comm=None,
+                                        custom_collection_names=custom_collection_names))
+
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+
+        #Load results with directory_id == doc_id
+        results = {}
+        for res_doc in mongodb[collection_names['results']].find({'directory_id': doc_id}, ['name', 'type']):
+            results[res_doc['name']] = _io.metadir._class_for_name(res_doc['type']).from_mongodb(
+                mongodb, doc_id, res_doc['name'], preloaded_data=data, quick_load=quick_load,
+                custom_collection_names=custom_collection_names)
+
+        ret = cls(data, results, {})  # don't initialize children now
+        ret._init_children_from_mongodb(mongodb, None, doc_id, custom_collection_names, quick_load=quick_load)
+        return ret
+
     def __init__(self, data, protocol_results=None, children=None):
         """
         Create a new ProtocolResultsDir object.
@@ -2341,7 +2922,8 @@ class ProtocolResultsDir(_TreeNode):
 
     def _create_childval(self, key):  # (this is how children are created on-demand)
         """ Create the value for `key` on demand. """
-        if self.data.edesign._loaded_from and key in self._dirs:
+        if self.data.edesign._loaded_from and isinstance(self.data.edesign._loaded_from, str) \
+           and key in self._dirs:
             dirname = _pathlib.Path(self.data.edesign._loaded_from)
             subdir = self._dirs[key]
             subobj_dir = dirname / subdir
@@ -2382,7 +2964,7 @@ class ProtocolResultsDir(_TreeNode):
         None
         """
         if dirname is None:
-            dirname = self.data.edesign._loaded_from
+            dirname = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, str) else None
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
 
         if parent is None: self.data.write(dirname)  # assume parent has already written data
@@ -2398,6 +2980,101 @@ class ProtocolResultsDir(_TreeNode):
             results.write(dirname, data_already_written=True)
 
         self._write_children(dirname, write_subdir_json=False)  # writes sub-nodes
+
+    def write_to_mongodb(self, mongodb, doc_id, parent=None, custom_collection_names=None, session=None):
+        """
+        Write this protocol results directory to a MongoDB database.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database, optional
+            The MongoDB instance to write data to.  Can be left as `None` if this
+            results directory was initialized from a MongoDB, e.g. with
+            :function:`pygsti.io.read_results_from_mongodb`, in which case the same
+            database used for the initial read-in is used.
+
+        doc_id : str, optional
+            The user-defined identifier of the protocol results directory to write.  Can be
+            left as `None` if this results directory was initialized from a MongoDB,
+            in which case the same document identifier that was used at read-in is used.
+
+        parent : ProtocolResultsDir, optional
+            The parent protocol results directory, when a parent is writing this
+            data as a sub-protocol-data object.  Otherwise leave as None.
+
+        custom_collection_names : dict, optional
+            Overrides for the default MongoDB collection names used for storing different types of
+            pyGSTi objects.  In this case, the `"edesigns"` and `"data"` keys of this dictionary
+            are relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions
+            among other things.
+
+        Returns
+        -------
+        None
+        """
+        loaded_from = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, tuple) \
+            else None, None, None
+
+        if mongodb is None:
+            mongodb = loaded_from[0]
+            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
+
+        if doc_id is None:
+            doc_id = loaded_from[1]
+            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
+
+        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
+            custom_collection_names = loaded_from[2]  # override if inferring document id
+
+        if parent is None:
+            self.data.write_to_mongodb(mongodb, doc_id, None, custom_collection_names, session)
+
+        ##Write our class information to mongodb, even though we don't currently use this when loading
+        #_io.write_obj_to_mongodb(self, mongodb[collection_names['resultdirs']], doc_id,
+        #                         auxfile_types_member=None,
+        #                         omit_attributes=[...],
+        #                         session=session)
+
+        #write the results
+        for name, results in self.for_protocol.items():
+            assert(results.name == name)
+            results.write_to_mongodb(mongodb, doc_id, data_already_written=True,
+                                     custom_collection_names=custom_collection_names, session=session)
+        self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=False,
+                                        custom_collection_names=custom_collection_names,
+                                        session=session)  # writes sub-resultdirs
+
+    @classmethod
+    def remove_from_mongodb(cls, mongodb, doc_id, custom_collection_names=None, session=None):
+        """
+        Remove a protocol results directory from a MongoDB database.
+
+        Returns
+        -------
+        bool
+            `True` if the specified data was removed, `False` if it didn't exist.
+        """
+        collection_names = _io.mongodb_collection_names(custom_collection_names)
+        cls._remove_children_from_mongodb(mongodb, None, doc_id, custom_collection_names, session)
+
+        delcnt = 0
+        for res_doc in mongodb[collection_names['results']].find(
+                {'directory_id': doc_id}, ['name']):
+            if _io.remove_results_from_mongodb(mongodb, doc_id, res_doc['name'], comm=None,
+                                               custom_collection_names=custom_collection_names, session=session):
+                delcnt += 1
+
+        # Perhaps parent has already done this, but try to remove data anyway
+        _io.remove_data_from_mongodb(mongodb, doc_id, custom_collection_names, session)
+
+        #FUTURE: if we use resultdirs:
+        #delcnt = _io.remove_from_mongodb(mongodb[collection_names['resultdirs']], doc_id, 'auxfile_types',
+        #                                 session=session)
+        return bool(delcnt >= 1)
 
     def _result_namedicts_on_this_node(self):
         nds = [v.to_nameddict() for v in self.for_protocol.values()]

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ extras = {
         'ipython',
         'notebook'
     ],
+    'mongodb': ['pymongo'],
     'msgpack': ['msgpack'],
     'extensions': ['cython'],
     'linting': [

--- a/test/unit/io/test_mongo.py
+++ b/test/unit/io/test_mongo.py
@@ -1,0 +1,79 @@
+import unittest
+from ..util import BaseCase
+
+import pygsti
+from pygsti.modelpacks import smq1Q_XYI as std
+
+import collections
+collections.Callable = collections.abc.Callable
+
+try:
+    import pymongo
+    PYMONGO_IMPORTED = True
+except ImportError:
+    pymongo = None
+    PYMONGO_IMPORTED = False
+
+
+class MongoDBTester(BaseCase):
+
+    def setUp(self):
+        if pymongo is not None:
+            myclient = pymongo.MongoClient("mongodb://localhost:27017/")
+            self.mydb = myclient["pygsti_unittest_database"]
+        else:
+            self.mydb = None
+
+    @unittest.skipUnless(PYMONGO_IMPORTED, "pymongo not installed")
+    def test_mongodb_edesign(self):
+        edesign = std.create_gst_experiment_design(1)
+        #len(edesign.all_circuits_needing_data)  # 92
+
+        bRemoved = pygsti.protocols.ExperimentDesign.remove_from_mongodb(self.mydb, "my_test_edesign")
+        self.assertFalse(bRemoved)
+
+        edesign.write_to_mongodb(self.mydb, "my_test_edesign")
+        edesign2 = pygsti.io.read_edesign_from_mongodb(self.mydb, "my_test_edesign")
+        self.assertEqual(len(edesign2.all_circuits_needing_data), len(edesign.all_circuits_needing_data))
+
+        bRemoved = pygsti.protocols.ExperimentDesign.remove_from_mongodb(self.mydb, "my_test_edesign")
+        self.assertTrue(bRemoved)
+
+    @unittest.skipUnless(PYMONGO_IMPORTED, "pymongo not installed")
+    def test_mongodb_data(self):
+        edesign = std.create_gst_experiment_design(1)
+        datagen_mdl = std.target_model().depolarize(op_noise=0.03, spam_noise=0.05)
+        ds = pygsti.data.simulate_data(datagen_mdl, edesign, 1000, seed=123456)
+        data = pygsti.protocols.ProtocolData(edesign, ds)
+
+        bRemoved = pygsti.protocols.ProtocolData.remove_from_mongodb(self.mydb, "my_test_data")
+        self.assertFalse(bRemoved)
+
+        data.write_to_mongodb(self.mydb, "my_test_data")
+        data2 = pygsti.io.read_data_from_mongodb(self.mydb, "my_test_data")
+        self.assertTrue(isinstance(data2.edesign._loaded_from[0], pymongo.database.Database))
+        self.assertEqual(len(data.dataset), len(data2.dataset))
+
+        bRemoved = pygsti.protocols.ProtocolData.remove_from_mongodb(self.mydb, "my_test_data")
+        self.assertTrue(bRemoved)
+
+    @unittest.skipUnless(PYMONGO_IMPORTED, "pymongo not installed")
+    def test_mongodb_results(self):
+        edesign = std.create_gst_experiment_design(1)
+        datagen_mdl = std.target_model().depolarize(op_noise=0.03, spam_noise=0.05)
+        ds = pygsti.data.simulate_data(datagen_mdl, edesign, 1000, seed=123456)
+        data = pygsti.protocols.ProtocolData(edesign, ds)
+
+        gst = pygsti.protocols.StandardGST('full TP')
+        results = gst.run(data)
+
+        bRemoved = pygsti.protocols.ProtocolResultsDir.remove_from_mongodb(self.mydb, "my_test_results")
+        self.assertFalse(bRemoved)
+
+        results.write_to_mongodb(self.mydb, "my_test_results")
+        resultsdir2 = pygsti.io.read_results_from_mongodb(self.mydb, 'my_test_results')
+        results2 = resultsdir2.for_protocol['StandardGST']
+
+        self.assertTrue(isinstance(results2.estimates['full TP'].models['target'], pygsti.models.Model))
+        bRemoved = pygsti.protocols.ProtocolResultsDir.remove_from_mongodb(self.mydb, "my_test_results")
+        self.assertTrue(bRemoved)


### PR DESCRIPTION
**Adds ability to serialize pyGSTi objects to a MongoDB database.**

Leverages the framework used to save pyGSTi objects to json files within a filesystem hierarchy to alternatively save these objects to a MongoDB database.  This medium provides some potential benefits over a filesystem in that it's easier to share and distribute (see *sharding* MongoDB lingo), and can be made robust through transactions and automated backups.

This PR represents the first implementation of a MongoDB serialization interface, adding MongoDB counterparts to many of the file I/O functions.  In particular, it adds `write_to_mongodb` methods for experiment design, protocol data, and protocol results objects, and adds `pygsti.io.read_edesign_from_mongodb`, `pygsti.io.read_data_from_mongodb`, and `pygsti.io.read_results_from_mongodb` functions.  Human-readable names should be used as the `doc_id` arguments to these functions, which loosely correspond to the directory-node names within the filesystem picture.

A module of unit tests is included, which tests most but not all of the functionality (missing in particular serialization of `ConfidenceRegionFactory` objects).  Note, however, that `pymongo` and a local MongoDB server are needed to run these tests and currently `pymongo` is not listed as a "testing" dependency in pyGSTi.