### PR TITLE
Feature edesign map-qubit-labels

### DIFF
--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -3684,10 +3684,10 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
             with _np.load(load_cevd_cache_filename) as cevd_cache:
                 twirledDerivDaggerDerivList=[list(cevd_cache.values())]
             
-        else: 
+        else:
             twirledDerivDaggerDerivList = \
                 [_compute_bulk_twirled_ddd_compact(model, germs_list, tol,
-                                                  evd_tol=evd_tol, float_type=float_type, printer=printer)
+                                                   evd_tol=evd_tol, float_type=float_type, printer=printer)
              for model in model_list]
              
             if save_cevd_cache_filename is not None:
@@ -3710,13 +3710,14 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
         nonzero_weight_indices= nonzero_weight_indices[0]
         for i, derivDaggerDeriv in enumerate(twirledDerivDaggerDerivList):
             #reconstruct the needed J^T J matrices
+            temp_DDD = None
             for j, idx in enumerate(nonzero_weight_indices):
                 if j==0:
                     temp_DDD = derivDaggerDeriv[idx] @ derivDaggerDeriv[idx].T
                 else:
                     temp_DDD += derivDaggerDeriv[idx] @ derivDaggerDeriv[idx].T
-
-            currentDDDList.append(temp_DDD)
+            if temp_DDD is not None:
+                currentDDDList.append(temp_DDD)
 
     else:  # should be unreachable since we set 'mode' internally above
         raise ValueError("Invalid mode: %s" % mode)  # pragma: no cover

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -113,6 +113,29 @@ class GateSetTomographyDesign(_proto.CircuitListsDesign, HasProcessorSpec):
         super().__init__(circuit_lists, all_circuits_needing_data, qubit_labels, nested, remove_duplicates)
         HasProcessorSpec.__init__(self, processorspec_filename_or_obj)
 
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        GateSetTomographyDesign
+        """
+        mapped_processorspec = self.processor_spec.map_qubit_labels(mapper)
+        mapped_circuits = [c.map_state_space_labels(mapper) for c in self.all_circuits_needing_data]
+        mapped_circuit_lists = [[c.map_state_space_labels(mapper) for c in circuit_list]
+                                for circuit_list in self.circuit_lists]
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        return GateSetTomographyDesign(mapped_processorspec, mapped_circuit_lists, mapped_circuits,
+                                       mapped_qubit_labels, self.nested, remove_duplicates=False)
+
 
 class StandardGSTDesign(GateSetTomographyDesign):
     """
@@ -321,6 +344,38 @@ class StandardGSTDesign(GateSetTomographyDesign):
         ret = ret.truncate_to_design(self)
         ret.nested = self.nested  # must set nested flag again because truncate_to_design resets to False to be safe
         return ret
