### PR TITLE
Feature wildcard serialization

### DIFF
--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1897,11 +1897,11 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
                     budget = _compute_wildcard_budget_1d_model(base_estimate, objfn_cache, mdc_objfn, parameters,
                                                                badfit_options, printer - 1)
 
-                    base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = budget
+                    base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = budget.to_nice_serialization()
                     base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] \
                         = None
 
-                    base_estimate.extra_parameters["unmodeled_error"] = budget
+                    base_estimate.extra_parameters["unmodeled_error"] = budget.to_nice_serialization()
                     base_estimate.extra_parameters["unmodeled_active_constraints"] = None
                 except NotImplementedError as e:
                     printer.warning("Failed to get wildcard budget - continuing anyway.  Error was:\n" + str(e))

--- a/pygsti/report/factory.py
+++ b/pygsti/report/factory.py
@@ -1221,10 +1221,13 @@ def construct_standard_report(results, title="auto",
                 #check if the wildcard budget is an instance
                 #of the diamond distance model, in which case we
                 #will add an extra flag/plot to the report.
-                if (isinstance(est.parameters['unmodeled_error'], PrimitiveOpsSingleScaleWildcardBudget)
-                   and est.parameters['unmodeled_error'].reference_name == 'diamond distance'):
+                wildcard = est.parameters['unmodeled_error']
+                if isinstance(wildcard, dict):  # assume a serialized budget object
+                    wildcard = _wildcardbudget.WildcardBudget.from_nice_serialization(wildcard)
+                if (isinstance(wildcard, PrimitiveOpsSingleScaleWildcardBudget)
+                   and wildcard.reference_name == 'diamond distance'):
                     flags.add('DiamondDistanceWildcard')
-                
+
     if combine_robust:
         flags.add('CombineRobust')
 

--- a/pygsti/report/factory.py
+++ b/pygsti/report/factory.py
@@ -29,6 +29,7 @@ from pygsti import tools as _tools
 from pygsti.models.explicitmodel import ExplicitOpModel as _ExplicitOpModel
 from pygsti.baseobjs.statespace import StateSpace as _StateSpace
 from pygsti.objectivefns import objectivefns as _objfns
+from pygsti.objectivefns import wildcardbudget as _wildcardbudget
 from pygsti.circuits.circuit import Circuit as _Circuit
 from pygsti.circuits.circuitlist import CircuitList as _CircuitList
 from pygsti.circuits.circuitstructure import PlaquetteGridCircuitStructure as _PlaquetteGridCircuitStructure
@@ -356,9 +357,13 @@ def _create_master_switchboard(ws, results_dict, confidence_level,
                 switchBd.eff_ds[d, i] = NA
                 switchBd.scaled_submxs_dict[d, i] = NA
 
-            switchBd.wildcard_budget_optional[d, i] = est.parameters.get("unmodeled_error", None)
+            wildcard = est.parameters.get("unmodeled_error", None)
+            if isinstance(wildcard, dict):  # assume a serialized budget object
+                wildcard = _wildcardbudget.WildcardBudget.from_nice_serialization(wildcard)
+
+            switchBd.wildcard_budget_optional[d, i] = wildcard
             if est.parameters.get("unmodeled_error", None):
-                switchBd.wildcard_budget[d, i] = est.parameters['unmodeled_error']
+                switchBd.wildcard_budget[d, i] = wildcard
             else:
                 switchBd.wildcard_budget[d, i] = NA
 
@@ -369,7 +374,7 @@ def _create_master_switchboard(ws, results_dict, confidence_level,
                                                                                      est.models['target'])
             except AttributeError:  # Implicit models don't support everything, like set_all_parameterizations
                 switchBd.mdl_gaugeinv_ep[d, i] = None
-            except AssertionError:  # if target is badly off, this can fail with an imaginary part assertion
+            except (ValueError, AssertionError):  # if target is badly off, e.g. an imaginary part assertion
                 switchBd.mdl_gaugeinv_ep[d, i] = None
 
             switchBd.mdl_final[d, i, :] = [est.models.get(l, NA) for l in gauge_opt_labels]
@@ -1498,6 +1503,7 @@ def construct_nqnoise_report(results, title="auto",
         'colorBoxPlotKeyPlot': ws.BoxKeyPlot(switchBd.prep_fiducials, switchBd.meas_fiducials),
         'bestGatesetGaugeOptParamsTable': ws.GaugeOptParamsTable(switchBd.goparams),
         'gramBarPlot': ws.GramMatrixBarPlot(switchBd.ds, switchBd.mdl_target, 10, switchBd.fiducials_tup)
+        # Note by EGN 11/10/2022 - I don't think 'gramBarPlot' is needed here, maybe just a copy/paste oversight?
     }
 
     report_params = {


### PR DESCRIPTION
**Adds ability to serialize results objects to disk or MongoDB that contain wildcard budgets**

This seems useful for obvious reasons.  As a side effect, `Estimate` objects are updated to hold *serialized* wildcard budget objects instead of the objects themselves.  This could break external code that extracts wildcard budgets from result objects.