+
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        StandardGSTDesign
+        """
+        pspec = self.processor_spec.map_qudit_labels(mapper)
+        prep_fiducials = [c.map_state_space_labels(mapper) for c in self.prep_fiducials]
+        meas_fiducials = [c.map_state_space_labels(mapper) for c in self.meas_fiducials]
+        germs = [c.map_state_space_labels(mapper) for c in self.germs]
+        qubit_labels = self._mapped_qubit_labels(mapper)
+        if isinstance(self.fiducial_pairs, dict):
+            fiducial_pairs = {c.map_state_space_labels(mapper): v for c, v in self.fiducial_pairs.items()}
+        else:
+            fiducial_pairs = self.fiducial_pairs
+
+        dscheck = None; action_if_missing = 'raise'; verbosity = 0  # values we could add as arguments later if desired.
+        return StandardGSTDesign(pspec, prep_fiducials, meas_fiducials,
+                                 germs, self.maxlengths, self.germ_length_limits, fiducial_pairs,
+                                 self.fpr_keep_fraction, self.fpr_keep_seed, self.include_lgst, self.nested,
+                                 self.circuit_rules, self.aliases, dscheck, action_if_missing, qubit_labels,
+                                 verbosity, add_default_protocol=False)
 
 
 class GSTInitialModel(_NicelySerializable):

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -370,6 +370,10 @@ class StandardGSTDesign(GateSetTomographyDesign):
         else:
             fiducial_pairs = self.fiducial_pairs
 
+        if not (self.circuit_rules is None and self.aliases is None):
+            raise NotImplementedError(("Mapping qubit labels for a StandardGSTDesign with circuit rules"
+                                       " and/or aliases is not implemented yet."))
+
         dscheck = None; action_if_missing = 'raise'; verbosity = 0  # values we could add as arguments later if desired.
         return StandardGSTDesign(pspec, prep_fiducials, meas_fiducials,
                                  germs, self.maxlengths, self.germ_length_limits, fiducial_pairs,

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -245,6 +245,34 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
                 defaultfit = 'full'
             self.add_default_protocol(RB(name='RB', defaultfit=defaultfit))
 
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        CliffordRBDesign
+        """
+        mapped_circuits_and_idealouts_by_depth = []
+        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
+            mapped_circuits_and_idealouts_by_depth.append(
+                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        if self.interleaved_circuit is not None:
+            raise NotImplementedError("TODO: figure out whether `interleaved_circuit` needs to be mapped!")
+        return CliffordRBDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
+                                                       mapped_qubit_labels,
+                                                       self.randomizeout, self.citerations, self.compilerargs,
+                                                       self.interleaved_circuit, self.descriptor,
+                                                       add_default_protocol=False)
+
 
 class DirectRBDesign(_vb.BenchmarkingDesign):
     """
@@ -564,6 +592,33 @@ class DirectRBDesign(_vb.BenchmarkingDesign):
                 defaultfit = 'full'
             self.add_default_protocol(RB(name='RB', defaultfit=defaultfit))
 
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        DirectRBDesign
+        """
+        mapped_circuits_and_idealouts_by_depth = []
+        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
+            mapped_circuits_and_idealouts_by_depth.append(
+                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        return DirectRBDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
+                                                     mapped_qubit_labels,
+                                                     self.sampler, self.samplerargs, self.addlocal,
+                                                     self.lsargs, self.randomizeout, self.cliffordtwirl,
+                                                     self.conditionaltwirl, self.citerations, self.compilerargs,
+                                                     self.partitioned, self.descriptor, add_default_protocol=False)
+
 
 class MirrorRBDesign(_vb.BenchmarkingDesign):
     """
@@ -778,6 +833,33 @@ class MirrorRBDesign(_vb.BenchmarkingDesign):
 
         if add_default_protocol:
             self.add_default_protocol(RB(name='RB', datatype='adjusted_success_probabilities', defaultfit='A-fixed'))
+
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        MirrorRBDesign
+        """
+        mapped_circuits_and_idealouts_by_depth = []
+        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
+            mapped_circuits_and_idealouts_by_depth.append(
+                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        return DirectRBDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
+                                                     mapped_qubit_labels,
+                                                     self.circuit_type, self.sampler,
+                                                     self.samplerargs, self.localclifford,
+                                                     self.paulirandomize, self.descriptor,
+                                                     add_default_protocol=False)
 
 
 class RandomizedBenchmarking(_vb.SummaryStatistics):

--- a/pygsti/protocols/rb.py
+++ b/pygsti/protocols/rb.py
@@ -260,10 +260,7 @@ class CliffordRBDesign(_vb.BenchmarkingDesign):
         -------
         CliffordRBDesign
         """
-        mapped_circuits_and_idealouts_by_depth = []
-        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
-            mapped_circuits_and_idealouts_by_depth.append(
-                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_circuits_and_idealouts_by_depth = self._mapped_circuits_and_idealouts_by_depth(mapper)
         mapped_qubit_labels = self._mapped_qubit_labels(mapper)
         if self.interleaved_circuit is not None:
             raise NotImplementedError("TODO: figure out whether `interleaved_circuit` needs to be mapped!")
@@ -607,10 +604,7 @@ class DirectRBDesign(_vb.BenchmarkingDesign):
         -------
         DirectRBDesign
         """
-        mapped_circuits_and_idealouts_by_depth = []
-        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
-            mapped_circuits_and_idealouts_by_depth.append(
-                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_circuits_and_idealouts_by_depth = self._mapped_circuits_and_idealouts_by_depth(mapper)
         mapped_qubit_labels = self._mapped_qubit_labels(mapper)
         return DirectRBDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
                                                      mapped_qubit_labels,
@@ -849,10 +843,7 @@ class MirrorRBDesign(_vb.BenchmarkingDesign):
         -------
         MirrorRBDesign
         """
-        mapped_circuits_and_idealouts_by_depth = []
-        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
-            mapped_circuits_and_idealouts_by_depth.append(
-                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_circuits_and_idealouts_by_depth = self._mapped_circuits_and_idealouts_by_depth(mapper)
         mapped_qubit_labels = self._mapped_qubit_labels(mapper)
         return DirectRBDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
                                                      mapped_qubit_labels,

--- a/pygsti/protocols/vb.py
+++ b/pygsti/protocols/vb.py
@@ -47,6 +47,26 @@ class ByDepthDesign(_proto.CircuitListsDesign):
         super().__init__(circuit_lists, qubit_labels=qubit_labels, remove_duplicates=remove_duplicates)
         self.depths = depths
 
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        ByDepthDesign
+        """
+        mapped_circuit_lists = [[c.map_state_space_labels(mapper) for c in circuit_list]
+                                for circuit_list in self.circuit_lists]
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        return ByDepthDesign(self.depths, mapped_circuit_lists, mapped_qubit_labels, remove_duplicates=False)
+
 
 class BenchmarkingDesign(ByDepthDesign):
     """
@@ -84,6 +104,27 @@ class BenchmarkingDesign(ByDepthDesign):
         super().__init__(depths, circuit_lists, qubit_labels, remove_duplicates)
         self.idealout_lists = ideal_outs
         self.auxfile_types['idealout_lists'] = 'json'
+
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        ByDepthDesign
+        """
+        mapped_circuit_lists = [[c.map_state_space_labels(mapper) for c in circuit_list]
+                                for circuit_list in self.circuit_lists]
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        return BenchmarkingDesign(self.depths, mapped_circuit_lists, list(self.idealout_lists),
+                                  mapped_qubit_labels, remove_duplicates=False)
 
 
 class PeriodicMirrorCircuitDesign(BenchmarkingDesign):
@@ -274,6 +315,32 @@ class PeriodicMirrorCircuitDesign(BenchmarkingDesign):
         self.localclifford = localclifford
         self.paulirandomize = paulirandomize
         self.fixed_versus_depth = fixed_versus_depth
+
+    def map_qubit_labels(self, mapper):
+        """
+        Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
+
+        Parameters
+        ----------
+        mapper : dict or function
+            A dictionary whose keys are the existing self.qubit_labels values
+            and whose value are the new labels, or a function which takes a
+            single (existing qubit-label) argument and returns a new qubit-label.
+
+        Returns
+        -------
+        PeriodicMirrorCircuitDesign
+        """
+        mapped_circuits_and_idealouts_by_depth = []
+        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
+            mapped_circuits_and_idealouts_by_depth.append(
+                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_qubit_labels = self._mapped_qubit_labels(mapper)
+        return PeriodicMirrorCircuitDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
+                                                                  mapped_qubit_labels,
+                                                                  self.sampler, self.samplerargs, self.localclifford,
+                                                                  self.paulirandomize, self.fixed_versus_depth,
+                                                                  self.descriptor)
 
 
 class SummaryStatistics(_proto.Protocol):

--- a/pygsti/protocols/vb.py
+++ b/pygsti/protocols/vb.py
@@ -105,6 +105,14 @@ class BenchmarkingDesign(ByDepthDesign):
         self.idealout_lists = ideal_outs
         self.auxfile_types['idealout_lists'] = 'json'
 
+    def _mapped_circuits_and_idealouts_by_depth(self, mapper):
+        """ Used in derived classes """
+        mapped_circuits_and_idealouts_by_depth = {}
+        for depth, circuit_list, idealout_list in zip(self.depths, self.circuit_lists, self.idealout_lists):
+            mapped_circuits_and_idealouts_by_depth[depth] = \
+                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)]
+        return mapped_circuits_and_idealouts_by_depth
+
     def map_qubit_labels(self, mapper):
         """
         Creates a new experiment design whose circuits' qubit labels are updated according to a given mapping.
@@ -331,10 +339,7 @@ class PeriodicMirrorCircuitDesign(BenchmarkingDesign):
         -------
         PeriodicMirrorCircuitDesign
         """
-        mapped_circuits_and_idealouts_by_depth = []
-        for circuit_list, idealout_list in zip(self.circuit_lists, self.idealout_lists):
-            mapped_circuits_and_idealouts_by_depth.append(
-                [(c.map_state_space_labels(mapper), iout) for c, iout in zip(circuit_list, idealout_list)])
+        mapped_circuits_and_idealouts_by_depth = self._mapped_circuits_and_idealouts_by_depth(mapper)
         mapped_qubit_labels = self._mapped_qubit_labels(mapper)
         return PeriodicMirrorCircuitDesign.from_existing_circuits(mapped_circuits_and_idealouts_by_depth,
                                                                   mapped_qubit_labels,


### PR DESCRIPTION
**Adds `map_qubit_labels` methods of experiment design classes.**

These methods make it easy and convenient to change the qubit labels of an experiment design.  This makes it possible to store "template experiment designs" that can be used to produce many replicas of themselves on different sets of qubits.  This functionality is implemented for `CombinedExperimentDesign` and `SimultaneousExperimentDesign` objects, and so can be applied to entire trees of experiment designs.

Basic unit tests were added.