### PR TITLE
Feature mongodb upgrade

### DIFF
--- a/pygsti/algorithms/core.py
+++ b/pygsti/algorithms/core.py
@@ -13,6 +13,7 @@ Core GST algorithms
 
 import collections as _collections
 import time as _time
+import copy as _copy
 
 import numpy as _np
 import scipy.optimize as _spo
@@ -797,8 +798,12 @@ def run_iterative_gst(dataset, start_model, circuit_lists,
 
             for j, obj_fn_builder in enumerate(iteration_objfn_builders):
                 tNxt = _time.time()
-                optimizer.fditer = optimizer.first_fditer if (i == 0 and j == 0) else 0
-                opt_result, mdc_store = run_gst_fit(mdc_store, optimizer, obj_fn_builder, printer - 1)
+                if i == 0 and j == 0:  # special case: in first optimization run, use "first_fditer"
+                    first_iter_optimizer = _copy.deepcopy(optimizer)  # use a separate copy of optimizer, as it
+                    first_iter_optimizer.fditer = optimizer.first_fditer  # is a persistent object (so don't modify!)
+                    opt_result, mdc_store = run_gst_fit(mdc_store, first_iter_optimizer, obj_fn_builder, printer - 1)
+                else:
+                    opt_result, mdc_store = run_gst_fit(mdc_store, optimizer, obj_fn_builder, printer - 1)
                 profiler.add_time('run_iterative_gst: iter %d %s-opt' % (i + 1, obj_fn_builder.name), tNxt)
 
             tNxt = _time.time()

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -3684,10 +3684,10 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
             with _np.load(load_cevd_cache_filename) as cevd_cache:
                 twirledDerivDaggerDerivList=[list(cevd_cache.values())]
             
-        else: 
+        else:
             twirledDerivDaggerDerivList = \
                 [_compute_bulk_twirled_ddd_compact(model, germs_list, tol,
-                                                  evd_tol=evd_tol, float_type=float_type, printer=printer)
+                                                   evd_tol=evd_tol, float_type=float_type, printer=printer)
              for model in model_list]
              
             if save_cevd_cache_filename is not None:
@@ -3710,13 +3710,14 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
         nonzero_weight_indices= nonzero_weight_indices[0]
         for i, derivDaggerDeriv in enumerate(twirledDerivDaggerDerivList):
             #reconstruct the needed J^T J matrices
+            temp_DDD = None
             for j, idx in enumerate(nonzero_weight_indices):
                 if j==0:
                     temp_DDD = derivDaggerDeriv[idx] @ derivDaggerDeriv[idx].T
                 else:
                     temp_DDD += derivDaggerDeriv[idx] @ derivDaggerDeriv[idx].T
-
-            currentDDDList.append(temp_DDD)
+            if temp_DDD is not None:
+                currentDDDList.append(temp_DDD)
 
     else:  # should be unreachable since we set 'mode' internally above
         raise ValueError("Invalid mode: %s" % mode)  # pragma: no cover

--- a/pygsti/algorithms/rbfit.py
+++ b/pygsti/algorithms/rbfit.py
@@ -437,6 +437,7 @@ class FitResults(_NicelySerializable):
         bootstraps_failrate : float, optional
             The proporition of the estimates of the parameters from bootstrapped dataset failed.
         """
+        super().__init__()
         self.fittype = fittype
         self.seed = seed
         self.rtype = rtype

--- a/pygsti/baseobjs/basis.py
+++ b/pygsti/baseobjs/basis.py
@@ -276,6 +276,7 @@ class Basis(_NicelySerializable):
             raise ValueError("Can't cast %s to be a basis!" % str(type(name_or_basis_or_matrices)))
 
     def __init__(self, name, longname, real, sparse):
+        super().__init__()
         self.name = name
         self.longname = longname
         self.real = real  # whether coefficients must be real (*not* whether elements are real - they're always complex)

--- a/pygsti/baseobjs/mongoserializable.py
+++ b/pygsti/baseobjs/mongoserializable.py
@@ -9,38 +9,64 @@ Defines the MongoSerializable class
 # in compliance with the License.  You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
-from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
+import importlib as _importlib
 
 
-class MongoSerializable(_NicelySerializable):
+class MongoSerializable(object):
     """
-    An extension of NicelySerializable for that need to perform special MongoDB serialization.
+    Base class for objects that can be serialized to a MongoDB database.
 
-    An interface that allows an object to save large chunks of data using, e.g.,
-    MongoDB's GridFS system, when serializing it as a json-able object for storage
-    in a MongoDB database.
+    At the very least, saving an object to a database creates a document in the
+    collection named by the `collection_name` class variable (which can be overriden by
+    derived classes).  Additionally, saving the object may create other documents outside
+    of this collection (e.g., if the object contains MongoSerializable attributes that specify
+    their own collection name).
+
+    This interface also allows an object to save large chunks of data using, e.g.,
+    MongoDB's GridFS system, when serializing itself instead of trying to write an
+    enourmous JSON dictionary as a single document (as an object that is NicelySerializable
+    might do).
     """
+    collection_name = 'pygsti_objects'
+
     @classmethod
-    def from_mongodb_serialization(cls, state, mongodb):
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, **kwargs):
+        """ Create a new object from the already-loaded main document `doc` and by access to the database `mongodb` """
+        raise NotImplementedError("Class '%s' doesn't implement _create_obj_from_doc_and_mongodb!"
+                                  % str(doc['module'] + '.' + doc['class']))
+
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing,
+                                                **kwargs):
+        """ Add to `write_ops` and update `doc` so that all of `self`'s data is serialized """
+        raise NotImplementedError("Subclasses must implement this!")
+
+    @classmethod
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        """ Remove the records corresponding to the object with `doc_id`, minding the filter given by `recursive` """
+        mongodb[collection_name].delete_one({'_id': doc_id}, session=session)  # just delete main document
+
+    def __init__(self):
+        self._dbcoordinates = None
+        #self.tags = {}  # FUTURE feature: save and load tags automatically?
+
+    @classmethod
+    def from_mongodb(cls, mongodb, doc_id, **kwargs):
         """
-        Create and initialize an object from a "nice" serialization and a auxiliary MongoDB instance.
-
-        A "nice" serialization here means one that is compatible with common text file formats, namely
-        JSON (e.g. that dictionary keys must be strings).  This serialization should have been created
-        by a prior call to `to_mongodb_serialization` using a reference to the same MongoDB database
-        as was used to serialize the object.
-
-        The `state` argument is typically a dictionary containing 'module' and 'state' keys specifying
-        the type of object that should be created.  This type must be this class or a subclass of it.
+        Create and initialize an object from a MongoDB instance.
 
         Parameters
         ----------
-        state : object
-            An object, usually a dictionary, representing the object to de-serialize.
+        mongodb : pymongo.database.Database
+            The MongoDB instance to load from.
 
-        mongodb_database : pymongo.database.Database
-            An MongoDB instance that may optionally hold auxiliary data associated with the
-            object but too large or complex to include in the "nice" serialization itself.
+        doc_id : bson.objecctid.ObjectId or dict
+            The object ID or filter used to find a single object ID wihtin the database.  This
+            document is loaded from the collection given by the `collection_name` attribute of
+            this class.
+
+        **kwargs : dict
+            Additional keyword arguments poentially used by subclass implementations.  Any arguments
+            allowed by a subclass's `_create_obj_from_doc_and_mongodb` method is allowed here.
 
         Returns
         -------
@@ -51,53 +77,600 @@ class MongoSerializable(_NicelySerializable):
         # when once is specified in the state dictionary.  This method should thus be used when de-serializing
         # using a potential base class, i.e.  BaseClass._from_nice_serialization_base(state).
         # (This method should rarely need to be overridden in derived (sub) classes.)
-        if isinstance(state, dict) and state['module'] == cls.__module__ and state['class'] == cls.__name__:
-            # then the state is actually for this class and we should call its _from_nice_serialization method:
-            return cls._from_mongodb_serialization(state, mongodb)
-        else:
-            # otherwise, this call functions as a base class call that defers to the correct derived class
-            return MongoSerializable._from_mongodb_serialization.__func__(cls, state, mongodb)
+        doc = _find_one_doc(mongodb, cls.collection_name, doc_id)
+        if doc is None:
+            raise ValueError(f"No document found in collection '{cls.collection_name}' identified by {doc_id}")
+        return cls.from_mongodb_doc(mongodb, doc, **kwargs)
 
-    def to_mongodb_serialization(self, mongodb):
+    @classmethod
+    def from_mongodb_doc(cls, mongodb, doc, **kwargs):
         """
-        Serialize this object in a "nice" way, with the optional help of an auxiliary MongoDB instance.
-
-        "Nice" here means that the resulting serialized form is compatible with common text formats,
-        namely JSON.  Object components that are especially large or awkward can be stored
-        within the provided MongoDB database, and links/ids of the stored documents included in the
-        returned serialization.
+        Create and initialize an object from a MongoDB instance and pre-loaded primary document.
 
         Parameters
         ----------
-        mongodb_database : pymongo.database.Database
-            An auxiliary MongoDB instance to optionally place data within (see above).
+        mongodb : pymongo.database.Database
+            The MongoDB instance to load from.
+
+        doc : dict
+            The already-retrieved main document for the object being loaded.  This takes the place
+            of giving an identifier for this object.
+
+        **kwargs : dict
+            Additional keyword arguments poentially used by subclass implementations.  Any arguments
+            allowed by a subclass's `_create_obj_from_doc_and_mongodb` method is allowed here.
 
         Returns
         -------
         object
-            Usually a dictionary representing the serialized object, but may also be another native
-            Python type, e.g. a string or list.
         """
-        return self._to_mongodb_serialization(mongodb)
+        if doc['module'] == cls.__module__ and doc['class'] == cls.__name__:
+            # then the state is actually for this class and we should call its _from_nice_serialization method:
+            ret = cls._create_obj_from_doc_and_mongodb(doc, mongodb, **kwargs)
+        else:
+            c = cls._doc_class(doc)
+            if not issubclass(c, cls):
+                raise ValueError("Class '%s' is trying to load a serialized '%s' object (not a subclass)!"
+                                 % (cls.__module__ + '.' + cls.__name__, doc['module'] + '.' + doc['class']))
+            ret = c._create_obj_from_doc_and_mongodb(doc, mongodb, **kwargs)
+        ret._dbcoordinates = (cls.collection_name, doc['_id'])
+        return ret
+
+    def write_to_mongodb(self, mongodb, session=None, overwrite_existing=False, **kwargs):
+        """
+        Write this object to a MongoDB database.
+
+        The collection name used is `self.collection_name`, and the `_id` is either:
+        1) the ID used by a previous write or initial read-in, if one exists, OR
+        2) a new random `bson.objectid.ObjectId`
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to write data to.
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions among other things.
+
+        overwrite_existing : bool, optional
+            Whether existing documents should be overwritten.  The default of `False` causes
+            a ValueError to be raised if a document with the given `_id` already exists
+            and is different from what is being written.
+
+        **kwargs : dict
+            Additional keyword arguments poentially used by subclass implementations.  Any arguments
+            allowed by a subclass's `_add_auxiliary_write_ops_and_update_doc` method is allowed here.
+
+        Returns
+        -------
+        bson.objectid.ObjectId
+            The identifier (`_id` value) of the main document that was written.
+        """
+        write_ops = WriteOpsByCollection(session)
+        my_id = self.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing, **kwargs)
+        write_ops.execute(mongodb)
+        return my_id
+
+    def add_mongodb_write_ops(self, write_ops, mongodb, overwrite_existing=False, **kwargs):
+        """
+        Accumulate write and update operations for writing this object to a MongoDB database.
+
+        Similar to :method:`write_to_mongodb` but collects write operations instead of actually
+        executing any write operations on the database.  This function may be preferred to
+        :method:`write_to_mongodb` when this object is being written as a part of a larger entity
+        and executing write operations is saved until the end.
+
+        As in :method:`write_to_mongodb`, `self.collection_name` is the collection name and `_id` is either:
+        1) the ID used by a previous write or initial read-in, if one exists, OR
+        2) a new random `bson.objectid.ObjectId`
+
+        Parameters
+        ----------
+        write_ops : WriteOpsByCollection
+            An object that keeps track of `pymongo` write operations on a per-collection
+            basis.  This object accumulates write operations to be performed at some point
+            in the future.
+
+        mongodb : pymongo.database.Database
+            The MongoDB instance to write data to.
+
+        overwrite_existing : bool, optional
+            Whether existing documents should be overwritten.  The default of `False` causes
+            a ValueError to be raised if a document with the given `_id` already exists
+            and is different from what is being written.
+
+        **kwargs : dict
+            Additional keyword arguments poentially used by subclass implementations.  Any arguments
+            allowed by a subclass's `_add_auxiliary_write_ops_and_update_doc` method is allowed here.
+
+        Returns
+        -------
+        bson.objectid.ObjectId
+            The identifier (`_id` value) of the main document that was written.
+        """
+        from bson.objectid import ObjectId as _ObjectId
+        collection_name = self.collection_name if (self._dbcoordinates is None) else self._dbcoordinates[0]
+        doc_id = _ObjectId() if (self._dbcoordinates is None) else self._dbcoordinates[1]
+        doc = {'_id': doc_id,
+               'module': self.__class__.__module__,
+               'class': self.__class__.__name__,
+               'version': 0}
+        self._add_auxiliary_write_ops_and_update_doc(doc, write_ops, mongodb, collection_name,
+                                                     overwrite_existing, **kwargs)
+        write_ops.add_one_op(collection_name, {'_id': doc_id}, doc, overwrite_existing, mongodb)
+        self._dbcoordinates = (collection_name, doc_id)
+        return doc_id
+
+    def remove_me_from_mongodb(self, mongodb, session=None, recursive="default"):
+        assert self._dbcoordinates is not None, "Cannot remove object that wasn't loaded from or written to DB!"
+        collection_name, doc_id = self._dbcoordinates[0], self._dbcoordinates[1]
+        recursive = RecursiveRemovalSpecification.cast(recursive, self.__class__)
+        self._remove_from_mongodb(mongodb, collection_name, doc_id, session, recursive)
 
     @classmethod
-    def _from_mongodb_serialization(cls, state, mongodb):
-        c = cls._state_class(state)
-        if not issubclass(c, cls):
-            raise ValueError("Class '%s' is trying to load a serialized '%s' object (not a subclass)!"
-                             % (cls.__module__ + '.' + cls.__name__, state['module'] + '.' + state['class']))
-        implementing_cls = cls
-        for candidate_cls in c.__mro__:
-            if '_from_mongodb_serialization' in candidate_cls.__dict__:
-                implementing_cls = candidate_cls; break
+    def remove_from_mongodb(cls, mongodb, doc_id, collection_name=None, session=None, recursive="default"):
+        """
+        Remove the documents corresponding to an instance of this class from a MongoDB database.
 
-        if implementing_cls == cls:  # then there's no actual derived-class implementation to call!
-            raise NotImplementedError("Class '%s' doesn't implement _from_mongodb_serialization!"
-                                      % str(state['module'] + '.' + state['class']))
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to remove documents from.
+
+        doc_id : bson.objectid.ObjectId
+            The identifier of the root document stored in the database.
+
+        collection_name : str, optional
+            the MongoDB collection within `mongodb` where the main document resides.
+            If `None`, then `<this_class>.collection_name` is used (which is usually
+            what you want).
+
+        session : pymongo.client_session.ClientSession, optional
+            MongoDB session object to use when interacting with the MongoDB
+            database. This can be used to implement transactions
+            among other things.
+
+        recursive : RecursiveRemovalSpecification, optional
+            An object that filters the type of documents that are removed.
+            Used when working with inter-related experiment designs, data,
+            and results objects to only remove the types of documents you
+            know aren't being shared with other documents.
+
+        Returns
+        -------
+        None
+        """
+        if collection_name is None:
+            collection_name = cls.collection_name
+        doc = mongodb[collection_name].find_one({'_id': doc_id}, ('module', 'class'))
+        if doc is None:
+            return
+        elif doc['module'] == cls.__module__ and doc['class'] == cls.__name__:
+            recursive = RecursiveRemovalSpecification.cast(recursive, cls)
+            cls._remove_from_mongodb(mongodb, collection_name, doc_id, session, recursive)
         else:
-            return c._from_mongodb_serialization(state, mongodb)
+            c = cls._doc_class(doc)
+            recursive = RecursiveRemovalSpecification.cast(recursive, c)
+            if not issubclass(c, cls):
+                raise ValueError("Class '%s' is trying to remove a serialized '%s' object (not a subclass)!"
+                                 % (cls.__module__ + '.' + cls.__name__, doc['module'] + '.' + doc['class']))
+            c._remove_from_mongodb(mongodb, collection_name, doc_id, session, recursive)
 
-    def _to_mongodb_serialization(self, mongodb):
-        #Call base class (*not* self.to_nice_serialization) here since this
-        # should just behave like the base to_nice_serialization, putting class & module name into a state
-        return _NicelySerializable._to_nice_serialization(self)
+    @classmethod
+    def _doc_class(cls, doc, check_is_subclass=True):
+        """ Returns the class specified by the given db document"""
+        m = _importlib.import_module(doc['module'])
+        c = getattr(m, doc['class'])  # will raise AttributeError if class cannot be found
+        if check_is_subclass and not issubclass(c, cls):
+            raise ValueError("Expected a subclass or instance of '%s' but state dict has '%s'!"
+                             % (cls.__module__ + '.' + cls.__name__, doc['module'] + '.' + doc['class']))
+        return c
+
+
+class WriteOpsByCollection(dict):
+    """
+    A dictionary of `pymongo` write operations stored on a per-collection basis.
+
+    A dictionary with collection-name (string) keys and where each value is a list of
+    `pymongo.InsertOne` and `pymongo.ReplaceOne` operations to be performed on the
+    named collection at some later (unpsecified) time.
+
+    The collection names (keys) can be restricted to a predefined set if desired.
+    """
+    def __init__(self, session=None, allowed_collection_names=None):
+        self.allowed_collection_names = allowed_collection_names
+        if self.allowed_collection_names is not None:
+            super().__init__({k: [] for k in self.allowed_collection_names})
+        else:
+            super().__init__()
+        self.special_ops = []
+        self.session = session
+
+    def add_ops_by_collection(self, other_ops):
+        """
+        Merge the information from another :class:`WriteOpsByCollection` into this one.
+
+        Parameters
+        ----------
+        other_ops : WriteOpsByCollection
+            The dictionary of write operations to merge in.
+
+        Returns
+        -------
+        None
+        """
+        assert isinstance(other_ops, WriteOpsByCollection)
+        for k, v in other_ops.items():
+            if self.allowed_collection_names is None and k not in self:
+                self[k] = []
+            self[k].extend(v)
+
+    def add_one_op(self, collection_name, uid, doc, overwrite_existing, mongodb, check_local_ops=True):
+        """
+        Add a single write operation to this dictionary, if one is allowed and needed.
+
+        Adds a `pymongo.InsertOne` or `pymongo.ReplaceOne` object to `self[collection_name]` in
+        order to write a document `doc` with unique identifer `uid`.  If `overwrite_existing` is
+        `False` then an error is raised if a document with `uid` already exists -- either in the
+        database or within the list of existing write operations -- *and* the existing document
+        doesn't match the document being written (`doc`).
+
+        Parameters
+        ----------
+        collection_name : str
+            The collection name (key) to add an operation to.
+
+        uid : bson.object.ObjectId or dict
+            Unique identifier for the document to write.
+
+        doc : dict
+            The document to write.
+
+        overwrite_existing : bool, optional
+            Whether existing documents should be overwritten.  The default of `False` causes
+            a ValueError to be raised if a document with the given `uid` already exists
+            *and* is different from `doc`.
+
+        mongodb : pymongo.database.Database
+            The MongoDB instance documents will eventually be written to.  This database is
+            *not* written to, and used solely to test for existing documents so that insert
+            vs. replace operations are chosen correctly.
+
+        check_local_ops : bool, optional
+            Whether the queued-up write operations contained within this :class:`WriteOpsByCollection`
+            object are considered when testing for the existence of documents.  Leaving this set
+            to `True` is the safe option.  Set this to `False` to get a performance increase when
+            you're sure there's no possibility a document with `uid` could have been "written" to
+            this `WriteOpsByCollection` since its initialization.
+
+        Returns
+        -------
+        bson.objectid.ObjectId
+            The identifier (`_id` value) of the document to be written or that already exists
+            and matches the one being written.
+        """
+        from pymongo import InsertOne, ReplaceOne
+        from bson.objectid import ObjectId as _ObjectId
+        assert self.allowed_collection_names is None or collection_name in self.allowed_collection_names
+        if self.allowed_collection_names is None and collection_name not in self:
+            self[collection_name] = []
+
+        #Get or create an id for the document to be inserted or replaced (or left as is)
+        if isinstance(uid, dict):
+            if '_id' in uid:
+                doc_id = uid['_id']
+            else:
+                existing_doc = _find_one_doc(mongodb, collection_name, uid, ('_id',))
+                if existing_doc is None and check_local_ops:
+                    existing_doc = self._find_one_local_doc(collection_name, uid)
+                doc_id = _ObjectId() if (existing_doc is None) else existing_doc['_id']
+        else:
+            assert isinstance(uid, _ObjectId)
+            doc_id = uid
+
+        assert ('_id' not in doc) or (doc['_id'] == doc_id)
+        doc['_id'] = doc_id
+
+        if overwrite_existing is True:
+            self[collection_name].append(ReplaceOne(doc_id, doc, upsert=True))
+            #mongodb[collection_name].replace_one(doc_id, doc, upsert=True)  # alt line for DEBUG
+        else:
+            existing_doc = mongodb[collection_name].find_one(doc_id)
+            if existing_doc is None and check_local_ops:
+                existing_doc = self._find_one_local_doc(collection_name, doc_id)
+                if existing_doc is not None:
+                    existing_doc = prepare_doc_for_existing_doc_check(existing_doc, existing_doc)  # eg can have tuples
+
+            if existing_doc is None:  # then insert the document as given
+                self[collection_name].append(InsertOne(doc))
+                #mongodb[collection_name].insert_one(doc)  # alt line for DEBUG
+            else:
+                #print("Found existing doc: ", doc.get('module','?'), doc.get('class','?'), doc.get('circuit_str','?'))
+                info_to_check = prepare_doc_for_existing_doc_check(doc, existing_doc)
+                if existing_doc != info_to_check:
+                    # overwrite_existing=False and a doc already exists AND docs are *different* => error
+                    diff_lines = recursive_compare_str(existing_doc, info_to_check, 'existing doc', 'doc to insert')
+                    raise ValueError("*Different* document with %s exists and `overwrite_existing=False`:\n%s"
+                                     % (str(uid), '\n'.join(diff_lines)))
+                # else do nothing, since doc exists and matches what we want to write => no error
+        return doc_id
+
+    def add_gridfs_put_op(self, collection_name, doc_id, binary_data, overwrite_existing, mongodb):
+        """
+        Add a GridFS put operation to this dictionary of write operations.
+
+        This is a special type of operation for placing large chunks of binary data into a MongoDB.
+        Arguments are similar to :method:`add_one_op`.
+        """
+        import gridfs as _gridfs
+        fs = _gridfs.GridFS(mongodb, collection=collection_name)
+        if fs.exists(doc_id) and not overwrite_existing:
+            pass  # don't check for equality here -- too slow since this is large data; just don't overwrite
+        else:  # either the file doesn't exist or overwrite_existing=True, so write it!
+            self.special_ops.append({'type': 'GridFS_put',
+                                     'collection_name': collection_name,
+                                     'data': binary_data,
+                                     'id': doc_id})
+        return doc_id
+
+    def execute(self, mongodb):
+        """
+        Execute all of the "queued" operations within this dictionary on a MongoDB instance.
+
+        Note that `mongodb` should be the same as the `mongodb` given to any :method:`add_one_op` and
+        :method:`add_gridfs_put_op` method calls.  The session given at the initialization of
+        this object is used for these write operations.  On exit, this dictionary is empty, indicating
+        there are no more queued operations.
+
+        Parameters
+        ----------
+        mongodb : pymongo.database.Database
+            The MongoDB instance to execute write operations on.
+
+        Returns
+        -------
+        None
+        """
+        for op_info in self.special_ops:
+            if op_info['type'] == 'GridFS_put':
+                import gridfs as _gridfs
+                fs = _gridfs.GridFS(mongodb, collection=op_info['collection_name'])
+                file_id = fs.put(op_info['data'], _id=op_info['id'])
+                assert file_id == op_info['id']
+            else:
+                raise ValueError("Invalid special op:" + str(op_info))
+
+        for collection_name, ops in self.items():
+            if len(ops) > 0:  # bulk_write fails if ops is an empty list
+                mongodb[collection_name].bulk_write(ops, session=self.session)
+        self.clear()
+        self.special_ops = []
+
+    def _find_one_local_doc(self, collection_name, uid):
+        if not isinstance(uid, dict): uid = {'_id': uid}
+        for op in self.get(collection_name, []):
+            doc = op._doc  # Warning: using *private* attribute of InsertOne & ReplaceOne objects
+            for key, val in uid.items():
+                if (key not in doc) or doc[key] != val:
+                    break  # doc does not match uid
+            else:  # doc *does* match uid
+                return doc
+        return None
+
+
+def prepare_doc_for_existing_doc_check(doc, existing_doc, set_id=True, convert_tuples_to_lists=True):
+    """
+    Prepares a to-be inserted document for comparison with an existing document.
+
+    Optionally (see parameters):
+    1) sets _id of `doc` to that of `existing_doc`.  This is useful in cases where the _id
+       field is redundant with other uniquely identifying fields in the document, and so inserted
+       documents don't need to match this field.
+    2) converts all of `doc`'s tuples to lists, as the existing_doc is typically read from a MongoDB
+       which only stores lists and doesn't distinguish between lists and tuples.
+
+    Parameters
+    ----------
+    doc : dict
+        the document to prepare
+
+    existing_doc : dict
+        the existing document
+
+    set_id : bool, optional
+        when `True`, add an `'_id'` field to `doc` matching `existing_doc` when one
+        is not already present.
+
+    convert_tuples_to_lists : bool, optional
+        when `True` convert all of the tuples within `doc` to lists.
+
+    Returns
+    -------
+    dict
+        the prepared document.
+    """
+    def tup_to_list(obj):
+        if isinstance(obj, (tuple, list)):
+            return [tup_to_list(v) for v in obj]
+        elif isinstance(obj, dict):
+            return {k: tup_to_list(v) for k, v in obj.items()}
+        else:
+            return obj
+
+    doc = doc.copy()
+    if '_id' not in doc:  # Allow doc to lack an _id field and still be considered same as existing_doc
+        doc['_id'] = existing_doc['_id']
+    return tup_to_list(doc)
+
+
+def recursive_compare_str(a, b, a_name='first obj', b_name='second obj', prefix="", diff_accum=None):
+    """
+    Compares two objects and generates a list of strings describing how they differ.
+
+    Recursively traverses dictionaries, tuples, and lists.
+
+    Parameters
+    ----------
+    a, b : object
+        The objects to compare
+
+    a_name, b_name : str, optional
+        Names for the `a` and `b` objects for referencing them in the output strings.
+
+    prefix : str, optional
+        An optional prefix to the descriptions in the returned strings.
+
+    diff_accum : list, optional
+        An existing list that is accumulating difference-descriptions.
+        `None` means start a new list.
+
+    Returns
+    -------
+    list
+        A list of strings, each describing a difference between the objects.
+    """
+    typ = type(a)
+    if diff_accum is None:
+        diff_accum = []
+
+    if typ != type(b):
+        diff_accum.append(prefix + f": are different types ({typ} vs {type(b)})")
+
+    if isinstance(a, dict):
+        a_keys = set(a.keys())
+        b_keys = set(b.keys())
+        for k in a_keys.intersection(b_keys):
+            recursive_compare_str(a[k], b[k], a_name, b_name, f"{prefix}.{k}", diff_accum)
+        for k in (b_keys - a_keys):  # keys missing from a
+            diff_accum.append(f"{prefix}.{k}: missing from {a_name}")
+        for k in (a_keys - b_keys):  # keys missing from b
+            diff_accum.append(f"{prefix}.{k}: missing from {b_name}")
+    elif isinstance(a, (list, tuple)):
+        if len(a) != len(b):
+            diff_accum.append(f"{prefix}: have different lengths ({len(a)} vs {len(b)})")
+        else:
+            for i, (va, vb) in enumerate(zip(a, b)):
+                recursive_compare_str(va, vb, a_name, b_name, f"{prefix}[{i}]", diff_accum)
+    else:
+        if a != b:
+            diff_accum.append(f"{prefix}: {a} != {b}")
+    return diff_accum
+
+
+def _find_one_doc(db, collection_name, doc_id, projection=None, error_if_no_doc=False):
+    if doc_id is not None and not isinstance(doc_id, dict):
+        doc_id = {'_id': doc_id}
+    docs = db[collection_name].find(doc_id, projection)  # works if doc_id is a dict or an ObjectId
+    single_doc = None
+    for doc in docs:  # weird having a loop here, but needed b/c cursor.count method deprecated
+        if single_doc is not None:
+            raise ValueError((f"Multiple records where identified by the given `doc_id` ({doc_id})."
+                              " `doc_id` must specify exactly one record."))
+        single_doc = doc
+
+    if single_doc is None and error_if_no_doc:
+        raise ValueError(f"Could not find document specified by {doc_id}!")
+    return single_doc
+
+
+class RecursiveRemovalSpecification(object):
+    """
+    Specifies which types of objects to remove when performing a recursive removal of MongoDB documents.
+
+    Parameters
+    ----------
+    edesigns : bool, optional
+        Whether experiment designs are allowed to be removed.
+
+    data : bool, optional
+        Whether protocol data objects are allowed to be removed.
+
+    results : bool, optional
+        Whether result objects and directories are allowed to be removed.
+
+    circuits : bool, optional
+        Whether circuit objects stored in common collections (e.g. `"pygsti_circuits"`) are allowed to be removed.
+
+    protocols : bool, optional
+        Whether protocol objects are allowed to be removed.
+
+    children : bool, optional
+        Whether child objects of :class:`TreeNode` objects are allowed to be removed.
+    """
+
+    @classmethod
+    def cast(cls, obj, root_cls_being_deleted=None):
+        """
+        Create a :class:`RecursiveRemovalSpecification` object from another object.
+
+        If `obj` is already a :class:`RecursiveRemovalSpecification` object then it is
+        just returned directly.  Otherwise, `obj` can be a string, boolean value, or `None`:
+
+        - False, None, or `"none"`: no objects are removed recursively (the safe option)
+        - True or `"all"`: all recursive removal operation are permitted (the un-safe option)
+        - `"default"`: only recursive removal of the type being removed is allowed.  For example,
+                       when removing a `ProtocolData` object, it and any child `ProtocolData` objects
+                       are removed but experiment designs are not, nor are (potentially shared) circuits.
+        - `"upstream"`: recursive removal of the type being removed and "upstream" types is allowed.  "Upstream"
+                        refers to items closer to the front of the list: experiment designs, data objects, result
+                        objects. For example, when removing a `ProtocolData` object, it and any child `ProtocolData`
+                        objects, along with their experiment designs are removed, but circuit objects are not.
+        - `"all_but_circuits"`: everything but circuit objects are allowed to be removed.  Circuit objects are
+                                treated specially because they are very likely to be re-used (shared).
+
+        Parameters
+        ----------
+        obj : object
+            The object to convert.  See description above.
+
+        root_cls_being_deleted : class, optional
+            The Python class of the main object being deleted.  This additional information is needed
+            when (and only when) `obj == "default"`.
+
+        Returns
+        -------
+        RecursiveRemovalSpecification
+        """
+        from pygsti.protocols import ExperimentDesign as _ExperimentDesign, ProtocolData as _ProtocolData
+        from pygsti.protocols import ProtocolResults as _ProtocolResults, ProtocolResultsDir as _ProtocolResultsDir
+        if isinstance(obj, RecursiveRemovalSpecification):
+            return obj
+        elif obj is False or obj is None or obj == "none":
+            return cls()  # defaults are all to *not* remove objects
+        elif obj is True or obj == "all":
+            return cls(True, True, True, True, True, True)
+        elif obj == "default":
+            if root_cls_being_deleted is None:
+                raise ValueError("Must supply `root_cls_being_deleted` when using 'default' recursive removal spec!")
+            if issubclass(root_cls_being_deleted, _ExperimentDesign):
+                return cls(edesigns=True, children=True)
+            elif issubclass(root_cls_being_deleted, _ProtocolData):
+                return cls(data=True, children=True)
+            elif issubclass(root_cls_being_deleted, (_ProtocolResults, _ProtocolResultsDir)):
+                return cls(results=True, children=True)
+            else:
+                return cls()
+        elif obj == "default+":
+            if root_cls_being_deleted is None:
+                raise ValueError("Must supply `root_cls_being_deleted` when using 'default' recursive removal spec!")
+            if issubclass(root_cls_being_deleted, _ExperimentDesign):
+                return cls(edesigns=True, children=True)
+            elif issubclass(root_cls_being_deleted, _ProtocolData):
+                return cls(data=True, edesigns=True, children=True)
+            elif issubclass(root_cls_being_deleted, (_ProtocolResults, _ProtocolResultsDir)):
+                return cls(results=True, data=True, edesigns=True, protocols=True, children=True)
+            else:
+                return cls()
+        elif obj == "all_but_circuits":
+            return cls(edesigns=True, data=True, results=True, circuits=False, protocols=True, children=True)
+        else:
+            raise ValueError("Could not cast %s to a RecursiveRemovalSpecification!" % str(obj))
+
+    def __init__(self, edesigns=False, data=False, results=False, circuits=False, protocols=False, children=False):
+        self.edesigns = edesigns
+        self.data = data
+        self.results = results
+        self.circuits = circuits
+        self.protocols = protocols
+        self.children = children

--- a/pygsti/baseobjs/mongoserializable.py
+++ b/pygsti/baseobjs/mongoserializable.py
@@ -561,14 +561,11 @@ def recursive_compare_str(a, b, a_name='first obj', b_name='second obj', prefix=
 def _find_one_doc(db, collection_name, doc_id, projection=None, error_if_no_doc=False):
     if doc_id is not None and not isinstance(doc_id, dict):
         doc_id = {'_id': doc_id}
-    docs = db[collection_name].find(doc_id, projection)  # works if doc_id is a dict or an ObjectId
-    single_doc = None
-    for doc in docs:  # weird having a loop here, but needed b/c cursor.count method deprecated
-        if single_doc is not None:
+    if '_id' not in doc_id:  # otherwise can bypass since if _id is specified a doc must be unique
+        if db[collection_name].count_documents(doc_id, limit=2) > 1:
             raise ValueError((f"Multiple records where identified by the given `doc_id` ({doc_id})."
                               " `doc_id` must specify exactly one record."))
-        single_doc = doc
-
+    single_doc = db[collection_name].find_one(doc_id, projection)
     if single_doc is None and error_if_no_doc:
         raise ValueError(f"Could not find document specified by {doc_id}!")
     return single_doc

--- a/pygsti/baseobjs/mongoserializable.py
+++ b/pygsti/baseobjs/mongoserializable.py
@@ -373,7 +373,7 @@ class WriteOpsByCollection(dict):
         doc['_id'] = doc_id
 
         if overwrite_existing is True:
-            self[collection_name].append(ReplaceOne(doc_id, doc, upsert=True))
+            self[collection_name].append(ReplaceOne({'_id': doc_id}, doc, upsert=True))
             #mongodb[collection_name].replace_one(doc_id, doc, upsert=True)  # alt line for DEBUG
         else:
             existing_doc = mongodb[collection_name].find_one(doc_id)

--- a/pygsti/baseobjs/nicelyserializable.py
+++ b/pygsti/baseobjs/nicelyserializable.py
@@ -15,9 +15,10 @@ import pathlib as _pathlib
 import json as _json
 import numpy as _np
 import scipy.sparse as _sps
+from pygsti.baseobjs.mongoserializable import MongoSerializable
 
 
-class NicelySerializable(object):
+class NicelySerializable(MongoSerializable):
     """
     The base class for all "nicely serializable" objects in pyGSTi.
 
@@ -344,3 +345,11 @@ class NicelySerializable(object):
             return complex(val)
         else:
             return val
+
+    @classmethod
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb):
+        #Ignore mongodb, just init from doc:
+        return cls.from_nice_serialization(doc)
+
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing):
+        doc.update(self.to_nice_serialization())

--- a/pygsti/baseobjs/qubitgraph.py
+++ b/pygsti/baseobjs/qubitgraph.py
@@ -183,6 +183,7 @@ class QubitGraph(_NicelySerializable):
             `initial_edges`, and this argument is required whenever such
             indices are used.
         """
+        super().__init__()
         self.nqubits = len(qubit_labels)
         self.directed = directed
 

--- a/pygsti/baseobjs/statespace.py
+++ b/pygsti/baseobjs/statespace.py
@@ -49,6 +49,9 @@ class StateSpace(_NicelySerializable):
             return QubitSpace(obj)
         return ExplicitStateSpace(obj)
 
+    def __init__(self):
+        super().__init__()
+
     @property
     def udim(self):
         """
@@ -579,6 +582,7 @@ class QuditSpace(StateSpace):
     """
 
     def __init__(self, nqudits_or_labels, udim_or_udims):
+        super().__init__()
         if isinstance(nqudits_or_labels, int):
             self.qudit_labels = tuple(range(nqudits_or_labels))
         else:
@@ -990,6 +994,7 @@ class ExplicitStateSpace(StateSpace):
         #Step1: convert label_list (and dims, if given) to a list of
         # elements describing each "tensor product block" - each of
         # which is a tuple of string labels.
+        super().__init__()
 
         def is_label(x):
             """ Return whether x is a valid space-label """

--- a/pygsti/baseobjs/unitarygatefunction.py
+++ b/pygsti/baseobjs/unitarygatefunction.py
@@ -36,3 +36,6 @@ class UnitaryGateFunction(_NicelySerializable):
         ret = cls()  # assumes no __init__ args
         ret.shape = tuple(state['shape'])
         return ret
+
+    def __init__(self):
+        super().__init__()

--- a/pygsti/circuits/circuitlist.py
+++ b/pygsti/circuits/circuitlist.py
@@ -87,6 +87,7 @@ class CircuitList(_NicelySerializable):
         name : str, optional
             An optional name for this list, used for status messages.
         """
+        super().__init__()
         self._circuits = tuple(map(_Circuit.cast, circuits))  # *static* container - can't add/append
         self.op_label_aliases = op_label_aliases
         self.circuit_rules = circuit_rules

--- a/pygsti/circuits/circuitstructure.py
+++ b/pygsti/circuits/circuitstructure.py
@@ -53,6 +53,7 @@ class CircuitPlaquette(_NicelySerializable):
         """
         Create a new CircuitPlaquette.
         """
+        super().__init__()
         self.elements = _collections.OrderedDict(elements)
         self.circuit_rules = circuit_rules
         self.op_label_aliases = op_label_aliases

--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -24,6 +24,7 @@ import numpy as _np
 
 from pygsti.circuits import circuit as _cir
 from pygsti.baseobjs import outcomelabeldict as _ld, _compatibility as _compat
+from pygsti.baseobjs.mongoserializable import MongoSerializable as _MongoSerializable
 from pygsti.tools import NamedDict as _NamedDict
 from pygsti.tools import listtools as _lt
 from pygsti.tools.legacytools import deprecate as _deprecated_fn
@@ -821,7 +822,7 @@ def _round_int_repcnt(nreps):
         return int(round(nreps))
 
 
-class DataSet(object):
+class DataSet(_MongoSerializable):
     """
     An association between Circuits and outcome counts, serving as the input data for many QCVV protocols.
 
@@ -909,6 +910,7 @@ class DataSet(object):
         Keys should be the circuits in this DataSet and value should
         be Python dictionaries.
     """
+    collection_name = "pygsti_datasets"
 
     def __init__(self, oli_data=None, time_data=None, rep_data=None,
                  circuits=None, circuit_indices=None,
@@ -992,6 +994,8 @@ class DataSet(object):
         DataSet
            a new data set object.
         """
+        super().__init__()
+
         # uuid for efficient hashing (set when done adding data or loading from file)
         self.uuid = None
 
@@ -3134,3 +3138,107 @@ class DataSet(object):
 
         df = cdict.to_dataframe()
         return _process_dataframe(df, pivot_valuename, pivot_value, drop_columns)
+
+    @classmethod
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, collision_action="aggregate",
+                                         record_zero_counts=False, with_times="auto",
+                                         circuit_parse_cache=None, verbosity=1):
+        from pymongo import ASCENDING, DESCENDING
+        from pygsti.io import stdinput as _stdinput
+        datarow_collection_name = doc['datarow_collection_name']
+        outcomeLabels = doc['outcomes']
+
+        dataset = DataSet(outcome_labels=outcomeLabels, collision_action=collision_action,
+                          comment=doc['comment'])
+        parser = _stdinput.StdInputParser()
+
+        datarow_collection = mongodb[datarow_collection_name]
+        for i, datarow_doc in enumerate(datarow_collection.find({'parent': doc['_id']}).sort('index', ASCENDING)):
+            if i != datarow_doc['index']:
+                _warnings.warn("Data set's row data is incomplete! There seem to be missing rows.")
+
+            circuit = parser.parse_circuit(datarow_doc['circuit'], lookup={},  # allow a lookup to be passed?
+                                           create_subcircuits=not _cir.Circuit.default_expand_subcircuits)
+
+            oliArray = _np.array(datarow_doc['outcome_indices'], dataset.oliType)
+            countArray = _np.array(datarow_doc['repetitions'], dataset.repType)
+            if 'times' not in datarow_doc:  # with_times can be False or 'auto'
+                if with_times is True:
+                    raise ValueError("Circuit %d does not contain time information and 'with_times=True'" % i)
+                timeArray = _np.zeros(countArray.shape[0], dataset.timeType)
+            else:
+                if with_times is False:
+                    raise ValueError("Circuit %d contains time information and 'with_times=False'" % i)
+                timeArray = _np.array(datarow_doc['time'], dataset.timeType)
+
+            dataset._add_raw_arrays(circuit, oliArray, timeArray, countArray,
+                                    overwrite_existing=True,
+                                    record_zero_counts=record_zero_counts,
+                                    aux=datarow_doc.get('aux', {}))
+
+        dataset.done_adding_data()
+        return dataset
+
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing,
+                                                circuits=None, outcome_label_order=None, with_times="auto",
+                                                datarow_collection_name='pygsti_datarows'):
+        if circuits is not None:
+            if len(circuits) > 0 and not isinstance(circuits[0], _cir.Circuit):
+                raise ValueError("Argument circuits must be a list of Circuit objects!")
+        else:
+            circuits = list(self.keys())
+
+        if outcome_label_order is not None:  # convert to tuples if needed
+            outcome_label_order = [(ol,) if isinstance(ol, str) else ol
+                                   for ol in outcome_label_order]
+
+        outcomeLabels = self.outcome_labels
+        if outcome_label_order is not None:
+            assert(len(outcome_label_order) == len(outcomeLabels))
+            assert(all([ol in outcomeLabels for ol in outcome_label_order]))
+            assert(all([ol in outcome_label_order for ol in outcomeLabels]))
+            outcomeLabels = outcome_label_order
+            oli_map_data = {self.olIndex[ol]: i for i, ol in enumerate(outcomeLabels)}  # dataset -> stored indices
+
+            def oli_map(outcome_label_indices):
+                return [oli_map_data[i] for i in outcome_label_indices]
+        else:
+            def oli_map(outcome_label_indices):
+                return [i.item() for i in outcome_label_indices]  # converts numpy types -> native python types
+
+        doc['outcomes'] = outcomeLabels
+        doc['comment'] = self.comment if hasattr(self, 'comment') else None
+        doc['datarow_collection_name'] = datarow_collection_name
+
+        if with_times == "auto":
+            trivial_times = self.has_trivial_timedependence
+        else:
+            trivial_times = not with_times
+
+        dataset_id = doc['_id']
+
+        for i, circuit in enumerate(circuits):  # circuit should be a Circuit object here
+            dataRow = self[circuit]
+            datarow_doc = {'index': i,
+                           'circuit': circuit.str,
+                           'parent': dataset_id,
+                           'outcome_indices': oli_map(dataRow.oli),
+                           'repetitions': [r.item() for r in dataRow.reps]  # converts numpy -> Python native types
+                           }
+
+            if trivial_times:  # ensure that "repetitions" are just "counts" in trivial-time case
+                assert(len(dataRow.oli) == len(set(dataRow.oli))), "Duplicate value in trivial-time data set row!"
+            else:
+                datarow_doc['times'] = list(dataRow.time)
+
+            if dataRow.aux:
+                datarow_doc['aux'] = dataRow.aux  # needs to be JSON-able!
+
+            write_ops.add_one_op(datarow_collection_name, {'circuit': circuit.str, 'parent': dataset_id},
+                                 datarow_doc, overwrite_existing, mongodb)
+
+    @classmethod
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        dataset_doc = mongodb[collection_name].find_one_and_delete({'_id': doc_id}, session=session)
+        datarow_collection_name = dataset_doc['datarow_collection_name']
+        mongodb[datarow_collection_name].delete_many({'parent': dataset_doc['_id']}, session=session)

--- a/pygsti/forwardsims/forwardsim.py
+++ b/pygsti/forwardsims/forwardsim.py
@@ -80,6 +80,7 @@ class ForwardSimulator(_NicelySerializable):
         return ()
 
     def __init__(self, model=None):
+        super().__init__()
         #self.dim = model.dim
         self.model = model
 

--- a/pygsti/io/mongodb.py
+++ b/pygsti/io/mongodb.py
@@ -24,29 +24,69 @@ from pygsti.io import readers as _load
 from pygsti.io.metadir import _check_jsonable, _full_class_name, _to_jsonable, _from_jsonable, _class_for_name
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
 from pygsti.baseobjs.mongoserializable import MongoSerializable as _MongoSerializable
+from pygsti.baseobjs.mongoserializable import RecursiveRemovalSpecification as _RecursiveRemovalSpecification
+from pygsti.baseobjs.mongoserializable import WriteOpsByCollection as _WriteOpsByCollection
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
 
 
-#Names used for subcollections
-subcollection_names = {
-    'circuits': 'circuits',
-    'objects': 'objects',
-    'arrays': 'numpy_arrays',
-    'datarows': 'datarows',
-}
-
-#Top-level collection name for storing stand-alone objects
-# (those with their own write_to_mongodb methods that but are *not* treenodes, e.g., Estimates)
-STANDALONE_COLLECTION_NAME = 'pygsti_standalone_objects'
-
-
-def cnm(subcollection_key):
-    return subcollection_names[subcollection_key]
-
-
-def read_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_member='auxfile_types',
+def read_auxtree_from_mongodb(mongodb, collection_name, doc_id, auxfile_types_member='auxfile_types',
                               ignore_meta=('_id', 'type',), separate_auxfiletypes=False,
                               quick_load=False):
+    """
+    Read a document containing links to auxiliary documents from a MongoDB database.
+
+    Parameters
+    ----------
+    mongodb : pymongo.database.Database
+        The MongoDB instance to load data from.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` to read from.
+
+    doc_id : bson.objectid.ObjectId
+        The identifier, of the root document to load from the database.
+
+    auxfile_types_member : str
+        the name of the attribute within the document that holds the dictionary
+        mapping of attributes to auxiliary-file (document) types.  Usually this is
+        `"auxfile_types"`.
+
+    ignore_meta : tuple, optional
+        Keys within the root document that should be ignored, i.e. not loaded into
+        elements of the returned dict.  By default, `"_id"` and `"type"` are in this
+        category because they give the database id and a class name to be built,
+        respectively, and are not needed in the constructed dictionary.  Unless
+        you know what you're doing, leave this as the default.
+
+    separate_auxfiletypes : bool, optional
+        If True, then return the `auxfile_types_member` element (a dict
+        describing how quantities that aren't in the main document have been
+        serialized) as a separate return value, instead of placing it
+        within the returned dict.
+
+    quick_load : bool, optional
+        Setting this to True skips the loading of members that may take
+        a long time to load, namely those in separate documents that are
+        large.  When the loading of an attribute is skipped, it is set to `None`.
+
+    Returns
+    -------
+    loaded_qtys : dict
+        A dictionary of the quantities in the main document plus any loaded
+        from the auxiliary documents.
+    auxfile_types : dict
+        Only returned as a separate value when `separate_auxfiletypes=True`.
+        A dict describing how members of `loaded_qtys` that weren't loaded
+        directly from the main document were serialized.
+    """
+    doc = mongodb[collection_name].find_one({'_id': doc_id})
+    return read_auxtree_from_mongodb_doc(mongodb, collection_name, doc, auxfile_types_member,
+                                         ignore_meta, separate_auxfiletypes, quick_load)
+
+
+def read_auxtree_from_mongodb_doc(mongodb, doc, auxfile_types_member='auxfile_types',
+                                  ignore_meta=('_id', 'type',), separate_auxfiletypes=False,
+                                  quick_load=False):
     """
     Load the contents of a MongoDB document into a dict.
 
@@ -55,13 +95,11 @@ def read_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_membe
 
     Parameters
     ----------
-    root_mongo_collection : pymongo.collection.Collection
-        The root MongoDB collection to load data from.  (Sub-collections are read
-        from as needed.)
+    mongodb : pymongo.database.Database
+        The MongoDB instance to load data from.
 
-    doc_id : object
-        The identifier, usually a `bson.objectid.ObjectId` or string, of the
-        root document to load from the database.
+    doc : dict
+        The already-retrieved main document being read in.
 
     auxfile_types_member : str, optional
         The key within the root document that is used to describe how other
@@ -96,7 +134,6 @@ def read_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_membe
         A dict describing how members of `loaded_qtys` that weren't loaded
         directly from the root document were serialized.
     """
-    doc = root_mongo_collection.find_one({'_id': doc_id})
     ret = {}
 
     for key, val in doc.items():
@@ -106,8 +143,8 @@ def read_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_membe
     for key, typ in doc[auxfile_types_member].items():
         if key in ignore_meta: continue  # don't load -> members items in ignore_meta
 
-        bLoaded, val = _load_subcollection_member(root_mongo_collection, doc_id, key, typ,
-                                                  doc.get(key, None), quick_load)
+        bLoaded, val = _load_auxdoc_member(mongodb, key, typ,
+                                           doc.get(key, None), quick_load)
         if bLoaded:
             ret[key] = val
         elif val is True:  # val is value of whether to set value to None
@@ -120,7 +157,7 @@ def read_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_membe
         return ret
 
 
-def _load_subcollection_member(root_mongo_collection, parent_id, member_name, typ, metadata, quick_load):
+def _load_auxdoc_member(mongodb, member_name, typ, metadata, quick_load):
     from pymongo import ASCENDING, DESCENDING
     subtypes = typ.split(':')
     cur_typ = subtypes[0]
@@ -138,8 +175,8 @@ def _load_subcollection_member(root_mongo_collection, parent_id, member_name, ty
             val = []
             for i, meta in enumerate(metadata):
                 membernm_so_far = member_name + str(i)
-                bLoaded, el = _load_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                         next_typ, meta, quick_load)
+                bLoaded, el = _load_auxdoc_member(mongodb, membernm_so_far,
+                                                  next_typ, meta, quick_load)
                 if bLoaded:
                     val.append(el)
                 else:
@@ -154,8 +191,8 @@ def _load_subcollection_member(root_mongo_collection, parent_id, member_name, ty
             for k in keys:
                 membernm_so_far = member_name + "_" + k
                 meta = metadata.get(k, None)
-                bLoaded, v = _load_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                        next_typ, meta, quick_load)
+                bLoaded, v = _load_auxdoc_member(mongodb, membernm_so_far,
+                                                 next_typ, meta, quick_load)
                 if bLoaded:
                     val[k] = v
                 else:
@@ -169,8 +206,8 @@ def _load_subcollection_member(root_mongo_collection, parent_id, member_name, ty
             val = {}
             for i, (k, meta) in enumerate(keymeta_pairs):
                 membernm_so_far = member_name + "_kvpair" + str(i)
-                bLoaded, el = _load_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                         next_typ, meta, quick_load)
+                bLoaded, el = _load_auxdoc_member(mongodb, membernm_so_far,
+                                                  next_typ, meta, quick_load)
                 if bLoaded:
                     if isinstance(k, list): k = tuple(k)  # convert list-type keys -> tuples
                     val[k] = el
@@ -191,80 +228,58 @@ def _load_subcollection_member(root_mongo_collection, parent_id, member_name, ty
 
         if cur_typ == 'reset':  # 'reset' doesn't write and loads in as None
             val = None  # no file exists for this member
+        elif metadata is None:
+            # value was None and we do nothing here
+            val = None
         elif cur_typ == 'text-circuit-list':
-            coll = root_mongo_collection[cnm('circuits')]
+            coll = mongodb[metadata['collection_name']]
+            circuit_doc_ids = metadata['ids']
+
             circuit_strs = []
-            for i, cdoc in enumerate(coll.find({'parent': parent_id,
-                                                'member_name': member_name}).sort('index', ASCENDING)):
-                assert(cdoc['auxfile_type'] == cur_typ)
-                assert(cdoc['index'] == i)
+            for circuit_doc_id in circuit_doc_ids:
+                cdoc = coll.find_one(circuit_doc_id)
                 circuit_strs.append(cdoc['circuit_str'])
             val = _load.convert_strings_to_circuits(circuit_strs)
 
         elif cur_typ == 'dir-serialized-object':
-            coll = root_mongo_collection[cnm('objects')]
-            link_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
-            if link_doc is not None:
-                assert(link_doc['auxfile_type'] == cur_typ)
-                standalone_id = link_doc['standalone_object_id']
-    
-                coll = root_mongo_collection.database[STANDALONE_COLLECTION_NAME]
-                obj_doc = coll.find_one({'_id': standalone_id}, ['type'])
-                val = _class_for_name(obj_doc['type']).from_mongodb(coll, standalone_id, quick_load=quick_load)
+            obj_doc = mongodb[metadata['collection_name']].find_one(metadata['id'])
+            val = _MongoSerializable.from_mongodb_doc(mongodb, obj_doc, quick_load=quick_load)
 
         elif cur_typ == 'partialdir-serialized-object':
-            coll = root_mongo_collection[cnm('objects')]
-            link_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
-
-            if link_doc is not None:
-                assert(link_doc['auxfile_type'] == cur_typ)
-                standalone_id = link_doc['standalone_object_id']
-
-                coll = root_mongo_collection.database[STANDALONE_COLLECTION_NAME]
-                obj_doc = coll.find_one({'_id': standalone_id}, ['type'])
-                val = _class_for_name(obj_doc['type'])._from_mongodb_partial(coll, standalone_id, quick_load=quick_load)
+            obj_doc = mongodb[metadata['collection_name']].find_one(metadata['id'])
+            val = _MongoSerializable.from_mongodb_doc(mongodb, obj_doc, quick_load=quick_load, load_data=False)
 
         elif cur_typ == 'serialized-object':
-            coll = root_mongo_collection[cnm('objects')]
-            obj_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
-            if obj_doc is not None:
-                assert(obj_doc['auxfile_type'] == cur_typ)
-                if obj_doc['serialization_type'] == 'mongodb':
-                    val = _MongoSerializable.from_mongodb_serialization(obj_doc['object'],
-                                                                        root_mongo_collection.database)
-                else:
-                    val = _NicelySerializable.from_nice_serialization(obj_doc['object'])
+            obj_doc = mongodb[metadata['collection_name']].find_one(metadata['id'])
+            val = _MongoSerializable.from_mongodb_doc(mongodb, obj_doc)  #, quick_load=quick_load)
 
-        elif cur_typ == 'circuit-str-json':
-            coll = root_mongo_collection[cnm('circuits')]
+        elif cur_typ == 'circuit-str-json':  # same as text above
+            coll = mongodb[metadata['collection_name']]
+            circuit_doc_ids = metadata['ids']
+
             circuit_strs = []
-            for i, cdoc in enumerate(coll.find({'parent': parent_id,
-                                                'member_name': member_name}).sort('index', ASCENDING)):
-                assert(cdoc['auxfile_type'] == cur_typ)
-                assert(cdoc['index'] == i)
+            for circuit_doc_id in circuit_doc_ids:
+                cdoc = coll.find_one(circuit_doc_id)
                 circuit_strs.append(cdoc['circuit_str'])
             val = _load.convert_strings_to_circuits(circuit_strs)
 
         elif typ == 'numpy-array':
-            coll = root_mongo_collection[cnm('arrays')]
-            array_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
+            array_doc = mongodb[metadata['collection_name']].find_one(metadata['id'])
             if array_doc is not None:
-                assert(array_doc['auxfile_type'] == cur_typ)
-                val = _pickle.loads(array_doc['numpy_array'])
+                assert(array_doc['auxdoc_type'] == cur_typ)
+                val = _pickle.loads(array_doc['numpy_array_data'])
 
         elif typ == 'json':
-            coll = root_mongo_collection[cnm('objects')]
-            obj_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
-            if obj_doc is not None:
-                assert(obj_doc['auxfile_type'] == typ)
-                val = obj_doc['object']
+            json_doc = mongodb[metadata['collection_name']].find_one(metadata['id'])
+            if json_doc is not None:
+                assert(json_doc['auxdoc_type'] == cur_typ)
+                val = json_doc['json_data']
 
         elif typ == 'pickle':
-            coll = root_mongo_collection[cnm('objects')]
-            obj_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
-            if obj_doc is not None:
-                assert(obj_doc['auxfile_type'] == typ)
-                val = _pickle.loads(obj_doc['object'])
+            pkl_doc = mongodb[metadata['collection_name']].find_one(metadata['id'])
+            if pkl_doc is not None:
+                assert(pkl_doc['auxdoc_type'] == cur_typ)
+                val = _pickle.loads(pkl_doc['pickle_data'])
 
         else:
             raise ValueError("Invalid aux-file type: %s" % typ)
@@ -272,48 +287,155 @@ def _load_subcollection_member(root_mongo_collection, parent_id, member_name, ty
     return True, val  # loading successful - 2nd element is value loaded
 
 
-class WriteOpsBySubcollection(dict):
-    def __init__(self, allowed_subcollection_names=None):
-        if allowed_subcollection_names is not None:
-            self.allowed_subcollection_names = allowed_subcollection_names
-        else:
-            self.allowed_subcollection_names = (cnm('circuits'), cnm('objects'), cnm('arrays'))
-
-        # separate "special" list for stand-alone object (i.e. objects
-        #  with a .write_to_mongo method) writes 'pygsti_standalone_objects'
-        self.standalone_writes = []
-
-        super().__init__({k: [] for k in self.allowed_subcollection_names})
-
-    def add_ops_by_subcollection(self, other_ops):
-        assert(isinstance(other_ops, WriteOpsBySubcollection))
-        for k, v in other_ops.items():
-            self[k].extend(v)
-        self.standalone_writes.extend(other_ops.standalone_writes)
-
-    def add_one_op(self, subcollection_name, full_id, rest_of_info, overwrite_existing, root_mongo_collection):
-        from pymongo import InsertOne, ReplaceOne
-        assert(subcollection_name in self.allowed_subcollection_names)
-        info = full_id.copy()
-        info.update(rest_of_info)
-        if overwrite_existing is True:
-            self[subcollection_name].append(ReplaceOne(full_id, info, upsert=True))
-        else:
-            existing_doc = root_mongo_collection[subcollection_name].find_one(full_id)
-            if existing_doc is None:  # then insert the document as given
-                self[subcollection_name].append(InsertOne(info))
-            else:
-                info_to_check = prepare_doc_for_existing_doc_check(info, existing_doc)
-                if existing_doc != info_to_check:
-                    # overwrite_existing=False and a doc already exists AND docs are *different* => error
-                    diff_lines = recursive_compare_str(existing_doc, info_to_check, 'existing doc', 'doc to insert')
-                    raise ValueError("*Different* document with %s exists and `overwrite_existing=False`:\n%s"
-                                     % (str(full_id), '\n'.join(diff_lines)))
-                # else do nothing, since doc exists and matches what we want to write => no error
-
-
-def write_obj_to_mongodb_auxtree(obj, root_mongo_collection, doc_id, auxfile_types_member, omit_attributes=(),
+def write_obj_to_mongodb_auxtree(obj, mongodb, collection_name, doc_id, auxfile_types_member, omit_attributes=(),
                                  include_attributes=None, additional_meta=None, session=None, overwrite_existing=False):
+    """
+    Write the attributes of an object to a MongoDB database, potentially as multiple documents.
+
+    Parameters
+    ----------
+    obj : object
+        The object that is to be written.
+
+    mongodb : pymongo.database.Database
+        The MongoDB instance to write data to.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` to write to.
+
+    doc_id : bson.objectid.ObjectId
+        The identifier, of the root document to store in the database.
+        If `None` a new id will be created.
+
+    auxfile_types_member : str, optional
+        The attribute of `obj` that is used to describe how other
+        members should be serialized into separate "auxiliary" documents.
+        Unless you know what you're doing, leave this as the default.
+
+    omit_attributes : list or tuple
+        List of (string-valued) names of attributes to omit when serializing
+        this object.  Usually you should just leave this empty.
+
+    include_attributes : list or tuple or None
+        A list of (string-valued) names of attributs to specifically include
+        when serializing this object.  If `None`, then *all* attributes are
+        included except those specifically omitted via `omit_attributes`.
+        If `include_attributes` is not `None` then `omit_attributes` is
+        ignored.
+
+    additional_meta : dict, optional
+        A dictionary of additional meta-data to be included in the main document
+        (but that isn't an attribute of `obj`).
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    overwrite_existing : bool, optional
+        Whether existing documents should be overwritten.  The default of `False` causes
+        a ValueError to be raised if a document with the given `doc_id` already exists.
+        Setting this to `True` mimics the behaviour of a typical filesystem, where writing
+        to a path can be done regardless of whether it already exists.
+
+    Returns
+    -------
+    bson.objectid.ObjectId
+        The identifer of the root document that was written.
+    """
+    from bson.objectid import ObjectId
+
+    if doc_id is None:
+        doc_id = ObjectId()
+    to_insert = {'_id': doc_id}
+    write_ops = _WriteOpsByCollection(session)
+    add_obj_auxtree_write_ops_and_update_doc(obj, to_insert, write_ops, mongodb, collection_name,
+                                             auxfile_types_member, omit_attributes,
+                                             include_attributes, additional_meta, overwrite_existing)
+    write_ops.add_one_op(collection_name, {'_id': doc_id}, to_insert, overwrite_existing, mongodb)  # add main doc
+
+    try:
+        write_ops.execute(mongodb)
+    except Exception as e:
+        if session is None:
+            #Unless this may be a transaction, Try to undo any DB writes we can by deleting the document
+            # we just failed to write
+            try:
+                remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session)
+            except:
+                pass  # ok if this fails
+        raise e
+
+    return doc_id
+
+
+def add_obj_auxtree_write_ops_and_update_doc(obj, doc, write_ops, mongodb, collection_name,
+                                             auxfile_types_member, omit_attributes=(),
+                                             include_attributes=None, additional_meta=None, overwrite_existing=False):
+    """
+    Similar to `write_obj_to_mongodb_auxtree`, but just collect write operations and update a main-doc dictionary.
+
+    This function effectively performs all the heavy-lifting to write an object to
+    a MongoDB database without actually executing any write operations.  Instead, a
+    dictionary representing the main document (which we typically assume will be written
+    later) is updated and additional write operations (for auxiliary documents) are added
+    to a :class:`WriteOpsByCollection` object.  This function is intended for use within
+    a :class:`MongoSerializable`-derived object's `_add_auxiliary_write_ops_and_update_doc`
+    method.
+
+    Parameters
+    ----------
+    obj : object
+        The object that is to be written.
+
+    doc : dict
+        The root-document data, which is updated as needed and is expected to
+        be initialized at least with an `_id` key-value pair.
+
+    write_ops : WriteOpsByCollection
+        An object that keeps track of `pymongo` write operations on a per-collection
+        basis.  This object accumulates write operations to be performed at some point
+        in the future.
+
+    mongodb : pymongo.database.Database
+        The MongoDB instance that is planned to be written to.  Used to test for existing
+        records and *not* to write to, as writing is assumed to be done later, potentially as
+        a bulk write operaiton.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` that is planned to write to.
+
+    auxfile_types_member : str, optional
+        The attribute of `obj` that is used to describe how other
+        members should be serialized into separate "auxiliary" documents.
+        Unless you know what you're doing, leave this as the default.
+
+    omit_attributes : list or tuple
+        List of (string-valued) names of attributes to omit when serializing
+        this object.  Usually you should just leave this empty.
+
+    include_attributes : list or tuple or None
+        A list of (string-valued) names of attributs to specifically include
+        when serializing this object.  If `None`, then *all* attributes are
+        included except those specifically omitted via `omit_attributes`.
+        If `include_attributes` is not `None` then `omit_attributes` is
+        ignored.
+
+    additional_meta : dict, optional
+        A dictionary of additional meta-data to be included in the main document
+        (but that isn't an attribute of `obj`).
+
+    overwrite_existing : bool, optional
+        Whether existing documents should be overwritten.  The default of `False` causes
+        a ValueError to be raised if a document with the given `doc_id` already exists.
+        Setting this to `True` mimics the behaviour of a typical filesystem, where writing
+        to a path can be done regardless of whether it already exists.
+
+    Returns
+    -------
+    bson.objectid.ObjectId
+        The identifer of the root document that was written.
+    """
     # Note: include_attributes = None means include everything not omitted
     # Note2: include_attributes takes precedence over omit_attributes
     meta = {'type': _full_class_name(obj)}
@@ -339,11 +461,11 @@ def write_obj_to_mongodb_auxtree(obj, root_mongo_collection, doc_id, auxfile_typ
         vals = obj.__dict__
         auxtypes = obj.__dict__[auxfile_types_member] if (auxfile_types_member is not None) else {}
 
-    return write_auxtree_to_mongodb(root_mongo_collection, doc_id, vals, auxtypes, init_meta=meta,
-                                    session=session, overwrite_existing=overwrite_existing)
+    return add_auxtree_write_ops_and_update_doc(doc, write_ops, mongodb, collection_name, vals,
+                                                auxtypes, init_meta=meta, overwrite_existing=overwrite_existing)
 
 
-def write_auxtree_to_mongodb(root_mongo_collection, doc_id, valuedict, auxfile_types=None, init_meta=None,
+def write_auxtree_to_mongodb(mongodb, collection_name, doc_id, valuedict, auxfile_types=None, init_meta=None,
                              session=None, overwrite_existing=False):
     """
     Write a dictionary of quantities to a MongoDB database, potentially as multiple documents.
@@ -356,14 +478,15 @@ def write_auxtree_to_mongodb(root_mongo_collection, doc_id, valuedict, auxfile_t
 
     Parameters
     ----------
-    root_mongo_collection : pymongo.collection.Collection
-        The root MongoDB collection to write data to.  Sub-collections are created
-        and written to as needed.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to write data to.
 
-    doc_id : object
-        The identifier, usually a `bson.objectid.ObjectId` or string, of the
-        root document to store in the database.  If `None` a new id will be
-        created.
+    collection_name : str
+        the MongoDB collection within `mongodb` to write to.
+
+    doc_id : bson.objectid.ObjectId
+        The identifier, of the root document to store in the database.
+        If `None` a new id will be created.
 
     valuedict : dict
         The dictionary of values to serialize to disk.
@@ -395,21 +518,103 @@ def write_auxtree_to_mongodb(root_mongo_collection, doc_id, valuedict, auxfile_t
 
     Returns
     -------
-    None
+    bson.objectid.ObjectId
+        The identifer of the root document that was written.
     """
     from bson.objectid import ObjectId
+
+    if doc_id is None:
+        doc_id = ObjectId()
+    to_insert = {'_id': doc_id}
+    write_ops = _WriteOpsByCollection(session)
+    add_auxtree_write_ops_and_update_doc(to_insert, write_ops, mongodb, collection_name, valuedict,
+                                         auxfile_types, init_meta, overwrite_existing)
+    write_ops.add_one_op(collection_name, {'_id': doc_id}, to_insert, overwrite_existing, mongodb)  # add main doc
+
+    try:
+        write_ops.execute(mongodb)
+    except Exception as e:
+        if session is None:
+            #Unless this may be a transaction, Try to undo any DB writes we can by deleting the document
+            # we just failed to write
+            try:
+                remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                            recursive='none')  # just be safe and not delete anything we need
+            except:
+                pass  # ok if this fails
+        raise e
+
+    return doc_id
+
+
+def add_auxtree_write_ops_and_update_doc(doc, write_ops, mongodb, collection_name, valuedict,
+                                         auxfile_types=None, init_meta=None, overwrite_existing=False):
+    """
+    Similar to `write_auxtree_to_mongodb`, but just collect write operations and update a main-doc dictionary.
+
+    This function effectively performs all the heavy-lifting to write a dictionary to
+    multiple documents within a MongoDB database without actually executing any write
+    operations.  Instead, a dictionary representing the main document (which we typically
+    assume will be written  later) is updated and additional write operations (for auxiliary
+    documents) are added to a :class:`WriteOpsByCollection` object.  This function is intended
+    for use within a :class:`MongoSerializable`-derived object's `_add_auxiliary_write_ops_and_update_doc`
+    method.
+
+    Parameters
+    ----------
+    doc : dict
+        The root-document data, which is updated as needed and is expected to
+        be initialized at least with an `_id` key-value pair.
+
+    write_ops : WriteOpsByCollection
+        An object that keeps track of `pymongo` write operations on a per-collection
+        basis.  This object accumulates write operations to be performed at some point
+        in the future.
+
+    mongodb : pymongo.database.Database
+        The MongoDB instance that is planned to be written to.  Used to test for existing
+        records and *not* to write to, as writing is assumed to be done later, potentially as
+        a bulk write operaiton.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` that is planned to write to.
+
+    valuedict : dict
+        The dictionary of values to serialize to disk.
+
+    auxfile_types : dict, optional
+        A dictionary whose keys are a subset of the keys of `valuedict`,
+        and whose values are known "aux-file" types.  `auxfile_types[key]`
+        says that `valuedict[key]` should be serialized into a separate
+        document with the given format rather than be included directly in
+        the root document.  If None, this dictionary is assumed to be
+        `valuedict['auxfile_types']`.
+
+    init_meta : dict, optional
+        A dictionary of "initial" meta-data to be included in the root document
+        (but that isn't in `valuedict`).  For example, the class name of an
+        object is often stored as in the "type" field of meta.json when the_model
+        objects .__dict__ is used as `valuedict`.
+
+    overwrite_existing : bool, optional
+        Whether existing documents should be overwritten.  The default of `False` causes
+        a ValueError to be raised if a document with the given `doc_id` already exists.
+        Setting this to `True` mimics the behaviour of a typical filesystem, where writing
+        to a path can be done regardless of whether it already exists.
+
+    Returns
+    -------
+    bson.objectid.ObjectId
+        The identifer of the root document that was written.
+    """
     from pymongo import InsertOne, ReplaceOne
     to_insert = {}
 
     if auxfile_types is None:  # Note: this case may never be used
         auxfile_types = valuedict['auxfile_types']
 
-    if doc_id is None:
-        doc_id = ObjectId()  # Note: may run into trouble if _id must be str
-
     if init_meta: to_insert.update(init_meta)
     to_insert['auxfile_types'] = auxfile_types
-    to_insert['_id'] = doc_id
 
     #Initial check -- REMOVED because it's ok to "overwrite" the *same* data with overwrite_existing=False
     #if not overwrite_existing and root_mongo_collection.count_documents({'_id': doc_id}, session=session) > 0:
@@ -420,76 +625,39 @@ def write_auxtree_to_mongodb(root_mongo_collection, doc_id, valuedict, auxfile_t
         if isinstance(val, _VerbosityPrinter): val = val.verbosity  # HACK!!
         to_insert[key] = val
 
-    write_ops = WriteOpsBySubcollection()
     for auxnm, typ in auxfile_types.items():
+        if typ in ('none', 'reset'):  # HACK needed?
+            continue
         val = valuedict[auxnm]
 
         try:
-            auxmeta, ops = _write_subcollection_member(root_mongo_collection, doc_id, auxnm, typ, val,
-                                                       session, overwrite_existing)
+            auxmeta = _write_auxdoc_member(mongodb, write_ops, collection_name, doc['_id'], auxnm,
+                                           typ, val, overwrite_existing)
         except Exception as e:
             raise ValueError("FAILED to prepare to write aux doc member %s w/format %s (see direct cause above)"
                              % (auxnm, typ)) from e
 
-        write_ops.add_ops_by_subcollection(ops)
         if auxmeta is not None:
             to_insert[auxnm] = auxmeta  # metadata about auxiliary document(s) for this aux name
 
-    try:
-        for standalone_id, obj, bPartial in write_ops.standalone_writes:
-            if not bPartial:
-                obj.write_to_mongodb(root_mongo_collection.database[STANDALONE_COLLECTION_NAME], standalone_id,
-                                     session=session, overwrite_existing=overwrite_existing)
-            else:
-                obj._write_partial_to_mongodb(root_mongo_collection.database[STANDALONE_COLLECTION_NAME], standalone_id,
-                                              session=session, overwrite_existing=overwrite_existing)
-
-        for subcollection_name, ops in write_ops.items():
-            if len(ops) > 0:  # bulk_write fails if ops is an empty list
-                root_mongo_collection[subcollection_name].bulk_write(ops, session=session)
-
-        if overwrite_existing:
-            root_mongo_collection.replace_one({'_id': doc_id}, to_insert, upsert=True, session=session)
-        else:
-            existing_doc = root_mongo_collection.find_one({'_id': doc_id})
-            if existing_doc is None:  # then insert the document as given
-                root_mongo_collection.insert_one(to_insert, session=session)
-            else:
-                to_check = prepare_doc_for_existing_doc_check(to_insert, existing_doc)
-                if existing_doc != to_check:
-                    diff_lines = recursive_compare_str(existing_doc, to_check, 'existing doc', 'doc to insert')
-                    raise ValueError("*Different* document with _id=%s exists and `overwrite_existing=False`:\n%s"
-                                     % (str(doc_id), '\n'.join(diff_lines)))
-                # else do nothing, since doc exists and matches what we want to write => no error
-
-    except Exception as e:
-        if session is None:
-            #Unless this may be a transaction, Try to undo any DB writes we can by deleting the document
-            # we just failed to write
-            try:
-                remove_auxtree_from_mongodb(root_mongo_collection, doc_id, 'auxfile_types', session)
-            except:
-                pass  # ok if this fails
-        raise e
+    doc.update(to_insert)
 
 
-def _write_subcollection_member(root_mongo_collection, parent_id, member_name, typ, val,
-                                session=None, overwrite_existing=False):
+def _write_auxdoc_member(mongodb, write_ops, parent_collection_name, parent_id, member_name, typ, val,
+                         overwrite_existing=False):
     from bson.binary import Binary as _Binary
     from bson.objectid import ObjectId
     subtypes = typ.split(':')
     cur_typ = subtypes[0]
     next_typ = ':'.join(subtypes[1:])
 
-    write_ops = WriteOpsBySubcollection()
     if cur_typ == 'list':
         if val is not None:
             metadata = []
             for i, el in enumerate(val):
                 membernm_so_far = member_name + str(i)
-                meta, ops = _write_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                        next_typ, el, session, overwrite_existing)
-                write_ops.add_ops_by_subcollection(ops)
+                meta = _write_auxdoc_member(mongodb, write_ops, parent_collection_name, parent_id, membernm_so_far,
+                                            next_typ, el, overwrite_existing)
                 metadata.append(meta)
         else:
             metadata = None
@@ -499,9 +667,8 @@ def _write_subcollection_member(root_mongo_collection, parent_id, member_name, t
             metadata = {}
             for k, v in val.items():
                 membernm_so_far = member_name + "_" + k
-                meta, ops = _write_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                        next_typ, v, session, overwrite_existing)
-                write_ops.add_ops_by_subcollection(ops)
+                meta = _write_auxdoc_member(mongodb, write_ops, parent_collection_name, parent_id, membernm_so_far,
+                                            next_typ, v, overwrite_existing)
                 metadata[k] = meta
         else:
             metadata = None
@@ -511,9 +678,8 @@ def _write_subcollection_member(root_mongo_collection, parent_id, member_name, t
             metadata = []
             for i, (k, v) in enumerate(val.items()):
                 membernm_so_far = member_name + "_kvpair" + str(i)
-                meta, ops = _write_subcollection_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                        next_typ, v, session, overwrite_existing)
-                write_ops.add_ops_by_subcollection(ops)
+                meta = _write_auxdoc_member(mongodb, write_ops, parent_collection_name, parent_id, membernm_so_far,
+                                            next_typ, v, overwrite_existing)
                 metadata.append((k, meta))
         else:
             metadata = None
@@ -521,7 +687,6 @@ def _write_subcollection_member(root_mongo_collection, parent_id, member_name, t
     else:
         #Simple types that just write the given file
         metadata = None
-        member_id = {'parent': parent_id, 'member_name': member_name}
 
         if val is None:   # None values don't get written
             pass
@@ -529,94 +694,101 @@ def _write_subcollection_member(root_mongo_collection, parent_id, member_name, t
             pass
 
         elif cur_typ == 'text-circuit-list':
+            circuit_doc_ids = []
             for i, circuit in enumerate(val):
-                write_ops.add_one_op(cnm('circuits'), member_id,
-                                     {'auxfile_type': cur_typ, 'index': i, 'circuit_str': circuit.str},
-                                     overwrite_existing, root_mongo_collection)
+                circuit_doc_ids.append(
+                    write_ops.add_one_op('pygsti_circuits', {'circuit_str': circuit.str},
+                                         {'circuit_str': circuit.str},  # add more circuit info in future?
+                                         overwrite_existing, mongodb, check_local_ops=True))
+            metadata = {'collection_name': 'pygsti_circuits', 'ids': circuit_doc_ids}
 
         elif cur_typ == 'dir-serialized-object':
-            existing_link_doc = root_mongo_collection[cnm('objects')].find_one(member_id)
-            standalone_id = ObjectId() if (existing_link_doc is None) else existing_link_doc['standalone_object_id']
-            write_ops.standalone_writes.append((standalone_id, val, False))  # list of (id, object_to_write, bPartial)
-            write_ops.add_one_op(cnm('objects'), member_id,
-                                 {'auxfile_type': cur_typ, 'standalone_object_id': standalone_id},
-                                 overwrite_existing, root_mongo_collection)
+            val_id = val.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing)
+            metadata = {'collection_name': val.collection_name, 'id': val_id}
 
         elif cur_typ == 'partialdir-serialized-object':
-            existing_link_doc = root_mongo_collection[cnm('objects')].find_one(member_id)
-            standalone_id = ObjectId() if (existing_link_doc is None) else existing_link_doc['standalone_object_id']
-            write_ops.standalone_writes.append((standalone_id, val, True))  # list of (id, object_to_write, bPartial)
-            write_ops.add_one_op(cnm('objects'), member_id,
-                                 {'auxfile_type': cur_typ, 'standalone_object_id': standalone_id},
-                                 overwrite_existing, root_mongo_collection)
+            val_id = val.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing,
+                                               already_written_data_id="N/A partial")
+            metadata = {'collection_name': val.collection_name, 'id': val_id}
 
         elif cur_typ == 'serialized-object':
-            assert(isinstance(val, _NicelySerializable)), \
-                "Non-nicely-serializable '%s' object given for a 'serialized-object' auxfile type!" % (str(type(val)))
-            if isinstance(val, _MongoSerializable):
-                jsonable = val.to_mongodb_serialization(root_mongo_collection.database)
-                sertype = "mongodb"
-            else:
-                jsonable = val.to_nice_serialization()
-                sertype = "nice"
-            write_ops.add_one_op(cnm('objects'), member_id, {'auxfile_type': cur_typ, 'object': jsonable,
-                                                             'serialization_type': sertype},
-                                 overwrite_existing, root_mongo_collection)
+            assert(isinstance(val, _MongoSerializable)), \
+                "Non-mongo-serializable '%s' object given for a 'serialized-object' auxfile type!" % (str(type(val)))
+            val_id = val.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing)
+            metadata = {'collection_name': val.collection_name, 'id': val_id}
 
         elif cur_typ == 'circuit-str-json':
+            circuit_doc_ids = []
             for i, circuit in enumerate(val):
-                write_ops.add_one_op(cnm('circuits'), member_id,
-                                     {'auxfile_type': cur_typ, 'index': i, 'circuit_str': circuit.str},
-                                     overwrite_existing, root_mongo_collection)
+                circuit_doc_ids.append(
+                    write_ops.add_one_op('pygsti_circuits', {'circuit_str': circuit.str},
+                                         {'circuit_str': circuit.str},  # add more circuit info in future?
+                                         overwrite_existing, mongodb, check_local_ops=True))
+            metadata = {'collection_name': 'pygsti_circuits', 'ids': circuit_doc_ids}
 
         elif cur_typ == 'numpy-array':
-            write_ops.add_one_op(cnm('arrays'), member_id,
-                                 {'auxfile_type': cur_typ,
-                                  'numpy_array': _Binary(_pickle.dumps(val, protocol=2), subtype=128)},
-                                 overwrite_existing, root_mongo_collection)
+            member_id = {'parent_collection': parent_collection_name, 'parent': parent_id, 'member_name': member_name}
+            val_doc = member_id.copy()
+            val_doc.update({'auxdoc_type': cur_typ,
+                            'numpy_array_data': _Binary(_pickle.dumps(val, protocol=2), subtype=128)})
+            val_id = write_ops.add_one_op('pygsti_arrays', member_id, val_doc, overwrite_existing, mongodb)
+            metadata = {'collection_name': 'pygsti_arrays', 'id': val_id}
 
         elif typ == 'json':
             _check_jsonable(val)
-            write_ops.add_one_op(cnm('objects'), member_id,
-                                 {'auxfile_type': cur_typ, 'object': val},
-                                 overwrite_existing, root_mongo_collection)
+            member_id = {'parent_collection': parent_collection_name, 'parent': parent_id, 'member_name': member_name}
+            val_doc = member_id.copy()
+            val_doc.update({'auxdoc_type': cur_typ,
+                            'json_data': _Binary(_pickle.dumps(val, protocol=2), subtype=128)})
+            val_id = write_ops.add_one_op('pygsti_json_data', member_id, val_doc, overwrite_existing, mongodb)
+            metadata = {'collection_name': 'pygsti_json_data', 'id': val_id}
 
         elif typ == 'pickle':
-            write_ops.add_one_op(cnm('objects'), member_id,
-                                 {'auxfile_type': cur_typ,
-                                  'object': _Binary(_pickle.dumps(val, protocol=2), subtype=128)},
-                                 overwrite_existing, root_mongo_collection)
-
+            member_id = {'parent_collection': parent_collection_name, 'parent': parent_id, 'member_name': member_name}
+            val_doc = member_id.copy()
+            val_doc.update({'auxdoc_type': cur_typ,
+                            'pickle_data': _Binary(_pickle.dumps(val, protocol=2), subtype=128)})
+            val_id = write_ops.add_one_op('pygsti_pickle_data', member_id, val_doc, overwrite_existing, mongodb)
+            metadata = {'collection_name': 'pygsti_pickle_data', 'id': val_id}
         else:
             raise ValueError("Invalid aux-file type: %s" % typ)
 
-    return metadata, write_ops
+    return metadata
 
 
-def remove_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_member='auxfile_types', session=None):
+def remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, auxfile_types_member='auxfile_types', session=None,
+                                recursive=None):
     """
-    Remove a stored dictionary from a MongoDB database.
+    Remove some or all of the MongoDB documents written by `write_auxtree_to_mongodb`
 
-    Removes the root document and any auxiliary documents.
+    Removes a root document and possibly auxiliary documents.
 
     Parameters
     ----------
-    root_mongo_collection : pymongo.collection.Collection
-        The MongoDB collection of the root document to remove.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to remove documents from.
 
-    doc_id : object
-        The identifier, usually a `bson.objectid.ObjectId` or string, of the
-        root document.
+    collection_name : str
+        the MongoDB collection within `mongodb` to remove document from.
+
+    doc_id : bson.objectid.ObjectId
+        The identifier of the root document stored in the database.
 
     auxfile_types_member : str, optional
-        The key within the root document that is used to describe how other
-        members have been serialized into documents.  Unless you know what you're
-        doing, leave this as the default.
+        The key of the stored document used to describe how other
+        members are serialized into separate "auxiliary" documents.
+        Unless you know what you're doing, leave this as the default.
 
     session : pymongo.client_session.ClientSession, optional
         MongoDB session object to use when interacting with the MongoDB
         database. This can be used to implement transactions
         among other things.
+
+    recursive : RecursiveRemovalSpecification, optional
+        An object that filters the type of documents that are removed.
+        Used when working with inter-related experiment designs, data,
+        and results objects to only remove the types of documents you
+        know aren't being shared with other documents.
 
     Returns
     -------
@@ -624,74 +796,69 @@ def remove_auxtree_from_mongodb(root_mongo_collection, doc_id, auxfile_types_mem
         The result of deleting (or attempting to delete) the root record
     """
     #Note: grab entire document here since we may need values of some members to deleting linked records
-    doc = root_mongo_collection.find_one({'_id': doc_id}, session=session)  # [auxfile_types_member]
+    doc = mongodb[collection_name].find_one({'_id': doc_id}, session=session)  # [auxfile_types_member]
+    recursive = _RecursiveRemovalSpecification.cast(recursive)
     if doc is None:
         return
 
-    #Remove any auxfile members that could have linked standalone records that we can't just clear in bulk
-    all_standalone_ids = []
     for key, typ in doc[auxfile_types_member].items():
-        if 'dir-serialized-object' in typ:  # allow for "partialdir" and for, e.g., "dict:dir-serialized-object"
-            all_standalone_ids.extend(_get_standalone_ids_of_member(root_mongo_collection, doc_id, key, typ,
-                                                                    doc.get(key, None)))
+        _remove_auxdoc_member(mongodb, key, typ, doc.get(key, None), session, recursive)
 
-    #Remove standalone ids
-    coll = root_mongo_collection.database[STANDALONE_COLLECTION_NAME]
-    for standalone_id in all_standalone_ids:
-        obj_doc = coll.find_one({'_id': standalone_id}, ['type'])
-        _class_for_name(obj_doc['type']).remove_from_mongodb(coll, standalone_id, session=session)
-
-    # Begin removing DB documents here -- before this point we're just figuring out what to remove
-
-    #Remove other auxfile documents and the original
-    for aux_subcollection_name in (cnm('objects'), cnm('circuits'), cnm('arrays')):
-        root_mongo_collection[aux_subcollection_name].delete_many({'parent': doc_id}, session=session)
-
-    return root_mongo_collection.delete_one({'_id': doc_id}, session=session)  # returns deleted count (0 or 1)
+    return mongodb[collection_name].delete_one({'_id': doc_id}, session=session)  # returns deleted count (0 or 1)
 
 
-def _get_standalone_ids_of_member(root_mongo_collection, parent_id, member_name, typ, val):
+def _remove_auxdoc_member(mongodb, member_name, typ, metadata, session, recursive):
+    from pymongo import ASCENDING, DESCENDING
     subtypes = typ.split(':')
     cur_typ = subtypes[0]
     next_typ = ':'.join(subtypes[1:])
 
-    standalone_ids = []
     if cur_typ == 'list':
-        if val is not None:
-            for i, el in enumerate(val):
+        if metadata is not None:  # otherwise signals that value is None, and no auxdoc to remove
+            for i, meta in enumerate(metadata):
                 membernm_so_far = member_name + str(i)
-                ids = _get_standalone_ids_of_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                    next_typ, el)
-                standalone_ids.extend(ids)
+                _remove_auxdoc_member(mongodb, membernm_so_far, next_typ, meta, session, recursive)
 
     elif cur_typ == 'dict':
-        if val is not None:
-            for k, v in val.items():
+        if metadata is not None:  # otherwise signals that value is None, and no auxdoc to remove
+            keys = list(metadata.keys())  # sort?
+            for k in keys:
                 membernm_so_far = member_name + "_" + k
-                ids = _get_standalone_ids_of_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                    next_typ, v)
-                standalone_ids.extend(ids)
+                meta = metadata.get(k, None)
+                _remove_auxdoc_member(mongodb, membernm_so_far,
+                                      next_typ, meta, session, recursive)
 
     elif cur_typ == 'fancykeydict':
-        if val is not None:
-            for i, (k, v) in enumerate(val.items()):
+        if metadata is not None:  # otherwise signals that value is None, and no auxdoc to remove
+            keymeta_pairs = list(metadata)  # should be a list of (key, metadata_for_value) pairs
+            for i, (k, meta) in enumerate(keymeta_pairs):
                 membernm_so_far = member_name + "_kvpair" + str(i)
-                ids = _get_standalone_ids_of_member(root_mongo_collection, parent_id, membernm_so_far,
-                                                    next_typ, v)
-                standalone_ids.extend(ids)
+                _remove_auxdoc_member(mongodb, membernm_so_far,
+                                      next_typ, meta, session, recursive)
+
     else:
-        if typ == 'dir-serialized-object' or typ == 'partialdir-serialized-object':
-            coll = root_mongo_collection[cnm('objects')]
-            link_doc = coll.find_one({'parent': parent_id, 'member_name': member_name})
-            if link_doc is not None:
-                assert(link_doc['auxfile_type'] == typ)
-                standalone_id = link_doc['standalone_object_id']
-                standalone_ids.append(standalone_id)
+        if cur_typ in ('none', 'reset'):  # no auxdoc exists for this member
+            return  # done here
+        elif metadata is None:
+            return  # value was None and so no auxdoc was created -- nothing to remove
+        elif cur_typ in ('text-circuit-list', 'circuit-str-json'):
+            if recursive.circuits:
+                coll = mongodb[metadata['collection_name']]
+                circuit_doc_ids = metadata['ids']
+                for circuit_doc_id in circuit_doc_ids:
+                    coll.delete_one({'_id': circuit_doc_id}, session=session)  # returns deleted count (0 or 1)
+        elif cur_typ in ('dir-serialized-object', 'partialdir-serialized-object', 'serialized-object'):
+            _MongoSerializable.remove_from_mongodb(mongodb, metadata['id'], metadata['collection_name'],
+                                                   session, recursive=recursive)
+        elif typ in ('numpy-array', 'json', 'pickle'):
+            mongodb[metadata['collection_name']].delete_one({'_id': metadata['id']}, session=session)
+        else:
+            raise ValueError("Invalid aux-file type: %s" % typ)
 
-    return standalone_ids
+    return
 
 
-def read_dict_from_mongodb(mongodb_collection, identifying_metadata):
+def read_dict_from_mongodb(mongodb, collection_name, identifying_metadata):
     """
     Read a dictionary serialized via :function:`write_dict_to_mongodb` into a dictionary.
 
@@ -700,8 +867,11 @@ def read_dict_from_mongodb(mongodb_collection, identifying_metadata):
 
     Parameters
     ----------
-    mongodb_collection : pymongo.collection.Collection
-        the MongoDB collection to read from.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to read data from.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` to read from.
 
     identifying_metadata : dict
         JSON-able metadata that identifies the dictionary being
@@ -714,13 +884,13 @@ def read_dict_from_mongodb(mongodb_collection, identifying_metadata):
     from bson.binary import Binary as _Binary
 
     ret = {}
-    for doc in mongodb_collection.find(identifying_metadata):
+    for doc in mongodb[collection_name].find(identifying_metadata):
         ret[doc['key']] = _pickle.loads(doc['value']) if isinstance(doc['value'], _Binary) \
             else _from_jsonable(doc['value'])
     return ret
 
 
-def write_dict_to_mongodb(d, mongodb_collection, identifying_metadata, session=None):
+def write_dict_to_mongodb(d, mongodb, collection_name, identifying_metadata, overwrite_existing=False, session=None):
     """
     Write each element of `d` as a separate document in a MongoDB collection
 
@@ -738,18 +908,65 @@ def write_dict_to_mongodb(d, mongodb_collection, identifying_metadata, session=N
     d : dict
         the dictionary of elements to serialize.
 
-    mongodb_collection : pymongo.collection.Collection
-        the MongoDB collection to write to.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to write data to.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` to write to.
 
     identifying_metadata : dict
         JSON-able metadata that identifies the dictionary being
         serialized.  This metadata should be saved for later retrieving
         the elements of `d` from `mongodb_collection`.
 
+    overwrite_existing : bool, optional
+        Whether existing documents should be overwritten.  The default of `False` causes
+        a ValueError to be raised if a document with the given `doc_id` already exists.
+
     session : pymongo.client_session.ClientSession, optional
         MongoDB session object to use when interacting with the MongoDB
         database. This can be used to implement transactions
         among other things.
+
+    Returns
+    -------
+    None
+    """
+    write_ops = _WriteOpsByCollection(session)
+    add_dict_to_mongodb_write_ops(d, write_ops, mongodb, collection_name, identifying_metadata, overwrite_existing)
+    write_ops.execute(mongodb)
+
+
+def add_dict_to_mongodb_write_ops(d, write_ops, mongodb, collection_name, identifying_metadata, overwrite_existing):
+    """
+    Similar to `write_dict_to_mongodb`, but just collect write operations and update a main-doc dictionary.
+
+    Parameters
+    ----------
+    d : dict
+        the dictionary of elements to serialize.
+
+    write_ops : WriteOpsByCollection
+        An object that keeps track of `pymongo` write operations on a per-collection
+        basis.  This object accumulates write operations to be performed at some point
+        in the future.
+
+    mongodb : pymongo.database.Database
+        The MongoDB instance that is planned to be written to.  Used to test for existing
+        records and *not* to write to, as writing is assumed to be done later, potentially as
+        a bulk write operaiton.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` that is planned to write to.
+
+    identifying_metadata : dict
+        JSON-able metadata that identifies the dictionary being
+        serialized.  This metadata should be saved for later retrieving
+        the elements of `d` from `mongodb_collection`.
+
+    overwrite_existing : bool, optional
+        Whether existing documents should be overwritten.  The default of `False` causes
+        a ValueError to be raised if a document with the given `doc_id` already exists.
 
     Returns
     -------
@@ -769,17 +986,20 @@ def write_dict_to_mongodb(d, mongodb_collection, identifying_metadata, session=N
             val_to_insert = _Binary(_pickle.dumps(val, protocol=2), subtype=128)
 
         to_insert['value'] = val_to_insert
-        mongodb_collection.replace_one(full_id, to_insert, upsert=True, session=session)
+        write_ops.add_one_op(collection_name, full_id, to_insert, overwrite_existing, mongodb)
 
 
-def remove_dict_from_mongodb(mongodb_collection, identifying_metadata, session=None):
+def remove_dict_from_mongodb(mongodb, collection_name, identifying_metadata, session=None):
     """
     Remove elements of (separate documents) of a dictionary stored in a MongoDB collection
 
     Parameters
     ----------
-    mongodb_collection : pymongo.collection.Collection
-        the MongoDB collection to remove documents from.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to remove data from.
+
+    collection_name : str
+        the MongoDB collection within `mongodb` to remove documents from.
 
     identifying_metadata : dict
         JSON-able metadata that identifies the dictionary being
@@ -794,375 +1014,4 @@ def remove_dict_from_mongodb(mongodb_collection, identifying_metadata, session=N
     -------
     None
     """
-    return mongodb_collection.delete_many(identifying_metadata, session=session)
-
-
-def write_dataset_to_mongodb(dataset, mongodb_collection, identifying_metadata,
-                             circuits=None, outcome_label_order=None, with_times="auto",
-                             datarow_subcollection_name=None, session=None):
-    """
-    Write a data set to a MongoDB database.
-
-    A single document is created in the given `mongodb_collection` representing
-    the entire dataset, and one document per data-row (circuit) is created in the
-    sub-collection of `mongodb_collection` named by `datarow_subollection_name`.
-
-    Parameters
-    ----------
-    dataset : DataSet
-        the dictionary of elements to serialize.
-
-    mongodb_collection : pymongo.collection.Collection
-        the MongoDB collection to write to.
-
-    identifying_metadata : dict
-        JSON-able metadata that identifies the data set being
-        serialized.  This metadata should be saved for later retrieving
-        the elements of `d` from `mongodb_collection`.
-
-    circuits : list of Circuits, optional
-        The list of circuits to include in the written dataset.
-        If None, all circuits are output.
-
-    outcome_label_order : list, optional
-        A list of the outcome labels in dataset which specifies
-        the column order in the output file.
-
-    with_times : bool or "auto", optional
-        Whether to include (save) time-stamp information in output.  This
-        can only be True when `fixed_column_mode=False`.  `"auto"` will set
-        this to True if `fixed_column_mode=False` and `dataset` has data at
-        non-trivial (non-zero) times.
-
-    datarow_subcollection_name : str, optional
-        The name of the MongoDB subcollection that holds the written
-        data set's row data as one record per row.  If `None`, defaults
-        to `pygsti.io.mongodb.subcollection_names['datarows']`.
-
-    session : pymongo.client_session.ClientSession, optional
-        MongoDB session object to use when interacting with the MongoDB
-        database. This can be used to implement transactions
-        among other things.
-
-    Returns
-    -------
-    None
-    """
-    if circuits is not None:
-        if len(circuits) > 0 and not isinstance(circuits[0], _Circuit):
-            raise ValueError("Argument circuits must be a list of Circuit objects!")
-    else:
-        circuits = list(dataset.keys())
-
-    if datarow_subcollection_name is None:
-        datarow_subcollection_name = cnm('datarows')
-
-    if outcome_label_order is not None:  # convert to tuples if needed
-        outcome_label_order = [(ol,) if isinstance(ol, str) else ol
-                               for ol in outcome_label_order]
-
-    outcomeLabels = dataset.outcome_labels
-    if outcome_label_order is not None:
-        assert(len(outcome_label_order) == len(outcomeLabels))
-        assert(all([ol in outcomeLabels for ol in outcome_label_order]))
-        assert(all([ol in outcome_label_order for ol in outcomeLabels]))
-        outcomeLabels = outcome_label_order
-        oli_map_data = {dataset.olIndex[ol]: i for i, ol in enumerate(outcomeLabels)}  # dataset -> stored indices
-
-        def oli_map(outcome_label_indices):
-            return [oli_map_data[i] for i in outcome_label_indices]
-    else:
-        def oli_map(outcome_label_indices):
-            return [i.item() for i in outcome_label_indices]  # converts numpy types -> native python types
-
-    dataset_doc = identifying_metadata.copy()
-    dataset_doc['outcomes'] = outcomeLabels
-    dataset_doc['comment'] = dataset.comment if hasattr(dataset, 'comment') else None
-    dataset_doc['datarow_subcollection_name'] = datarow_subcollection_name
-
-    if with_times == "auto":
-        trivial_times = dataset.has_trivial_timedependence
-    else:
-        trivial_times = not with_times
-
-    if '_id' in identifying_metadata:
-        dataset_id = identifying_metadata['_id']
-    else:
-        from bson.objectid import ObjectId as _ObjectId
-        existing_dataset_doc = mongodb_collection.find_one(identifying_metadata, session=session)
-        dataset_id = existing_dataset_doc['_id'] if (existing_dataset_doc is not None) else _ObjectId()
-        identifying_metadata = identifying_metadata.copy()
-        identifying_metadata['_id'] = dataset_id  # be sure to query & replace the same ID below
-
-    mongodb_collection.replace_one(identifying_metadata, dataset_doc, upsert=True, session=session)
-    datarow_collection = mongodb_collection[datarow_subcollection_name]
-
-    for i, circuit in enumerate(circuits):  # circuit should be a Circuit object here
-        dataRow = dataset[circuit]
-        datarow_doc = {'index': i,
-                       'circuit': circuit.str,
-                       'parent': dataset_id,
-                       'outcome_indices': oli_map(dataRow.oli),
-                       'repetitions': [r.item() for r in dataRow.reps]  # converts numpy -> Python native types
-                       }
-
-        if trivial_times:  # ensure that "repetitions" are just "counts" in trivial-time case
-            assert(len(dataRow.oli) == len(set(dataRow.oli))), "Duplicate value in trivial-time data set row!"
-        else:
-            datarow_doc['times'] = list(dataRow.time)
-
-        if dataRow.aux:
-            datarow_doc['aux'] = dataRow.aux  # needs to be JSON-able!
-
-        datarow_collection.replace_one({'circuit': circuit.str, 'parent': dataset_id}, datarow_doc,
-                                       upsert=True, session=session)
-
-
-def remove_dataset_from_mongodb(mongodb_collection, identifying_metadata,
-                                datarow_subcollection_name=None, session=None):
-    """
-    Remove (delete) a data set from a MongoDB database.
-
-    Parameters
-    ----------
-    mongodb_collection : pymongo.collection.Collection
-        the MongoDB collection to remove a data set from.
-
-    identifying_metadata : dict
-        JSON-able metadata that identifies the data set being
-        serialized.
-
-    datarow_subcollection_name : str, optional
-        The name of the MongoDB subcollection that holds the
-        data set's row data.  If `None`, defaults to
-        `pygsti.io.mongodb.subcollection_names['datarows']`.
-
-    session : pymongo.client_session.ClientSession, optional
-        MongoDB session object to use when interacting with the MongoDB
-        database. This can be used to implement transactions
-        among other things.
-
-    Returns
-    -------
-    None
-    """
-    if datarow_subcollection_name is None:
-        datarow_subcollection_name = cnm('datarows')
-    dataset_doc = mongodb_collection.find_one_and_delete(identifying_metadata, session=session)
-    mongodb_collection[datarow_subcollection_name].delete_many({'parent': dataset_doc['_id']}, session=session)
-
-
-def read_dataset_from_mongodb(mongodb_collection, identifying_metadata, collision_action="aggregate",
-                              record_zero_counts=False, with_times="auto", circuit_parse_cache=None, verbosity=1):
-    """
-    Load a DataSet from a MongoDB database.
-
-    Parameters
-    ----------
-    mongodb_collection : pymongo.collection.Collection
-        the MongoDB collection to read from.
-
-    identifying_metadata : dict
-        JSON-able metadata that identifies the data set being
-        loaded.
-
-    collision_action : {"aggregate", "keepseparate"}
-        Specifies how duplicate circuits should be handled.  "aggregate"
-        adds duplicate-circuit counts, whereas "keepseparate" tags duplicate
-        circuits by setting their `.occurrence` IDs to sequential positive integers.
-
-    record_zero_counts : bool, optional
-        Whether zero-counts are actually recorded (stored) in the returned
-        DataSet.  If False, then zero counts are ignored, except for potentially
-        registering new outcome labels.
-
-    with_times : bool or "auto", optional
-        Whether to the time-stamped data format should be read in.  If
-        "auto", then the time-stamped format is allowed but not required on a
-        per-circuit basis (so the dataset can contain both formats).  Typically
-        you only need to set this to False when reading in a template file.
-
-    circuit_parse_cache : dict, optional
-        A dictionary mapping qubit string representations into created
-        :class:`Circuit` objects, which can improve performance by reducing
-        or eliminating the need to parse circuit strings.
-
-    verbosity : int, optional
-        If zero, no output is shown.  If greater than zero,
-        loading progress is shown.
-
-    Returns
-    -------
-    DataSet
-    """
-    from pymongo import ASCENDING, DESCENDING
-
-    dataset_doc = mongodb_collection.find_one(identifying_metadata)
-    if dataset_doc is None:
-        raise ValueError("Could not find a dataset with the given identifying metadata!")
-
-    datarow_subcollection_name = dataset_doc['datarow_subcollection_name']
-    outcomeLabels = dataset_doc['outcomes']
-
-    dataset = _DataSet(outcome_labels=outcomeLabels, collision_action=collision_action,
-                       comment=dataset_doc['comment'])
-    parser = _stdinput.StdInputParser()
-
-    datarow_collection = mongodb_collection[datarow_subcollection_name]
-    for i, datarow_doc in enumerate(datarow_collection.find({'parent': dataset_doc['_id']}).sort('index', ASCENDING)):
-        if i != datarow_doc['index']:
-            _warnings.warn("Data set's row data is incomplete! There seem to be missing rows.")
-
-        circuit = parser.parse_circuit(datarow_doc['circuit'], lookup={},  # allow a lookup to be passed?
-                                       create_subcircuits=not _Circuit.default_expand_subcircuits)
-
-        oliArray = _np.array(datarow_doc['outcome_indices'], dataset.oliType)
-        countArray = _np.array(datarow_doc['repetitions'], dataset.repType)
-        if 'times' not in datarow_doc:  # with_times can be False or 'auto'
-            if with_times is True:
-                raise ValueError("Circuit %d does not contain time information and 'with_times=True'" % i)
-            timeArray = _np.zeros(countArray.shape[0], dataset.timeType)
-        else:
-            if with_times is False:
-                raise ValueError("Circuit %d contains time information and 'with_times=False'" % i)
-            timeArray = _np.array(datarow_doc['time'], dataset.timeType)
-
-        dataset._add_raw_arrays(circuit, oliArray, timeArray, countArray,
-                                overwrite_existing=True,
-                                record_zero_counts=record_zero_counts,
-                                aux=datarow_doc.get('aux', {}))
-
-    dataset.done_adding_data()
-    return dataset
-
-
-def mongodb_collection_names(custom_collection_names=None):
-    """
-    Construct a dictionary listing the MongoDB collection names used by pyGSTi read/write methods.
-
-    The keys of the returned dictionary correspond to types or broader categories of
-    pyGSTi objects that can serialize themselves to a MongoDB instance.  The values give
-    the corresponding MongoDB collection name used by that type.
-
-    Use of such a dictionary is needed (as opposed to just giving each I/O call
-    a collection name, for instance) because pyGSTi I/O calls often read or write
-    a hierarchy of objects with different types (e.g., experiment designs, data sets,
-    and results).
-
-    Parameters
-    ----------
-    custom_collection_names : dict, optional
-        Overrides the default collection names.  The keys of this dictionary must be a
-        subset of the valid type-names (the keys of the return value when this argument is `None`).
-
-    Returns
-    -------
-    dict
-    """
-    collection_names = {'edesigns': 'pygsti_experiment_designs',
-                        'data': 'pygsti_protocol_data',
-                        'results': 'pygsti_protocol_results'}
-    if custom_collection_names is not None:
-        for k, v in custom_collection_names.items():
-            assert(k in collection_names), "%s is an invalid collection-type (key)!" % str(k)
-            collection_names[k] = v
-    return collection_names
-
-
-def prepare_doc_for_existing_doc_check(doc, existing_doc, set_id=True, convert_tuples_to_lists=True):
-    """
-    Prepares a to-be inserted document for comparison with an existing document.
-
-    Optionally (see parameters):
-    1) sets _id of `doc` to that of `existing_doc`.  This is useful in cases where the _id
-       field is redundant with other uniquely identifying fields in the document, and so inserted
-       documents don't need to match this field.
-    2) converts all of `doc`'s tuples to lists, as the existing_doc is typically read from a MongoDB
-       which only stores lists and doesn't distinguish between lists and tuples.
-
-    Parameters
-    ----------
-    doc : dict
-        the document to prepare
-
-    existing_doc : dict
-        the existing document
-
-    set_id : bool, optional
-        when `True`, add an `'_id'` field to `doc` matching `existing_doc` when one
-        is not already present.
-
-    convert_tuples_to_lists : bool, optional
-        when `True` convert all of the tuples within `doc` to lists.
-
-    Returns
-    -------
-    dict
-        the prepared document.
-    """
-    def tup_to_list(obj):
-        if isinstance(obj, (tuple, list)):
-            return [tup_to_list(v) for v in obj]
-        elif isinstance(obj, dict):
-            return {k: tup_to_list(v) for k, v in obj.items()}
-        else:
-            return obj
-
-    doc = doc.copy()
-    if '_id' not in doc:  # Allow doc to lack an _id field and still be considered same as existing_doc
-        doc['_id'] = existing_doc['_id']
-    return tup_to_list(doc)
-
-
-def recursive_compare_str(a, b, a_name='first obj', b_name='second obj', prefix="", diff_accum=None):
-    """
-    Compares two objects and generates a list of strings describing how they differ.
-
-    Recursively traverses dictionaries, tuples, and lists.
-
-    Parameters
-    ----------
-    a, b : object
-        The objects to compare
-
-    a_name, b_name : str, optional
-        Names for the `a` and `b` objects for referencing them in the output strings.
-
-    prefix : str, optional
-        An optional prefix to the descriptions in the returned strings.
-
-    diff_accum : list, optional
-        An existing list that is accumulating difference-descriptions.
-        `None` means start a new list.
-
-    Returns
-    -------
-    list
-        A list of strings, each describing a difference between the objects.
-    """
-    typ = type(a)
-    if diff_accum is None:
-        diff_accum = []
-
-    if typ != type(b):
-        diff_accum.append(prefix + f": are different types ({typ} vs {type(b)})")
-
-    if isinstance(a, dict):
-        a_keys = set(a.keys())
-        b_keys = set(b.keys())
-        for k in a_keys.intersection(b_keys):
-            recursive_compare_str(a[k], b[k], a_name, b_name, f"{prefix}.{k}", diff_accum)
-        for k in (b_keys - a_keys):  # keys missing from a
-            diff_accum.append(f"{prefix}.{k}: missing from {a_name}")
-        for k in (a_keys - b_keys):  # keys missing from b
-            diff_accum.append(f"{prefix}.{k}: missing from {b_name}")
-    elif isinstance(a, (list, tuple)):
-        if len(a) != len(b):
-            diff_accum.append(f"{prefix}: have different lengths ({len(a)} vs {len(b)})")
-        else:
-            for i, (va, vb) in enumerate(zip(a, b)):
-                recursive_compare_str(va, vb, a_name, b_name, f"{prefix}[{i}]", diff_accum)
-    else:
-        if a != b:
-            diff_accum.append(f"{prefix}: {a} != {b}")
-    return diff_accum
+    return mongodb[collection_name].delete_many(identifying_metadata, session=session)

--- a/pygsti/io/mongodb.py
+++ b/pygsti/io/mongodb.py
@@ -740,7 +740,7 @@ def _write_auxdoc_member(mongodb, write_ops, parent_collection_name, parent_id, 
             member_id = {'parent_collection': parent_collection_name, 'parent': parent_id, 'member_name': member_name}
             val_doc = member_id.copy()
             val_doc.update({'auxdoc_type': cur_typ,
-                            'json_data': _Binary(_pickle.dumps(val, protocol=2), subtype=128)})
+                            'json_data': val})
             val_id = write_ops.add_one_op('pygsti_json_data', member_id, val_doc, overwrite_existing, mongodb)
             metadata = {'collection_name': 'pygsti_json_data', 'id': val_id}
 

--- a/pygsti/io/mongodb.py
+++ b/pygsti/io/mongodb.py
@@ -433,7 +433,7 @@ def write_auxtree_to_mongodb(root_mongo_collection, doc_id, valuedict, auxfile_t
 
         write_ops.add_ops_by_subcollection(ops)
         if auxmeta is not None:
-            to_insert[auxnm] = auxmeta  # metadata about auxfile(s) for this auxnm
+            to_insert[auxnm] = auxmeta  # metadata about auxiliary document(s) for this aux name
 
     try:
         for standalone_id, obj, bPartial in write_ops.standalone_writes:

--- a/pygsti/io/readers.py
+++ b/pygsti/io/readers.py
@@ -571,7 +571,7 @@ def load_data_from_dir(dirname, quick_load=False, comm=None):
     return read_data_from_dir(dirname, quick_load, comm)
 
 
-def read_data_from_dir(dirname, quick_load=False, comm=None):
+def read_data_from_dir(dirname, preloaded_edesign=None, quick_load=False, comm=None):
     """
     Load a :class:`ProtocolData` from a directory on disk.
 
@@ -579,6 +579,11 @@ def read_data_from_dir(dirname, quick_load=False, comm=None):
     ----------
     dirname : string
         Directory name.
+
+    preloaded_edesign : ExperimentDesign, optional
+        The experiment deisgn belonging to the to-be-loaded data object, in cases
+        when this has been loaded already (only use this if you know what
+        you're doing).
 
     quick_load : bool, optional
         Setting this to True skips the loading of components that may take
@@ -598,10 +603,11 @@ def read_data_from_dir(dirname, quick_load=False, comm=None):
     except FileNotFoundError:
         from ..protocols import ProtocolData as _ProtocolData
         protocol_data = _ProtocolData  # use ProtocolData as default class
-    return protocol_data.from_dir(dirname, quick_load=quick_load)
+    return protocol_data.from_dir(dirname, preloaded_edesign=preloaded_edesign, quick_load=quick_load)
 
 
-def read_data_from_mongodb(mongodb, doc_id, quick_load=False, comm=None, custom_collection_names=None):
+def read_data_from_mongodb(mongodb, doc_id, preloaded_edesign=None, quick_load=False, comm=None,
+                           custom_collection_names=None):
     """
     Load a :class:`ProtocolData` from a MongoDB database.
 
@@ -612,6 +618,11 @@ def read_data_from_mongodb(mongodb, doc_id, quick_load=False, comm=None, custom_
 
     doc_id : str
         The user-defined identifier of the data to load.
+
+    preloaded_edesign : ExperimentDesign, optional
+        The experiment deisgn belonging to the to-be-loaded data object, in cases
+        when this has been loaded already (only use this if you know what
+        you're doing).
 
     quick_load : bool, optional
         Setting this to True skips the loading of components that may take
@@ -636,7 +647,7 @@ def read_data_from_mongodb(mongodb, doc_id, quick_load=False, comm=None, custom_
         data_cls = _ProtocolData
     else:
         data_cls = _metadir._class_for_name(doc['type'])
-    return data_cls.from_mongodb(mongodb, doc_id, quick_load=quick_load,
+    return data_cls.from_mongodb(mongodb, doc_id, preloaded_edesign=preloaded_edesign, quick_load=quick_load,
                                  custom_collection_names=custom_collection_names)
 
 

--- a/pygsti/io/readers.py
+++ b/pygsti/io/readers.py
@@ -450,7 +450,7 @@ def read_protocol_from_mongodb(mongodb_collection, doc_id, quick_load=False):
     return _metadir._class_for_name(doc['type']).from_mongodb(mongodb_collection, doc_id, quick_load=quick_load)
 
 
-def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None):
+def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None, recursive=False):
     """
     Remove a :class:`Protocol` from a MongoDB database.
 
@@ -470,13 +470,20 @@ def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None):
         database. This can be used to implement transactions
         among other things.
 
+    recursive : RecursiveRemovalSpecification, optional
+        An object that filters the type of documents that are removed.
+        Used when working with inter-related experiment designs, data,
+        and results objects to only remove the types of documents you
+        know aren't being shared with other documents.
+
     Returns
     -------
     bool
         `True` if the specified protocol object was removed, `False` if it didn't exist.
     """
     from ..protocols import Protocol as _Protocol
-    return _Protocol.remove_from_mongodb(mongodb_collection, doc_id, session)
+    return _Protocol.remove_from_mongodb(mongodb_collection, doc_id, session=session,
+                                         recursive=recursive)
 
 
 @_deprecated_fn('read_edesign_from_dir')
@@ -551,7 +558,7 @@ def create_edesign_from_dir(dirname):
         raise ValueError("Could not create an experiment design from the files in this directory!")
 
 
-def read_edesign_from_mongodb(mongodb, doc_id, quick_load=False, comm=None, custom_collection_names=None):
+def read_edesign_from_mongodb(mongodb, doc_id, quick_load=False, comm=None):
     """
     Load a :class:`ExperimentDesign` from a MongoDB database.
 
@@ -571,23 +578,15 @@ def read_edesign_from_mongodb(mongodb, doc_id, quick_load=False, comm=None, cust
     comm : mpi4py.MPI.Comm, optional
         When not ``None``, an MPI communicator used to synchronize file access.
 
-    custom_collection_names : dict, optional
-        Overrides for the default MongoDB collection names used for storing different
-        types of pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
-        is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
     Returns
     -------
     ExperimentDesign
     """
-    doc = mongodb[_mongodb.mongodb_collection_names(custom_collection_names)['edesigns']].find_one({'_id': doc_id})
-    if 'type' not in doc:
-        raise ValueError("Document exists, but expected 'type' key within document is missing!")
-    return _metadir._class_for_name(doc['type']).from_mongodb(mongodb, doc_id, quick_load=quick_load,
-                                                              custom_collection_names=custom_collection_names)
+    import pygsti.protocols as _proto
+    return _proto.ExperimentDesign.from_mongodb(mongodb, doc_id, quick_load=quick_load)
 
 
-def remove_edesign_from_mongodb(mongodb, doc_id, custom_collection_names=None, session=None):
+def remove_edesign_from_mongodb(mongodb, doc_id, session=None, recursive="default"):
     """
     Remove an :class:`ExperimentDesign` from a MongoDB database.
 
@@ -602,15 +601,16 @@ def remove_edesign_from_mongodb(mongodb, doc_id, custom_collection_names=None, s
     doc_id : str
         The user-defined identifier of the experiment design to remove.
 
-    custom_collection_names : dict, optional
-        Overrides for the default MongoDB collection names used for storing different
-        types of pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
-        is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
     session : pymongo.client_session.ClientSession, optional
         MongoDB session object to use when interacting with the MongoDB
         database. This can be used to implement transactions
         among other things.
+
+    recursive : RecursiveRemovalSpecification, optional
+        An object that filters the type of documents that are removed.
+        Used when working with inter-related experiment designs, data,
+        and results objects to only remove the types of documents you
+        know aren't being shared with other documents.
 
     Returns
     -------
@@ -618,7 +618,8 @@ def remove_edesign_from_mongodb(mongodb, doc_id, custom_collection_names=None, s
         `True` if the specified experiment design was removed, `False` if it didn't exist.
     """
     from ..protocols import ExperimentDesign as _ExperimentDesign
-    return _ExperimentDesign.remove_from_mongodb(mongodb, doc_id, custom_collection_names, session)
+    return _ExperimentDesign.remove_from_mongodb(mongodb, doc_id, session=session,
+                                                 recursive=recursive)
 
 
 @_deprecated_fn('read_data_from_dir')
@@ -662,8 +663,7 @@ def read_data_from_dir(dirname, preloaded_edesign=None, quick_load=False, comm=N
     return protocol_data.from_dir(dirname, preloaded_edesign=preloaded_edesign, quick_load=quick_load)
 
 
-def read_data_from_mongodb(mongodb, doc_id, preloaded_edesign=None, quick_load=False, comm=None,
-                           custom_collection_names=None):
+def read_data_from_mongodb(mongodb, doc_id, preloaded_edesign=None, quick_load=False, comm=None):
     """
     Load a :class:`ProtocolData` from a MongoDB database.
 
@@ -688,26 +688,15 @@ def read_data_from_mongodb(mongodb, doc_id, preloaded_edesign=None, quick_load=F
     comm : mpi4py.MPI.Comm, optional
         When not ``None``, an MPI communicator used to synchronize database access.
 
-    custom_collection_names : dict, optional
-        Overrides for the default MongoDB collection names used for storing different
-        types of pyGSTi objects.  Default values are given by
-        :method:`pygsti.io.mongodb_collection_names`.
-
     Returns
     -------
     ProtocolData
     """
-    doc = mongodb[_mongodb.mongodb_collection_names(custom_collection_names)['data']].find_one({'_id': doc_id})
-    if doc is None or 'type' not in doc:
-        from ..protocols import ProtocolData as _ProtocolData
-        data_cls = _ProtocolData
-    else:
-        data_cls = _metadir._class_for_name(doc['type'])
-    return data_cls.from_mongodb(mongodb, doc_id, preloaded_edesign=preloaded_edesign, quick_load=quick_load,
-                                 custom_collection_names=custom_collection_names)
+    import pygsti.protocols as _proto
+    return _proto.ProtocolData.from_mongodb(mongodb, doc_id, preloaded_edesign=preloaded_edesign, quick_load=quick_load)
 
 
-def remove_data_from_mongodb(mongodb, doc_id, custom_collection_names=None, session=None):
+def remove_data_from_mongodb(mongodb, doc_id, session=None, recursive="default"):
     """
     Remove :class:`ProtocolData` from a MongoDB database.
 
@@ -722,15 +711,16 @@ def remove_data_from_mongodb(mongodb, doc_id, custom_collection_names=None, sess
     doc_id : str
         The user-defined identifier of the experiment design to remove.
 
-    custom_collection_names : dict, optional
-        Overrides for the default MongoDB collection names used for storing different
-        types of pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
-        is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
     session : pymongo.client_session.ClientSession, optional
         MongoDB session object to use when interacting with the MongoDB
         database. This can be used to implement transactions
         among other things.
+
+    recursive : RecursiveRemovalSpecification, optional
+        An object that filters the type of documents that are removed.
+        Used when working with inter-related experiment designs, data,
+        and results objects to only remove the types of documents you
+        know aren't being shared with other documents.
 
     Returns
     -------
@@ -738,8 +728,8 @@ def remove_data_from_mongodb(mongodb, doc_id, custom_collection_names=None, sess
         `True` if the specified experiment design was removed, `False` if it didn't exist.
     """
     from ..protocols import ProtocolData as _ProtocolData
-    return _ProtocolData.remove_from_mongodb(mongodb, doc_id,
-                                             custom_collection_names, session)
+    return _ProtocolData.remove_from_mongodb(mongodb, doc_id, session,
+                                             recursive=recursive)
 
 
 @_deprecated_fn('read_results_from_dir')
@@ -796,14 +786,9 @@ def read_results_from_dir(dirname, name=None, preloaded_data=None, quick_load=Fa
         return _metadir._cls_from_meta_json(results_dir / name).from_dir(dirname, name, preloaded_data, quick_load)
 
 
-def read_results_from_mongodb(mongodb, doc_id, name=None, preloaded_data=None, quick_load=False,
-                              comm=None, custom_collection_names=None):
+def read_results_from_mongodb(mongodb, doc_id, preloaded_data=None, quick_load=False, comm=None):
     """
-    Load a :class:`ProtocolResults` or :class:`ProtocolsResultsDir` from a MongoDB database.
-
-    Which object type is loaded depends on whether `name` is given: if it is, then
-    a :class:`ProtocolResults` object is loaded.  If not, a :class:`ProtocolsResultsDir`
-    is loaded.
+    Load a :class:`ProtocolResults` from a MongoDB database.
 
     Parameters
     ----------
@@ -812,12 +797,6 @@ def read_results_from_mongodb(mongodb, doc_id, name=None, preloaded_data=None, q
 
     doc_id : str
         The user-defined identifier of the results directory to load.
-
-    name : string or None
-        The 'name' of a particular :class:`ProtocolResults` object belonging
-        to the directory given by `doc_id`.  If None, then *all*
-        the results (all names) in the given results directory are loaded and
-        returned as a :class:`ProtocolResultsDir` object.
 
     preloaded_data : ProtocolData, optional
         The data object belonging to the to-be-loaded results, in cases
@@ -832,36 +811,52 @@ def read_results_from_mongodb(mongodb, doc_id, name=None, preloaded_data=None, q
     comm : mpi4py.MPI.Comm, optional
         When not ``None``, an MPI communicator used to synchronize database access.
 
-    custom_collection_names : dict, optional
-        Overrides for the default MongoDB collection names used for storing different
-        types of pyGSTi objects.  Default values are given by
-        :method:`pygsti.io.mongodb_collection_names`.
+    Returns
+    -------
+    ProtocolResults
+    """
+    from ..protocols import ProtocolResults as _ProtocolResults
+    return _ProtocolResults.from_mongodb(mongodb, doc_id, preloaded_data=preloaded_data, quick_load=quick_load)
+
+
+def read_resultsdir_from_mongodb(mongodb, doc_id, preloaded_data=None, quick_load=False, comm=None):
+    """
+    Load a :class:`ProtocolsResultsDir` from a MongoDB database.
+
+    Parameters
+    ----------
+    mongodb : pymongo.database.Database
+        The MongoDB instance to load data from.
+
+    doc_id : str
+        The user-defined identifier of the results directory to load.
+
+    preloaded_data : ProtocolData, optional
+        The data object belonging to the to-be-loaded results, in cases
+        when this has been loaded already (only use this if you know what
+        you're doing).
+
+    quick_load : bool, optional
+        Setting this to True skips the loading of data and experiment-design
+        components that may take a long time to load. This can be useful
+        all the information of interest lies only within the results objects.
+
+    comm : mpi4py.MPI.Comm, optional
+        When not ``None``, an MPI communicator used to synchronize database access.
 
     Returns
     -------
-    ProtocolResults or ProtocolResultsDir
+    ProtocolResultsDir
     """
-    if name is None:
-        #Currently, there's just a single ProtocolResultsDir class.  If we want to allow custom classes
-        # we'll need to use the 'resultdirs' collection to store this information (FUTURE)
-        #doc = mongodb[_mongodb.mongodb_collection_names(custom_collection_names)['resultdirs']].find_one({'_id': doc_id})
-        #if doc is None or 'type' not in doc:
-        from ..protocols import ProtocolResultsDir as _ProtocolResultsDir
-        resultsdir_cls = _ProtocolResultsDir
-        #else:
-        #    resultsdir_cls = _metadir._class_for_name(doc['type'])
-        return resultsdir_cls.from_mongodb(mongodb, doc_id, None, None, preloaded_data, quick_load,
-                                           custom_collection_names)
-    else:  # it's a ProtocolResults object
-        doc = mongodb[_mongodb.mongodb_collection_names(custom_collection_names)['results']].find_one(
-            {'directory_id': doc_id, 'name': name}, ['type'])
-        results_cls = _metadir._class_for_name(doc['type'])
-        return results_cls.from_mongodb(mongodb, doc_id, name, preloaded_data, quick_load, custom_collection_names)
+    #Currently, there's just a single ProtocolResultsDir class.  If we want to allow custom classes
+    # we'll need to use the 'resultdirs' collection to store this information (FUTURE)
+    from ..protocols import ProtocolResultsDir as _ProtocolResultsDir
+    return _ProtocolResultsDir.from_mongodb(mongodb, doc_id, preloaded_data=preloaded_data, quick_load=quick_load)
 
 
-def remove_results_from_mongodb(mongodb, doc_id, name=None, comm=None, custom_collection_names=None, session=None):
+def remove_results_from_mongodb(mongodb, doc_id, comm=None, session=None, recursive="default"):
     """
-    Remove :class:`ProtocolResults` or :class:`ProtocolsResultsDir` data from a MongoDB database.
+    Remove :class:`ProtocolResults` data from a MongoDB database.
 
     Which object type is removed depends on whether `name` is given: if it is, then
     data corresponding to a :class:`ProtocolResults` object is removed.  If not, that of
@@ -875,39 +870,58 @@ def remove_results_from_mongodb(mongodb, doc_id, name=None, comm=None, custom_co
     doc_id : str
         The user-defined identifier of the results directory to remove.
 
-    name : string or None
-        The 'name' of a particular :class:`ProtocolResults` object belonging
-        to the directory given by `doc_id`.  If None, then *all*
-        the results (all names) in the given results directory are removed.
-
     comm : mpi4py.MPI.Comm, optional
         When not ``None``, an MPI communicator used to synchronize database access.
-
-    custom_collection_names : dict, optional
-        Overrides for the default MongoDB collection names used for storing different
-        types of pyGSTi objects.  Default values are given by
-        :method:`pygsti.io.mongodb_collection_names`.
 
     session : pymongo.client_session.ClientSession, optional
         MongoDB session object to use when interacting with the MongoDB
         database. This can be used to implement transactions
         among other things.
 
+    recursive : RecursiveRemovalSpecification, optional
+        An object that filters the type of documents that are removed.
+        Used when working with inter-related experiment designs, data,
+        and results objects to only remove the types of documents you
+        know aren't being shared with other documents.
+
     Returns
     -------
-    bool
-        `True` if the specified results were removed, `False` if they didn't exist.
+    None
     """
-    if name is None:
-        #See FUTURE comment in read_results_from_mongodb above
-        from ..protocols import ProtocolResultsDir as _ProtocolResultsDir
-        resultsdir_cls = _ProtocolResultsDir
-        return resultsdir_cls.remove_from_mongodb(mongodb, doc_id, custom_collection_names, session)
-    else:
-        doc = mongodb[_mongodb.mongodb_collection_names(custom_collection_names)['results']].find_one(
-            {'directory_id': doc_id, 'name': name}, ['type'])
-        if doc is None:
-            return False
+    from ..protocols import ProtocolResults as _ProtocolResults
+    return _ProtocolResults.remove_from_mongodb(mongodb, doc_id, session=session, recursive=recursive)
 
-        results_cls = _metadir._class_for_name(doc['type'])
-        return results_cls.remove_from_mongodb(mongodb, doc_id, name, custom_collection_names, session)
+
+def remove_resultsdir_from_mongodb(mongodb, doc_id, comm=None, session=None, recursive="default"):
+    """
+    Remove :class:`ProtocolsResultsDir` data from a MongoDB database.
+
+    Parameters
+    ----------
+    mongodb : pymongo.database.Database
+        The MongoDB instance to remove data from.
+
+    doc_id : str
+        The user-defined identifier of the results directory to remove.
+
+    comm : mpi4py.MPI.Comm, optional
+        When not ``None``, an MPI communicator used to synchronize database access.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    recursive : RecursiveRemovalSpecification, optional
+        An object that filters the type of documents that are removed.
+        Used when working with inter-related experiment designs, data,
+        and results objects to only remove the types of documents you
+        know aren't being shared with other documents.
+
+    Returns
+    -------
+    None
+    """
+    #See FUTURE comment in read_results_from_mongodb above
+    from ..protocols import ProtocolResultsDir as _ProtocolResultsDir
+    return _ProtocolResultsDir.remove_from_mongodb(mongodb, doc_id, session=session, recursive=recursive)

--- a/pygsti/io/readers.py
+++ b/pygsti/io/readers.py
@@ -423,6 +423,62 @@ def read_protocol_from_dir(dirname, quick_load=False, comm=None):
     return _metadir._cls_from_meta_json(dirname).from_dir(dirname, quick_load=quick_load)
 
 
+def read_protocol_from_mongodb(mongodb_collection, doc_id, quick_load=False):
+    """
+    Load a :class:`Protocol` from a MongoDB database.
+
+    Parameters
+    ----------
+    mongodb_collection : pymongo.collection.Collection
+        The MongoDB collection to load data from.
+
+    doc_id : str
+        The user-defined identifier of the protocol object to load.
+
+    quick_load : bool, optional
+        Setting this to True skips the loading of components that may take
+        a long time to load. This can be useful when this information isn't
+        needed and loading takes a long time.
+
+    Returns
+    -------
+    Protocol
+    """
+    doc = mongodb_collection.find_one({'_id': doc_id}, ['type'])
+    if 'type' not in doc:
+        raise ValueError("Document exists, but expected 'type' key within document is missing!")
+    return _metadir._class_for_name(doc['type']).from_mongodb(mongodb_collection, doc_id, quick_load=quick_load)
+
+
+def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None):
+    """
+    Remove a :class:`Protocol` from a MongoDB database.
+
+    If no protocol object with `doc_id` exists, this function returns `False`,
+    otherwise it returns `True`.
+
+    Parameters
+    ----------
+    mongodb_collection : pymongo.collection.Collection
+        The MongoDB collection to load data from.
+
+    doc_id : str
+        The user-defined identifier of the protocol object to remove.
+
+    session : pymongo.client_session.ClientSession, optional
+        MongoDB session object to use when interacting with the MongoDB
+        database. This can be used to implement transactions
+        among other things.
+
+    Returns
+    -------
+    bool
+        `True` if the specified protocol object was removed, `False` if it didn't exist.
+    """
+    from ..protocols import Protocol as _Protocol
+    return _Protocol.remove_from_mongodb(mongodb_collection, doc_id, session)
+
+
 @_deprecated_fn('read_edesign_from_dir')
 def load_edesign_from_dir(dirname, quick_load=False, comm=None):
     """Deprecated!"""

--- a/pygsti/io/readers.py
+++ b/pygsti/io/readers.py
@@ -423,14 +423,14 @@ def read_protocol_from_dir(dirname, quick_load=False, comm=None):
     return _metadir._cls_from_meta_json(dirname).from_dir(dirname, quick_load=quick_load)
 
 
-def read_protocol_from_mongodb(mongodb_collection, doc_id, quick_load=False):
+def read_protocol_from_mongodb(mongodb, doc_id, quick_load=False):
     """
     Load a :class:`Protocol` from a MongoDB database.
 
     Parameters
     ----------
-    mongodb_collection : pymongo.collection.Collection
-        The MongoDB collection to load data from.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to load data from.
 
     doc_id : str
         The user-defined identifier of the protocol object to load.
@@ -444,13 +444,11 @@ def read_protocol_from_mongodb(mongodb_collection, doc_id, quick_load=False):
     -------
     Protocol
     """
-    doc = mongodb_collection.find_one({'_id': doc_id}, ['type'])
-    if 'type' not in doc:
-        raise ValueError("Document exists, but expected 'type' key within document is missing!")
-    return _metadir._class_for_name(doc['type']).from_mongodb(mongodb_collection, doc_id, quick_load=quick_load)
+    import pygsti.protocols as _proto
+    return _proto.Protocol.from_mongodb(mongodb, doc_id, quick_load=quick_load)
 
 
-def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None, recursive=False):
+def remove_protocol_from_mongodb(mongodb, doc_id, session=None, recursive=False):
     """
     Remove a :class:`Protocol` from a MongoDB database.
 
@@ -459,8 +457,8 @@ def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None, recur
 
     Parameters
     ----------
-    mongodb_collection : pymongo.collection.Collection
-        The MongoDB collection to load data from.
+    mongodb : pymongo.database.Database
+        The MongoDB instance to remove data from.
 
     doc_id : str
         The user-defined identifier of the protocol object to remove.
@@ -482,7 +480,7 @@ def remove_protocol_from_mongodb(mongodb_collection, doc_id, session=None, recur
         `True` if the specified protocol object was removed, `False` if it didn't exist.
     """
     from ..protocols import Protocol as _Protocol
-    return _Protocol.remove_from_mongodb(mongodb_collection, doc_id, session=session,
+    return _Protocol.remove_from_mongodb(mongodb, doc_id, session=session,
                                          recursive=recursive)
 
 

--- a/pygsti/io/stdinput.py
+++ b/pygsti/io/stdinput.py
@@ -443,8 +443,12 @@ class StdInputParser(object):
                 outcomeLabels = [l.strip().split(':') for l in preamble_directives['Outcomes'].split(",")]
                 outcome_labels_specified_in_preamble = True
             if 'StdOutcomeQubits' in preamble_directives:
-                outcomeLabels = int(preamble_directives['Outcomes'])
+                outcomeLabels = int(preamble_directives['StdOutcomeQubits'])
                 outcome_labels_specified_in_preamble = True
+            if not outcome_labels_specified_in_preamble and 'Columns' in preamble_directives:
+                outcomeLabels = sorted(fixed_column_outcome_labels)
+                outcome_labels_specified_in_preamble = True
+
         finally:
             _os.chdir(orig_cwd)
 

--- a/pygsti/layouts/copalayout.py
+++ b/pygsti/layouts/copalayout.py
@@ -185,6 +185,7 @@ class CircuitOutcomeProbabilityArrayLayout(_NicelySerializable):
         # elindex_outcome_tuples : dict w/keys == indices into `unique_circuits` (which is why `unique_circuits`
         #                          is needed) and values == lists of (element_index, outcome) pairs.
 
+        super().__init__()
         self.circuits = circuits if isinstance(circuits, _CircuitList) else _CircuitList(circuits)
         if unique_circuits is None and to_unique is None:
             unique_circuits, to_unique = self._compute_unique_circuits(circuits)

--- a/pygsti/modelmembers/modelmember.py
+++ b/pygsti/modelmembers/modelmember.py
@@ -142,7 +142,8 @@ class ModelMember(ModelChild, _NicelySerializable):
         self._dirty = False  # True when there's any *possibility* that this
         # gate's parameters have been changed since the
         # last setting of dirty=False
-        super(ModelMember, self).__init__(parent)
+        ModelChild.__init__(self, parent)
+        _NicelySerializable.__init__(self)
 
     @property
     def state_space(self):

--- a/pygsti/modelmembers/states/tpstate.py
+++ b/pygsti/modelmembers/states/tpstate.py
@@ -198,4 +198,5 @@ class TPState(_DenseState):
     def _from_memoized_dict(cls, mm_dict, serial_memo):
         vec = cls._decodemx(mm_dict['dense_superket_vector'])
         state_space = _statespace.StateSpace.from_nice_serialization(mm_dict['state_space'])
-        return cls(vec, None, mm_dict['evotype'], state_space)  # use basis=None to skip 1st element check
+        basis = _Basis.from_nice_serialization(mm_dict['basis']) if (mm_dict['basis'] is not None) else None
+        return cls(vec, basis, mm_dict['evotype'], state_space)  # use basis=None to skip 1st element check

--- a/pygsti/modelmembers/states/tpstate.py
+++ b/pygsti/modelmembers/states/tpstate.py
@@ -199,4 +199,10 @@ class TPState(_DenseState):
         vec = cls._decodemx(mm_dict['dense_superket_vector'])
         state_space = _statespace.StateSpace.from_nice_serialization(mm_dict['state_space'])
         basis = _Basis.from_nice_serialization(mm_dict['basis']) if (mm_dict['basis'] is not None) else None
+
+        # HACK -- REMOVE LATER -- allows loading objs saved before fixing TP state bug
+        # at commit aa8a29049a9c3ddafe598d903602ab5afdb7aad4
+        if mm_dict['basis'] is not None and 'name' in mm_dict['basis'] and mm_dict['basis']['name'] == "*Empty*":
+            basis = None
+
         return cls(vec, basis, mm_dict['evotype'], state_space)  # use basis=None to skip 1st element check

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -46,6 +46,7 @@ class GaugeGroup(_NicelySerializable):
             A name for this group - used for reporting what type of
             gauge optimization was performed.
         """
+        super().__init__()
         self.name = name
 
     @property
@@ -94,7 +95,7 @@ class GaugeGroupElement(_NicelySerializable):
 
     def __init__(self):
         """Creates a new GaugeGroupElement"""
-        pass
+        super().__init__()
 
     @property
     def transform_matrix(self):
@@ -197,6 +198,7 @@ class InverseGaugeGroupElement(GaugeGroupElement):
     """
 
     def __init__(self, gauge_group_el):
+        super().__init__()
         self.inverse_element = gauge_group_el
 
     @property

--- a/pygsti/models/gaugegroup.py
+++ b/pygsti/models/gaugegroup.py
@@ -403,14 +403,14 @@ class OpGaugeGroupWithBasis(OpGaugeGroup):
     def _to_nice_serialization(self):
         state = super()._to_nice_serialization()
         state.update({'state_space_dimension': int(self._operation.state_space.dim),
-                      'basis': self._basis.to_nice_serialization(),
+                      'basis': self._basis if isinstance(self._basis, str) else self._basis.to_nice_serialization(),
                       'evotype': str(self._operation.evotype)
                       })
         return state
 
     @classmethod
     def _from_nice_serialization(cls, state):
-        basis = _Basis.from_nice_serialization(state['basis'])
+        basis = state['basis'] if isinstance(state['basis'], str) else _Basis.from_nice_serialization(state['basis'])
         return cls(_statespace.default_space_for_dim(state['state_space_dimension']), basis, state['evotype'])
 
 

--- a/pygsti/models/layerrules.py
+++ b/pygsti/models/layerrules.py
@@ -26,6 +26,9 @@ class LayerRules(_NicelySerializable):
     tailored to a specific models.
     """
 
+    def __init__(self):
+        super().__init__()
+
     def _create_op_for_circuitlabel(self, model, circuitlbl):
         """
         A helper method for derived classes used for processing :class:`CircuitLabel` labels.

--- a/pygsti/models/model.py
+++ b/pygsti/models/model.py
@@ -54,6 +54,7 @@ class Model(_NicelySerializable):
     """
 
     def __init__(self, state_space):
+        super().__init__()
         self._state_space = _statespace.StateSpace.cast(state_space)
         self._num_modeltest_params = None
         self._hyperparams = {}

--- a/pygsti/models/modelparaminterposer.py
+++ b/pygsti/models/modelparaminterposer.py
@@ -13,11 +13,13 @@ Defines the ModelParamsInterposer class and supporting functionality.
 import numpy as _np
 from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
 
+
 class ModelParamsInterposer(_NicelySerializable):
     """
     A function class that sits in between an :class:`OpModel`'s parameter vector and those of its operations.
     """
     def __init__(self, num_params, num_op_params):
+        super().__init__()
         self.num_params = num_params
         self.num_op_params = num_op_params
 

--- a/pygsti/objectivefns/objectivefns.py
+++ b/pygsti/objectivefns/objectivefns.py
@@ -216,6 +216,7 @@ class ObjectiveFunctionBuilder(_NicelySerializable):
         return builder
 
     def __init__(self, cls_to_build, name=None, description=None, regularization=None, penalties=None, **kwargs):
+        super().__init__()
         self.name = name if (name is not None) else cls_to_build.__name__
         self.description = description if (description is not None) else "_objfn"  # "Sum of Chi^2" OR "2*Delta(log(L))"
         self.cls_to_build = cls_to_build
@@ -6598,6 +6599,7 @@ class CachedObjectiveFunction(_NicelySerializable):
 
     The cache may only have values on the rank-0 proc (??)
     """
+    collection_name = "pygsti_cached_objective_fns"
 
     @classmethod
     def from_dir(cls, dirname, quick_load=False):
@@ -6624,37 +6626,19 @@ class CachedObjectiveFunction(_NicelySerializable):
         import pygsti.io as _io
         ret = cls.__new__(cls)
         ret.__dict__.update(_io.load_meta_based_dir(_pathlib.Path(dirname), 'auxfile_types', quick_load=quick_load))
+        _NicelySerializable.__init__(ret)
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb_collection, doc_id, quick_load=False):
-        """
-        Initialize a new CachedObjectiveFunction object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb_collection : pymongo.collection.Collection
-            The MongoDB collection to load data from.
-
-        doc_id : str
-            The user-defined identifier of the protocol object to load.
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of components that may take
-            a long time to load.
-
-        Returns
-        -------
-        Protocol
-        """
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, quick_load=False):
         import pygsti.io as _io
         ret = cls.__new__(cls)
-        ret.__dict__.update(_io.read_auxtree_from_mongodb(mongodb_collection, doc_id,
-                                                          'auxfile_types', quick_load=quick_load))
+        ret.__dict__.update(_io.read_auxtree_from_mongodb_doc(mongodb, doc, 'auxfile_types', quick_load=quick_load))
+        _NicelySerializable.__init__(ret)
         return ret
 
     def __init__(self, objective_function):
-
+        super().__init__()
         self.layout = objective_function.layout.global_layout
         self.model_paramvec = objective_function.model.to_vector().copy()
 
@@ -6715,52 +6699,16 @@ class CachedObjectiveFunction(_NicelySerializable):
         import pygsti.io as _io
         _io.write_obj_to_meta_based_dir(self, dirname, 'auxfile_types')
 
-    def write_to_mongodb(self, mongodb_collection, doc_id=None, session=None, overwrite_existing=False):
-        """
-        Write this CachedObjectiveFunction to a MongoDB database.
-
-        Parameters
-        ----------
-        mongodb_collection : pymongo.collection.Collection
-            The MongoDB collection to write to.
-
-        doc_id : str, optional
-            The user-defined identifier of the Estimate to write.  Can be
-            left as `None` to generate a random identifier.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists.
-            Setting this to `True` mimics the behaviour of a typical filesystem, where writing
-            to a path can be done regardless of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing):
         import pygsti.io as _io
-        _io.write_obj_to_mongodb_auxtree(self, mongodb_collection, doc_id, 'auxfile_types',
-                                         session=session, overwrite_existing=overwrite_existing)
+        _io.add_obj_auxtree_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                     'auxfile_types', overwrite_existing=overwrite_existing)
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb_collection, doc_id, session=None):
-        """
-        Remove a CachedObjectiveFunction from a MongoDB database.
-
-        Returns
-        -------
-        bool
-            `True` if the specified experiment design was removed, `False` if it didn't exist.
-        """
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
         import pygsti.io as _io
-        delcnt = _io.remove_auxtree_from_mongodb(mongodb_collection, doc_id, 'auxfile_types',
-                                                 session=session)
-        return bool(delcnt is not None and delcnt.deleted_count == 1)
+        _io.remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                        recursive=recursive)
 
     def _to_nice_serialization(self):
         state = super()._to_nice_serialization()

--- a/pygsti/objectivefns/wildcardbudget.py
+++ b/pygsti/objectivefns/wildcardbudget.py
@@ -54,6 +54,7 @@ class WildcardBudget(_NicelySerializable):
             which can be varied when trying to find an optimal budget (similar
             to the parameters of a :class:`Model`).
         """
+        super().__init__()
         self.wildcard_vector = w_vec
 
     def to_vector(self):

--- a/pygsti/optimize/customlm.py
+++ b/pygsti/optimize/customlm.py
@@ -104,6 +104,9 @@ class Optimizer(_NicelySerializable):
         else:
             return cls(**obj) if obj else cls()
 
+    def __init__(self):
+        super().__init__()
+
 
 class CustomLMOptimizer(Optimizer):
     """
@@ -211,6 +214,7 @@ class CustomLMOptimizer(Optimizer):
                  uphill_step_threshold=0.0, init_munu="auto", oob_check_interval=0,
                  oob_action="reject", oob_check_mode=0, serial_solve_proc_threshold=100, lsvec_mode="normal"):
 
+        super().__init__()
         if isinstance(tol, float): tol = {'relx': 1e-8, 'relf': tol, 'f': 1.0, 'jac': tol, 'maxdx': 1.0}
         self.maxiter = maxiter
         self.maxfev = maxfev

--- a/pygsti/processors/processorspec.py
+++ b/pygsti/processors/processorspec.py
@@ -37,7 +37,7 @@ class ProcessorSpec(_NicelySerializable):
     """
     # base class for potentially other types of processors (not composed of just qubits)
     def __init__(self):
-        pass
+        super().__init__()
 
 
 class QuditProcessorSpec(ProcessorSpec):

--- a/pygsti/protocols/confidenceregionfactory.py
+++ b/pygsti/protocols/confidenceregionfactory.py
@@ -21,7 +21,7 @@ import scipy.stats as _stats
 from pygsti import optimize as _opt
 from pygsti import tools as _tools
 from pygsti.models.explicitcalc import P_RANK_TOL
-from pygsti.baseobjs.mongoserializable import MongoSerializable as _MongoSerializable
+from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySerializable
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
 from pygsti.circuits.circuitlist import CircuitList as _CircuitList
 from pygsti.objectivefns.objectivefns import PoissonPicDeltaLogLFunction as _PoissonPicDeltaLogLFunction
@@ -54,7 +54,7 @@ from pygsti.objectivefns.objectivefns import FreqWeightedChi2Function as _FreqWe
 #
 
 
-class ConfidenceRegionFactory(_MongoSerializable):
+class ConfidenceRegionFactory(_NicelySerializable):
     """
     An object which is capable of generating confidence intervals/regions.
 
@@ -91,6 +91,7 @@ class ConfidenceRegionFactory(_MongoSerializable):
         whenver `hessian` is, and should be left as `None` when `hessian`
         is not specified.
     """
+    collection_name = "pygsti_confidence_region_factories"
 
     def __init__(self, parent, model_lbl, circuit_list_lbl,
                  hessian=None, non_mark_radius_sq=None):
@@ -123,6 +124,7 @@ class ConfidenceRegionFactory(_MongoSerializable):
             whenver `hessian` is, and should be left as `None` when `hessian`
             is not specified.
         """
+        super().__init__()
 
         #May be specified (together) whey hessian has already been computed
         assert(hessian is None or non_mark_radius_sq is not None), \
@@ -186,57 +188,72 @@ class ConfidenceRegionFactory(_MongoSerializable):
             ret.nGaugeParams = state['num_gauge_params']
         return ret
 
-    def _to_mongodb_serialization(self, mongodb):
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing):
         #Serialize hessian matrices separately using GridFS
+        doc_id_str = str(doc['_id'])
         if self.hessian is not None:
-            import gridfs as _gridfs
             import pickle as _pickle
-            fs = _gridfs.GridFS(mongodb, collection='pygsti_gridfs')
-            hessian_id = str(fs.put(_pickle.dumps(self.hessian, protocol=2)))  # str(.) to serialize bson.ObjectId
-            inv_hessian_projection_ids = {k: str(fs.put(_pickle.dumps(v, protocol=2)))
-                                          for k, v in self.inv_hessian_projections.items()}
+            hessian_id = doc_id_str + "/hessian"
+            write_ops.add_gridfs_put_op('pygsti_gridfs', hessian_id,
+                                        _pickle.dumps(self.hessian, protocol=2),
+                                        overwrite_existing, mongodb)
+
+            inv_hessian_projection_ids = {}
+            for k, v in self.inv_hessian_projections.items():
+                inv_hessian_proj_id = doc_id_str + "/inv_hessian_projections/" + k
+                write_ops.add_gridfs_put_op('pygsti_gridfs', inv_hessian_proj_id,
+                                            _pickle.dumps(v, protocol=2), overwrite_existing, mongodb)
+                inv_hessian_projection_ids[k] = inv_hessian_proj_id
         else:
             hessian_id = None
             inv_hessian_projection_ids = {}
 
-        state = super()._to_mongodb_serialization(mongodb)
-        state.update({'model_label': self.model_lbl,
-                      'circuit_list_label': self.circuit_list_lbl,
-                      'nonmarkovian_radius_squared': self.nonMarkRadiusSq,
-                      'hessian_matrix_id': hessian_id,
-                      'hessian_projection_parameters': {k: v for k, v in self.hessian_projection_parameters.items()},
-                      'inverse_hessian_projection_ids': inv_hessian_projection_ids,
-                      'num_nongauge_params': int(self.nNonGaugeParams) if (self.nNonGaugeParams is not None) else None,
-                      'num_gauge_params': int(self.nGaugeParams) if (self.nGaugeParams is not None) else None,
-                      #Note: need int(.) casts above because int64 is *not* JSON serializable (?)
-                      #Note: we don't currently serialize self.linresponse_gstfit_params (!)
-                      })
-
-        return state
+        doc.update({'model_label': self.model_lbl,
+                    'circuit_list_label': self.circuit_list_lbl,
+                    'nonmarkovian_radius_squared': self.nonMarkRadiusSq,
+                    'hessian_matrix_id': hessian_id,
+                    'hessian_projection_parameters': {k: v for k, v in self.hessian_projection_parameters.items()},
+                    'inverse_hessian_projection_ids': inv_hessian_projection_ids,
+                    'num_nongauge_params': int(self.nNonGaugeParams) if (self.nNonGaugeParams is not None) else None,
+                    'num_gauge_params': int(self.nGaugeParams) if (self.nGaugeParams is not None) else None,
+                    #Note: need int(.) casts above because int64 is *not* JSON serializable (?)
+                    #Note: we don't currently serialize self.linresponse_gstfit_params (!)
+                    })
 
     @classmethod
-    def _from_mongodb_serialization(cls, state, mongodb):
-        if state['hessian_matrix_id'] is not None:
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb):
+        if doc['hessian_matrix_id'] is not None:
             import gridfs as _gridfs
             import pickle as _pickle
-            from bson import ObjectId as _ObjectId
             fs = _gridfs.GridFS(mongodb, collection='pygsti_gridfs')
-            hessian_mx = _pickle.loads(fs.get(_ObjectId(state['hessian_matrix_id'])).read())
-            inv_hessian_projections = {projection_lbl: _pickle.loads(fs.get(_ObjectId(projection_id)).read())
-                                       for projection_lbl, projection_id in state['inverse_hessian_projection_ids'].items()}
+            hessian_mx = _pickle.loads(fs.get(doc['hessian_matrix_id']).read())
+            inv_hessian_projections = {proj_lbl: _pickle.loads(fs.get(proj_id).read())
+                                       for proj_lbl, proj_id in doc['inverse_hessian_projection_ids'].items()}
         else:
             hessian_mx = None
             inv_hessian_projections = {}
 
-        ret = cls(None, state['model_label'], state['circuit_list_label'],
-                  hessian_mx, state['nonmarkovian_radius_squared'])
-        if 'hessian_projection_parameters' in state:
-            for projection_lbl, params in state['hessian_projection_parameters'].items():
+        ret = cls(None, doc['model_label'], doc['circuit_list_label'],
+                  hessian_mx, doc['nonmarkovian_radius_squared'])
+        if 'hessian_projection_parameters' in doc:
+            for projection_lbl, params in doc['hessian_projection_parameters'].items():
                 ret.hessian_projection_parameters[projection_lbl] = params  # (param dict is entirely JSON-able)
                 ret.inv_hessian_projections[projection_lbl] = inv_hessian_projections[projection_lbl]
-            ret.nNonGaugeParams = state['num_nongauge_params']
-            ret.nGaugeParams = state['num_gauge_params']
+            ret.nNonGaugeParams = doc['num_nongauge_params']
+            ret.nGaugeParams = doc['num_gauge_params']
         return ret
+
+    @classmethod
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        doc = mongodb[collection_name].find_one_and_delete({'_id': doc_id}, session=session)
+        if doc is not None:
+            if doc['hessian_matrix_id'] is not None:
+                import gridfs as _gridfs
+                import pickle as _pickle
+                fs = _gridfs.GridFS(mongodb, collection='pygsti_gridfs')
+                fs.delete(doc['hessian_matrix_id'], session=session)
+                for proj_id in doc['inverse_hessian_projection_ids'].values():
+                    fs.delete(proj_id, session=session)
 
     def set_parent(self, parent):
         """

--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -194,7 +194,8 @@ class Estimate(_MongoSerializable):
                               '_final_objfn_cache': 'dir-serialized-object',
                               'final_objfn_builder': 'serialized-object',
                               '_final_objfn': 'reset',
-                              '_gaugeopt_suite': 'serialized-object'
+                              '_gaugeopt_suite': 'serialized-object',
+                              '_dbcoordinates': 'none'
                               }
 
     @property

--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -27,12 +27,13 @@ from pygsti.objectivefns import objectivefns as _objfns
 from pygsti.circuits.circuitlist import CircuitList as _CircuitList
 from pygsti.circuits.circuitstructure import PlaquetteGridCircuitStructure as _PlaquetteGridCircuitStructure
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
+from pygsti.baseobjs.mongoserializable import MongoSerializable as _MongoSerializable
 
 #Class for holding confidence region factory keys
 CRFkey = _collections.namedtuple('CRFkey', ['model', 'circuit_list'])
 
 
-class Estimate(object):
+class Estimate(_MongoSerializable):
     """
     A class encapsulating the `Model` objects related to a single GST estimate up-to-gauge freedoms.
 
@@ -53,6 +54,7 @@ class Estimate(object):
         A dictionary of parameters associated with how these models
         were obtained.
     """
+    collection_name = "pygsti_estimates"
 
     @classmethod
     def from_dir(cls, dirname, quick_load=False):
@@ -78,34 +80,17 @@ class Estimate(object):
         """
         ret = cls.__new__(cls)
         ret.__dict__.update(_io.load_meta_based_dir(_pathlib.Path(dirname), 'auxfile_types', quick_load=quick_load))
+        _MongoSerializable.__init__(ret)
         for crf in ret.confidence_region_factories.values():
             crf.set_parent(ret)  # re-link confidence_region_factories
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb_collection, doc_id, quick_load=False):
-        """
-        Initialize a new Estimate object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb_collection : pymongo.collection.Collection
-            The MongoDB collection to load data from.
-
-        doc_id : str
-            The user-defined identifier of the protocol object to load.
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of components that may take
-            a long time to load.
-
-        Returns
-        -------
-        Protocol
-        """
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, quick_load=False):
+        #def from_mongodb(cls, mongodb_collection, doc_id, ):
         ret = cls.__new__(cls)
-        ret.__dict__.update(_io.read_auxtree_from_mongodb(mongodb_collection, doc_id,
-                                                          'auxfile_types', quick_load=quick_load))
+        ret.__dict__.update(_io.read_auxtree_from_mongodb_doc(mongodb, doc, 'auxfile_types', quick_load=quick_load))
+        _MongoSerializable.__init__(ret)
         for crf in ret.confidence_region_factories.values():
             crf.set_parent(ret)  # re-link confidence_region_factories
         return ret
@@ -168,6 +153,7 @@ class Estimate(object):
             A dictionary of parameters associated with how these models
             were obtained.
         """
+        super().__init__()
         self.parent = parent
         #self.parameters = _collections.OrderedDict()
         #self.goparameters = _collections.OrderedDict()
@@ -249,36 +235,14 @@ class Estimate(object):
         """
         _io.write_obj_to_meta_based_dir(self, dirname, 'auxfile_types')
 
-    def write_to_mongodb(self, mongodb_collection, doc_id=None, session=None, overwrite_existing=False):
-        """
-        Write this Estimate to a MongoDB database.
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing):
+        _io.add_obj_auxtree_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                     'auxfile_types', overwrite_existing=overwrite_existing)
 
-        Parameters
-        ----------
-        mongodb_collection : pymongo.collection.Collection
-            The MongoDB collection to write to.
-
-        doc_id : str, optional
-            The user-defined identifier of the Estimate to write.  Can be
-            left as `None` to generate a random identifier.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists.
-            Setting this to `True` mimics the behaviour of a typical filesystem, where writing
-            to a path can be done regardless of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
-        _io.write_obj_to_mongodb_auxtree(self, mongodb_collection, doc_id, 'auxfile_types',
-                                         session=session, overwrite_existing=overwrite_existing)
+    @classmethod
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        _io.remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                        recursive=recursive)
 
     @classmethod
     def remove_from_mongodb(cls, mongodb_collection, doc_id, session=None):

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -424,6 +424,7 @@ class GSTInitialModel(_NicelySerializable):
     def __init__(self, model=None, target_model=None, starting_point=None, depolarize_start=0, randomize_start=0,
                  lgst_gaugeopt_tol=1e-6, contract_start_to_cptp=False):
         # Note: starting_point can be an initial model or string
+        super().__init__()
         self.model = model
         self.target_model = target_model
         if starting_point is None:
@@ -664,6 +665,7 @@ class GSTBadFitOptions(_NicelySerializable):
                  wildcard_L1_weights=None, wildcard_primitive_op_labels=None,
                  wildcard_initial_budget=None, wildcard_methods=('neldermead',),
                  wildcard_inadmissable_action='print', wildcard1d_reference='diamond distance'):
+        super().__init__()
         valid_actions = ('wildcard', 'wildcard1d', 'Robust+', 'Robust', 'robust+', 'robust', 'do nothing')
         if not all([(action in valid_actions) for action in actions]):
             raise ValueError("Invalid action in %s! Allowed actions are %s" % (str(actions), str(valid_actions)))
@@ -694,14 +696,14 @@ class GSTBadFitOptions(_NicelySerializable):
     @classmethod
     def _from_nice_serialization(cls, state):  # memo holds already de-serialized objects
         wildcard = state.get('wildcard', {})
-        cls(state['threshold'], tuple(state['actions']),
-            wildcard.get('budget_includes_spam', True),
-            wildcard.get('L1_weights', None),
-            wildcard.get('primitive_op_labels', None),
-            wildcard.get('initial_budget', None),
-            tuple(wildcard.get('methods', ['neldermead'])),
-            wildcard.get('inadmissable_action', 'print'),
-            wildcard.get('1d_reference', 'diamond distance'))
+        return cls(state['threshold'], tuple(state['actions']),
+                   wildcard.get('budget_includes_spam', True),
+                   wildcard.get('L1_weights', None),
+                   wildcard.get('primitive_op_labels', None),
+                   wildcard.get('initial_budget', None),
+                   tuple(wildcard.get('methods', ['neldermead'])),
+                   wildcard.get('inadmissable_action', 'print'),
+                   wildcard.get('1d_reference', 'diamond distance'))
 
 
 class GSTObjFnBuilders(_NicelySerializable):
@@ -786,6 +788,7 @@ class GSTObjFnBuilders(_NicelySerializable):
         return cls(iteration_builders, final_builders)
 
     def __init__(self, iteration_builders, final_builders=()):
+        super().__init__()
         self.iteration_builders = iteration_builders
         self.final_builders = final_builders
 
@@ -856,6 +859,7 @@ class GSTGaugeOptSuite(_NicelySerializable):
             raise ValueError("Could not convert %s object to a gauge optimization suite!" % str(type(obj)))
 
     def __init__(self, gaugeopt_suite_names=None, gaugeopt_argument_dicts=None, gaugeopt_target=None):
+        super().__init__()
         if gaugeopt_suite_names is not None:
             self.gaugeopt_suite_names = (gaugeopt_suite_names,) \
                 if isinstance(gaugeopt_suite_names, str) else tuple(gaugeopt_suite_names)

--- a/pygsti/protocols/protocol.py
+++ b/pygsti/protocols/protocol.py
@@ -22,9 +22,10 @@ from pygsti import data as _data
 from pygsti.tools import NamedDict as _NamedDict
 from pygsti.tools import listtools as _lt
 from pygsti.tools.dataframetools import _process_dataframe
+from pygsti.baseobjs.mongoserializable import MongoSerializable as _MongoSerializable
 
 
-class Protocol(object):
+class Protocol(_MongoSerializable):
     """
     An analysis routine that is run on experimental data.  A generalized notion of a  QCVV protocol.
 
@@ -40,6 +41,7 @@ class Protocol(object):
         results produced by this protocol.  If None, the class name will
         be used.
     """
+    collection_name = "pygsti_protocols"
 
     @classmethod
     def from_dir(cls, dirname, quick_load=False):
@@ -66,33 +68,15 @@ class Protocol(object):
         ret = cls.__new__(cls)
         ret.__dict__.update(_io.load_meta_based_dir(_pathlib.Path(dirname), 'auxfile_types', quick_load=quick_load))
         ret._init_unserialized_attributes()
+        _MongoSerializable.__init__(ret)
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb_collection, doc_id, quick_load=False):
-        """
-        Initialize a new Protocol object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb_collection : pymongo.collection.Collection
-            The MongoDB collection to load data from.
-
-        doc_id : str
-            The user-defined identifier of the protocol object to load.
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of components that may take
-            a long time to load.
-
-        Returns
-        -------
-        Protocol
-        """
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, quick_load=False):
         ret = cls.__new__(cls)
-        ret.__dict__.update(_io.read_auxtree_from_mongodb(mongodb_collection, doc_id,
-                                                          'auxfile_types', quick_load=quick_load))
+        ret.__dict__.update(_io.read_auxtree_from_mongodb_doc(mongodb, doc, 'auxfile_types', quick_load=quick_load))
         ret._init_unserialized_attributes()
+        _MongoSerializable.__init__(ret)
         return ret
 
     def __init__(self, name=None):
@@ -113,7 +97,7 @@ class Protocol(object):
         super().__init__()
         self.name = name if name else self.__class__.__name__
         self.tags = {}  # string-values (key,val) pairs that serve to label this protocol instance
-        self.auxfile_types = {}
+        self.auxfile_types = {'_dbcoordinates': 'none'}
         self._nameddict_attributes = ()  # (('name', 'ProtocolName', 'category'),) implied in setup_nameddict
 
     def run(self, data, memlimit=None, comm=None):
@@ -155,51 +139,15 @@ class Protocol(object):
         """
         _io.write_obj_to_meta_based_dir(self, dirname, 'auxfile_types')
 
-    def write_to_mongodb(self, mongodb_collection, doc_id=None, session=None, overwrite_existing=False):
-        """
-        Write this Protocol to a MongoDB database.
-
-        Parameters
-        ----------
-        mongodb_collection : pymongo.collection.Collection
-            The MongoDB collection to write to.
-
-        doc_id : str, optional
-            The user-defined identifier of the Protocol to write.  Can be
-            left as `None` to generate a random identifier.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists and
-            doesn't match the document being written.  Setting this to `True` mimics the
-            behaviour of a typical filesystem, where writing to a path can be done regardless
-            of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
-        _io.write_obj_to_mongodb_auxtree(self, mongodb_collection, doc_id, 'auxfile_types',
-                                         session=session, overwrite_existing=overwrite_existing)
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, overwrite_existing):
+        _io.add_obj_auxtree_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                     'auxfile_types', overwrite_existing=overwrite_existing)
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb_collection, doc_id, session=None):
-        """
-        Remove a Protocol from a MongoDB database.
-
-        Returns
-        -------
-        bool
-            `True` if the specified experiment design was removed, `False` if it didn't exist.
-        """
-        delcnt = _io.remove_auxtree_from_mongodb(mongodb_collection, doc_id, 'auxfile_types',
-                                                 session=session)
-        return bool(delcnt is not None and delcnt.deleted_count == 1)
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        if recursive.protocols:
+            _io.remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                            recursive=recursive)
 
     def setup_nameddict(self, final_dict):
         """
@@ -562,7 +510,7 @@ class DefaultRunner(ProtocolRunner):
         return ret
 
 
-class ExperimentDesign(_TreeNode):
+class ExperimentDesign(_TreeNode, _MongoSerializable):
     """
     An experimental-design specification for one or more QCVV protocols.
 
@@ -610,6 +558,7 @@ class ExperimentDesign(_TreeNode):
         The category that describes the children of this object.  This
         is used as a heading for the keys of `children`.
     """
+    collection_name = "pygsti_experiment_designs"
 
     @classmethod
     def from_dir(cls, dirname, parent=None, name=None, quick_load=False):
@@ -646,6 +595,7 @@ class ExperimentDesign(_TreeNode):
         ret.__dict__.update(_io.load_meta_based_dir(dirname / 'edesign', 'auxfile_types', quick_load=quick_load))
         ret._init_children(dirname, 'edesign', quick_load=quick_load)
         ret._loaded_from = str(dirname.absolute())
+        _MongoSerializable.__init__(ret)
 
         #Fixes to JSON codec's conversion of tuples => lists
         ret.qubit_labels = tuple(ret.qubit_labels) if isinstance(ret.qubit_labels, list) else ret.qubit_labels
@@ -653,54 +603,14 @@ class ExperimentDesign(_TreeNode):
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb, doc_id, parent=None, name=None, quick_load=False, custom_collection_names=None):
-        """
-        Initialize a new ExperimentDesign object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database
-            The MongoDB instance to load data from.
-
-        doc_id : str
-            The user-defined identifier of the experiment design to load.
-
-        parent : ExperimentDesign, optional
-            The parent design object, if there is one.  Primarily used
-            internally - if in doubt, leave this as `None`.
-
-        name : str, optional
-            The sub-name of the design object being loaded, i.e. the
-            key of this data object beneath `parent`.  Only used when
-            `parent` is not None.
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of the potentially long
-            circuit lists.  This can be useful when loading takes a long time
-            and all the information of interest lies elsewhere, e.g. in an
-            encompassing results object.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different
-            types of pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
-            is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        Returns
-        -------
-        ExperimentDesign
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, parent=None, name=None, quick_load=False):
         ret = cls.__new__(cls)
-        ret.__dict__.update(_io.read_auxtree_from_mongodb(mongodb[collection_names['edesigns']], doc_id,
-                                                          'auxfile_types', quick_load=quick_load))
-        ret._init_children_from_mongodb(mongodb, 'edesigns', doc_id, custom_collection_names,
-                                        quick_load=quick_load, preloaded_edesign=None)  # we're loading the edesign now
-        ret._loaded_from = (mongodb, doc_id, custom_collection_names.copy()
-                            if (custom_collection_names is not None) else None)
+        ret.__dict__.update(_io.read_auxtree_from_mongodb_doc(mongodb, doc, 'auxfile_types', quick_load=quick_load))
+        ret._init_children_from_mongodb_doc(doc, mongodb, quick_load=quick_load)
+        _MongoSerializable.__init__(ret)
 
         #Fixes to JSON codec's conversion of tuples => lists
         ret.qubit_labels = tuple(ret.qubit_labels) if isinstance(ret.qubit_labels, list) else ret.qubit_labels
-
         return ret
 
     @classmethod
@@ -776,7 +686,7 @@ class ExperimentDesign(_TreeNode):
                               'default_protocols': 'dict:dir-serialized-object'}
 
         # because TreeNode takes care of its own serialization:
-        self.auxfile_types.update({'_dirs': 'none', '_vals': 'none', '_loaded_from': 'none'})
+        self.auxfile_types.update({'_dirs': 'none', '_vals': 'none', '_loaded_from': 'none', '_dbcoordinates': 'none'})
 
         if qubit_labels is None:
             if children:
@@ -801,7 +711,8 @@ class ExperimentDesign(_TreeNode):
             {subname: self._auto_dirname(subname) for subname in children}
 
         assert(set(children.keys()) == set(children_dirs.keys()))
-        super().__init__(children_dirs, children)
+        _MongoSerializable.__init__(self)
+        _TreeNode.__init__(self, children_dirs, children)
 
     def _auto_dirname(self, child_key):
         """ A helper function to generate a default directory name base off of a sub-name key """
@@ -966,7 +877,7 @@ class ExperimentDesign(_TreeNode):
         None
         """
         if dirname is None:
-            dirname = self._loaded_from if isinstance(self._loaded_from, str) else None
+            dirname = self._loaded_from
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
 
         _io.write_obj_to_meta_based_dir(self, _pathlib.Path(dirname) / 'edesign', 'auxfile_types')
@@ -974,86 +885,19 @@ class ExperimentDesign(_TreeNode):
         self._write_children(dirname)
         self._loaded_from = str(_pathlib.Path(dirname).absolute())  # for future writes
 
-    def write_to_mongodb(self, mongodb=None, doc_id=None, parent=None, custom_collection_names=None,
-                         session=None, overwrite_existing=False):
-        """
-        Write this experiment design to a MongoDB database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database, optional
-            The MongoDB instance to write data to.  Can be left as `None` if this
-            experiment design was initialized from a MongoDB, e.g. with
-            :function:`pygsti.io.read_edesign_from_mongodb`, in which case the same
-            database used for the initial read-in is used.
-
-        doc_id : str, optional
-            The user-defined identifier of the experiment design to write.  Can be
-            left as `None` if this experiment design was initialized from a MongoDB,
-            in which case the same document identifier that was used at read-in is used.
-
-        parent : ExperimentDesign, optional
-            The parent experiment design, when a parent is writing this
-            design as a sub-experiment-design.  Otherwise leave as None.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects.  In this case, only the `"edesigns"` key of this dictionary
-            is relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists and
-            doesn't match the document being written.  Setting this to `True` mimics the
-            behaviour of a typical filesystem, where writing to a path can be done regardless
-            of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
-        loaded_from = self._loaded_from if isinstance(self._loaded_from, tuple) else None, None, None
-
-        if mongodb is None:
-            mongodb = loaded_from[0]
-            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
-
-        if doc_id is None:
-            doc_id = loaded_from[1]
-            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
-
-        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
-            custom_collection_names = loaded_from[2]  # override if inferring document id
-
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        _io.write_obj_to_mongodb_auxtree(self, mongodb[collection_names['edesigns']], doc_id, 'auxfile_types',
-                                         session=session, overwrite_existing=overwrite_existing,
-                                         additional_meta={'children': {}})
-        self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=True,
-                                        custom_collection_names=custom_collection_names, session=session)
-        self._loaded_from = (mongodb, doc_id, custom_collection_names.copy()
-                             if (custom_collection_names is not None) else None)
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                overwrite_existing, parent=None, name=None):
+        _io.add_obj_auxtree_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                     'auxfile_types', overwrite_existing=overwrite_existing)
+        self._add_children_write_ops_and_update_doc(doc, write_ops, mongodb, overwrite_existing)
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb, doc_id, custom_collection_names=None, session=None):
-        """
-        Remove an experiment design from a MongoDB database.
-
-        Returns
-        -------
-        bool
-            `True` if the specified experiment design was removed, `False` if it didn't exist.
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        cls._remove_children_from_mongodb(mongodb, 'edesigns', doc_id, custom_collection_names, session)
-        delcnt = _io.remove_auxtree_from_mongodb(mongodb[collection_names['edesigns']], doc_id, 'auxfile_types',
-                                                 session=session)
-        return bool(delcnt is not None and delcnt.deleted_count == 1)
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        if recursive.children:
+            cls._remove_children_from_mongodb(mongodb, collection_name, doc_id, session, recursive)
+        if recursive.edesigns:
+            _io.remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                            recursive=recursive)
 
     def setup_nameddict(self, final_dict):
         """
@@ -1141,7 +985,7 @@ class ExperimentDesign(_TreeNode):
             mapped_qubit_labels = tuple([mapper[ql] for ql in self.qubit_labels]) if isinstance(mapper, dict) \
                 else tuple(map(mapper, self.qubit_labels))
         return mapped_qubit_labels
-    
+
     def map_qubit_labels(self, mapper):
         """
         Creates a new ExperimentDesign whose circuits' qubit labels are updated according to a given mapping.
@@ -1868,7 +1712,7 @@ class FreeformDesign(ExperimentDesign):
         return FreeformDesign(mapped_circuits, mapped_qubit_labels)
 
 
-class ProtocolData(_TreeNode):
+class ProtocolData(_TreeNode, _MongoSerializable):
     """
     Represents the experimental data needed to run one or more QCVV protocols.
 
@@ -1896,8 +1740,8 @@ class ProtocolData(_TreeNode):
     passes : dict
         A dictionary of the data on a per-pass basis (works even it there's just one pass).
     """
-    DATASET_COLLECTION_NAME = "datasets"  # or pygsti_datasets?
-    CACHE_COLLECTION_NAME = "caches"  # or pygsti_caches?
+    collection_name = "pygsti_protocol_data"
+    CACHE_COLLECTION_NAME = "pygsti_protocol_data_caches"
 
     @classmethod
     def from_dir(cls, dirname, parent=None, name=None, preloaded_edesign=None, quick_load=False):
@@ -1971,81 +1815,30 @@ class ProtocolData(_TreeNode):
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb, doc_id, parent=None, name=None, preloaded_edesign=None,
-                     quick_load=False, custom_collection_names=None):
-        """
-        Initialize a new ProtocolData object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database
-            The MongoDB instance to load data from.
-
-        doc_id : str
-            The user-defined identifier of the protocol data to load.
-
-        parent : ProtocolData, optional
-            The parent data object, if there is one.  This is needed for
-            sub-data objects which reference/inherit their parent's dataset.
-            Primarily used internally - if in doubt, leave this as `None`.
-
-        name : str, optional
-            The sub-name of the object being loaded, i.e. the
-            key of this data object beneath `parent`.  Only used when
-            `parent` is not None.
-
-        preloaded_edesign : ExperimentDesign, optional
-            In the case that the :class:`ExperimentDesign` object for `doc_id`
-            is already loaded, it can be passed in here.  Otherwise leave this
-            as None and it will be loaded.
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of components that may take
-            a long time, e.g. the actual raw data set(s). This can be useful
-            when loading takes a long time and all the information of interest
-            lies elsewhere, e.g. in an encompassing results object.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects.  In this case, the `"edesigns"` and `"data"` keys of this dictionary
-            are relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        Returns
-        -------
-        ProtocolData
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, parent=None, name=None,
+                                         quick_load=False, preloaded_edesign=None):
         edesign = parent.edesign[name] if parent and name else \
             (preloaded_edesign if preloaded_edesign is not None else
-             _io.read_edesign_from_mongodb(mongodb, doc_id, quick_load, comm=None,
-                                           custom_collection_names=custom_collection_names))
+             _io.read_edesign_from_mongodb(mongodb, doc['edesign_id'], quick_load=quick_load, comm=None))
 
         if quick_load:
             dataset = None  # don't load any dataset - just the cache (usually b/c loading is slow)
         else:
             #Load dataset or multidataset from database
-            ds_names = [ds_doc['name'] for ds_doc in
-                        mongodb[collection_names['data']][cls.DATASET_COLLECTION_NAME].find(
-                            {'protocoldata_parent': doc_id}, ['name'])]
-            if ds_names == [None]:
-                dataset = _io.read_dataset_from_mongodb(mongodb[collection_names['data']][cls.DATASET_COLLECTION_NAME],
-                                                        {'name': None,
-                                                         'protocoldata_parent': doc_id})
-            else:
+            if 'dataset_id' in doc:
+                dataset = _data.DataSet.from_mongodb(mongodb, doc['dataset_id'])
+            elif 'dataset_ids' in doc:
                 dataset = {}
-                for dsname in ds_names:
-                    dataset[dsname] = _io.read_dataset_from_mongodb(
-                        mongodb[collection_names['data'][cls.DATASET_COLLECTION_NAME]],
-                        {'name': dsname,
-                         'protocoldata_parent': doc_id})
+                for dsname, ds_id in doc['dataset_ids'].items():
+                    dataset[dsname] = _data.DataSet.from_mongodb(mongodb, ds_id)
 
-        cache = _io.read_dict_from_mongodb(mongodb[collection_names['data']][cls.CACHE_COLLECTION_NAME],
+        doc_id = doc['_id']
+        cache = _io.read_dict_from_mongodb(mongodb, cls.CACHE_COLLECTION_NAME,
                                            {'member': 'cache',
                                             'protocoldata_parent': doc_id})
 
         ret = cls(edesign, dataset, cache)
-        ret._init_children_from_mongodb(mongodb, 'data', doc_id, custom_collection_names,
-                                        quick_load=quick_load, preloaded_edesign=edesign)
+        ret._init_children_from_mongodb_doc(doc, mongodb, preloaded_edesign=edesign, quick_load=quick_load)
         return ret
 
     def __init__(self, edesign, dataset=None, cache=None):
@@ -2088,7 +1881,8 @@ class ProtocolData(_TreeNode):
 
         if self.edesign is None:
             self.edesign = ExperimentDesign(list(ds_to_get_circuits_from.keys()))
-        super().__init__(self.edesign._dirs, {})  # children created on-demand
+        _MongoSerializable.__init__(self)
+        _TreeNode.__init__(self, self.edesign._dirs, {})  # children created on-demand
 
     def __getstate__(self):
         # don't pickle ourself recursively if self._passdatas contains just ourself
@@ -2207,7 +2001,7 @@ class ProtocolData(_TreeNode):
         None
         """
         if dirname is None:
-            dirname = self.edesign._loaded_from if isinstance(self.edesign._loaded_from, str) else None
+            dirname = self.edesign._loaded_from
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
         dirname = _pathlib.Path(dirname)
         data_dir = dirname / 'data'
@@ -2233,138 +2027,76 @@ class ProtocolData(_TreeNode):
 
         self._write_children(dirname, write_subdir_json=False)  # writes sub-datas
 
-    def write_to_mongodb(self, mongodb, doc_id, parent=None, edesign_already_written=False,
-                         custom_collection_names=None, session=None, overwrite_existing=False):
-        """
-        Write this protocol data to a MongoDB database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database, optional
-            The MongoDB instance to write data to.  Can be left as `None` if this
-            protocol data was initialized from a MongoDB, e.g. with
-            :function:`pygsti.io.read_data_from_mongodb`, in which case the same
-            database used for the initial read-in is used.
-
-        doc_id : str, optional
-            The user-defined identifier of the protocol data to write.  Can be
-            left as `None` if this protocol data was initialized from a MongoDB,
-            in which case the same document identifier that was used at read-in is used.
-
-        parent : ProtocolData, optional
-            The parent protocol data, when a parent is writing this
-            data as a sub-protocol-data object.  Otherwise leave as None.
-
-        edesign_already_written : bool, optional
-            If `True`, the experiment design within this data object is not written to the
-            database, and it is left to the caller to ensure the experiment design is saved.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects.  In this case, the `"edesigns"` and `"data"` keys of this dictionary
-            are relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists and
-            doesn't match the document being written.  Setting this to `True` mimics the
-            behaviour of a typical filesystem, where writing to a path can be done regardless
-            of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
-        loaded_from = self.edesign._loaded_from if isinstance(self.edesign._loaded_from, tuple) else None, None, None
-
-        if mongodb is None:
-            mongodb = loaded_from[0]
-            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
-
-        if doc_id is None:
-            doc_id = loaded_from[1]
-            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
-
-        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
-            custom_collection_names = loaded_from[2]  # override if inferring document id
-
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                overwrite_existing, parent=None, name=None,
+                                                already_written_edesign_id=None):
+        #Note: adding args beyond overwrite_existing allow 1) use with TreeNode children functions, which
+        # supply 'parent' when this object is a child and 2) additional kwargs (`already_written_edesign_id` in this
+        # case) for write_to_mongodb calls
 
         #Write our class information (*not* any member data, so include_attributes == ()) to mongodb,
         # even though we don't currently use this when loading (FUTURE work)
-        _io.write_obj_to_mongodb_auxtree(self, mongodb[collection_names['data']], doc_id,
-                                         auxfile_types_member=None, include_attributes=(),
-                                         session=session, overwrite_existing=overwrite_existing)
+        _io.add_obj_auxtree_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                     auxfile_types_member=None, include_attributes=(),
+                                                     overwrite_existing=overwrite_existing)
 
-        if parent is None and not edesign_already_written:  # assume parent writes edesign
-            self.edesign.write_to_mongodb(mongodb, doc_id, None, custom_collection_names, session)
+        if already_written_edesign_id is not None:
+            doc['edesign_id'] = already_written_edesign_id
+        elif parent is not None:  # assume parent has written edesign
+            doc['edesign_id'] = parent.edesign[name]._dbcoordinates[1]
+        else:
+            doc['edesign_id'] = self.edesign.write_to_mongodb(mongodb, write_ops.session, overwrite_existing)
+            # Don't do: self.edesign.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing)
+            # because this doesn't actually perform the write, which we need to access IDs in
+            # children (via ._dbcoordinates)
 
+        doc_id = doc['_id']
         if self.dataset is not None:  # otherwise don't write any dataset
-            if parent and (self.dataset is parent.dataset):  # then no need to write any data
-                assert(mongodb[collection_names['data']][self.DATASET_COLLECTION_NAME].count_documents(
-                    {'protocoldata_parent': doc_id}, session=session) == 0)
+            if parent and (self.dataset is parent.dataset):
+                pass  # then no need to write any data
             else:
                 if isinstance(self.dataset, (_data.MultiDataSet, dict)):
+                    ds_ids = {}; ds_cnms = set()
                     for dsname, ds in self.dataset.items():
-                        _io.write_dataset_to_mongodb(ds,
-                                                     mongodb[collection_names['data']][self.DATASET_COLLECTION_NAME],
-                                                     {'name': dsname,
-                                                      'protocoldata_parent': doc_id},
-                                                     session=session)
+                        ds_ids[dsname] = ds.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing)
+                        ds_cnms.add(ds.collection_name)
+                    assert len(ds_cnms) == 0, "All datasets must be saved in *same* collection!"
+                    doc['dataset_ids'] = ds_ids
+                    doc['dataset_collection_name'] = next(iter(ds_cnms)) if (len(ds_cnms) > 0) else None
                 else:
-                    _io.write_dataset_to_mongodb(self.dataset,
-                                                 mongodb[collection_names['data']][self.DATASET_COLLECTION_NAME],
-                                                 {'name': None,
-                                                  'protocoldata_parent': doc_id},
-                                                 session=session)
+                    doc['dataset_id'] = self.dataset.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing)
+                    doc['dataset_collection_name'] = self.dataset.collection_name
 
         if self.cache:
-            _io.write_dict_to_mongodb(self.cache, mongodb[collection_names['data']][self.CACHE_COLLECTION_NAME],
-                                      {'member': 'cache',
-                                       'protocoldata_parent': doc_id},
-                                      session=session)
+            _io.add_dict_to_mongodb_write_ops(self.cache, mongodb, self.CACHE_COLLECTION_NAME,
+                                              {'member': 'cache',
+                                               'protocoldata_parent': doc_id})
 
-        self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=False,
-                                        custom_collection_names=custom_collection_names,
-                                        session=session)  # writes sub-datas
+        self._add_children_write_ops_and_update_doc(doc, write_ops, mongodb,
+                                                    overwrite_existing)  # writes sub-datas
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb, doc_id, custom_collection_names=None, session=None):
-        """
-        Remove a protocol data object from a MongoDB database.
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        doc = mongodb[collection_name].find_one({'_id': doc_id}, session=session)
+        if recursive.children:
+            cls._remove_children_from_mongodb(mongodb, collection_name, doc_id, session, recursive)
 
-        Returns
-        -------
-        bool
-            `True` if the specified data was removed, `False` if it didn't exist.
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        cls._remove_children_from_mongodb(mongodb, 'data', doc_id, custom_collection_names, session)
+        if recursive.data:
+            _io.remove_dict_from_mongodb(mongodb, cls.CACHE_COLLECTION_NAME,
+                                         {'member': 'cache',
+                                          'protocoldata_parent': doc_id},
+                                         session=session)
 
-        _io.remove_dict_from_mongodb(mongodb[collection_names['data']][cls.CACHE_COLLECTION_NAME],
-                                     {'member': 'cache',
-                                      'protocoldata_parent': doc_id},
-                                     session=session)
+            dataset_ids = doc['dataset_ids'] if ('dataset_ids' in doc) else {None: doc['dataset_id']}
+            for ds_id in dataset_ids.values():
+                _data.DataSet.remove_from_mongodb(mongodb, ds_id, doc['dataset_collection_name'], session, recursive)
 
-        for ds_doc in mongodb[collection_names['data']][cls.DATASET_COLLECTION_NAME].find(
-                {'protocoldata_parent': doc_id}, ['name']):
-            _io.remove_dataset_from_mongodb(mongodb[collection_names['data']][cls.DATASET_COLLECTION_NAME],
-                                            {'name': ds_doc['name'],
-                                             'protocoldata_parent': doc_id},
-                                            session=session)
+            # Remove ProtocolData document itself
+            _io.remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                            recursive=recursive)
 
         # Perhaps parent has already done this, but try to remove edesign anyway
-        _io.remove_edesign_from_mongodb(mongodb, doc_id, custom_collection_names, session)
-
-        # Remove ProtocolData document itself
-        delcnt = _io.remove_auxtree_from_mongodb(mongodb[collection_names['data']], doc_id, 'auxfile_types',
-                                                 session=session)
-        return bool(delcnt is not None and delcnt.deleted_count == 1)
+        _io.remove_edesign_from_mongodb(mongodb, doc['edesign_id'], session, recursive)
 
     def setup_nameddict(self, final_dict):
         """
@@ -2429,7 +2161,7 @@ class ProtocolData(_TreeNode):
         return _process_dataframe(df, pivot_valuename, pivot_value, drop_columns, preserve_order=True)
 
 
-class ProtocolResults(object):
+class ProtocolResults(_MongoSerializable):
     """
     Stores the results from running a QCVV protocol on data.
 
@@ -2444,6 +2176,7 @@ class ProtocolResults(object):
     protocol_instance : Protocol
         The protocol that created these results.
     """
+    collection_name = "pygsti_results"
 
     @classmethod
     def from_dir(cls, dirname, name, preloaded_data=None, quick_load=False):
@@ -2492,60 +2225,22 @@ class ProtocolResults(object):
         ignore = ('type',) if load_protocol else ('type', 'protocol')
         ret = cls.__new__(cls)
         ret.__dict__.update(_io.load_meta_based_dir(dirname, 'auxfile_types', ignore, quick_load=quick_load))
+        _MongoSerializable.__init__(ret)
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb, doc_id, name, preloaded_data=None, quick_load=False, custom_collection_names=None):
-        """
-        Initialize a new ProtocolResults object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database
-            The MongoDB instance to load data from.
-
-        doc_id : str
-            The user-defined identifier of the results *directory* containing the
-            results object to be loaded.
-
-        name : str
-            The name, within the directory given by `doc_id`, of the particular results
-            object to load (there can be multiple under a given `doc_id`).
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of components that may take
-            a long time, e.g. the actual raw data set(s). This can be useful
-            when loading takes a long time and all the information of interest
-            lies elsewhere, e.g. in an encompassing results object.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects. Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        Returns
-        -------
-        ProtocolResults
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        result_id = doc_id + '/' + name  # derive_child_id_from_parent_id(doc_id, name)
-        ret = cls._from_mongodb_partial(mongodb[collection_names['results']], result_id, quick_load, load_protocol=True)
-        ret.data = preloaded_data if (preloaded_data is not None) else \
-            _io.read_data_from_mongodb(mongodb, doc_id, quick_load=quick_load,
-                                       custom_collection_names=custom_collection_names)
-        assert(ret.name == name), "ProtocolResults name inconsistency!"
-        return ret
-
-    @classmethod
-    def _from_mongodb_partial(cls, mongodb_collection, result_id, quick_load=False, load_protocol=False):
-        """
-        Internal method for loading only the results-specific data, and not the `data` member.
-        This method may be used independently by derived ProtocolResults objects which contain
-        multiple sub-results (e.g. MultiPassResults)
-        """
-        ignore = ('type',) if load_protocol else ('type', 'protocol')
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, quick_load=False,
+                                         preloaded_data=None, load_protocol=True, load_data=True):
+        ignore = ('_id', 'type',) if load_protocol else ('_id', 'type', 'protocol')
         ret = cls.__new__(cls)
-        ret.__dict__.update(_io.read_auxtree_from_mongodb(mongodb_collection, result_id,
-                                                          'auxfile_types', ignore, quick_load=quick_load))
+        ret.__dict__.update(_io.read_auxtree_from_mongodb_doc(mongodb, doc, 'auxfile_types', ignore,
+                                                              quick_load=quick_load))
+        _MongoSerializable.__init__(ret)
+
+        if load_data:  # can we get rid of this?
+            ret.data = (preloaded_data if preloaded_data is not None else
+                        _io.read_data_from_mongodb(mongodb, doc['protocoldata_id'],
+                                                   quick_load=quick_load, comm=None))
         return ret
 
     def __init__(self, data, protocol_instance):
@@ -2564,10 +2259,12 @@ class ProtocolResults(object):
         -------
         ProtocolResults
         """
+        super().__init__()
         self.name = protocol_instance.name  # just for convenience in JSON dir
         self.protocol = protocol_instance
         self.data = data
-        self.auxfile_types = {'data': 'none', 'protocol': 'dir-serialized-object'}
+        self.auxfile_types = {'data': 'none', 'protocol': 'dir-serialized-object',
+                              '_dbcoordinates': 'none'}
 
     def write(self, dirname=None, data_already_written=False):
         """
@@ -2592,7 +2289,7 @@ class ProtocolResults(object):
         None
         """
         if dirname is None:
-            dirname = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, str) else None
+            dirname = self.data.edesign._loaded_from
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
 
         p = _pathlib.Path(dirname)
@@ -2615,102 +2312,25 @@ class ProtocolResults(object):
         _io.write_obj_to_meta_based_dir(self, results_dir, 'auxfile_types',
                                         omit_attributes=() if write_protocol else ('protocol',))
 
-    def write_to_mongodb(self, mongodb=None, doc_id=None, data_already_written=False,
-                         custom_collection_names=None, session=None, overwrite_existing=False):
-        """
-        Write these protocol results to a MongoDB database.
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                overwrite_existing, already_written_data_id=None):
+        if already_written_data_id is not None:
+            doc['protocoldata_id'] = already_written_data_id
+        else:
+            doc['protocoldata_id'] = self.data.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing)
 
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database, optional
-            The MongoDB instance to write data to.  Can be left as `None` if this
-            protocol data was initialized from a MongoDB, e.g. with
-            :function:`pygsti.io.read_results_from_mongodb`, in which case the same
-            database used for the initial read-in is used.
-
-        doc_id : str, optional
-            The user-defined identifier of the results *directory*. Can be
-            left as `None` if this protocol results object was initialized from a MongoDB,
-            in which case the same document identifier that was used at read-in is used.
-
-        data_already_written : bool, optional
-            Set this to True if you're sure the `.data` :class:`ProtocolData` object
-            within this results object has already been written to `mongodb`.  Leaving
-            this as the default is a safe option.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects. Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists and
-            doesn't match the document being written.  Setting this to `True` mimics the
-            behaviour of a typical filesystem, where writing to a path can be done regardless
-            of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
-        loaded_from = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, tuple) \
-            else None, None, None
-
-        if mongodb is None:
-            mongodb = loaded_from[0]
-            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
-
-        if doc_id is None:
-            doc_id = loaded_from[1]
-            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
-
-        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
-            custom_collection_names = loaded_from[2]  # override if inferring document id
-
-        #write edesign and data
-        if not data_already_written:
-            self.data.write_to_mongodb(mongodb, doc_id, custom_collection_names=custom_collection_names,
-                                       session=session, overwrite_existing=overwrite_existing)
-
-        #write qtys to results dir
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        result_id = doc_id + '/' + self.name  # derive_child_id_from_parent_id(doc_id, self.name)
-        self._write_partial_to_mongodb(mongodb[collection_names['results']], result_id, write_protocol=True,
-                                       additional_meta={'directory_id': doc_id},
-                                       session=session, overwrite_existing=overwrite_existing)
-
-    def _write_partial_to_mongodb(self, mongodb_collection, result_id, write_protocol=False,
-                                  additional_meta=None, session=None, overwrite_existing=False):
-        """
-        Internal method used to write the results-specific data to a MongoDB.
-        This method does not write the object's `data` member, which must be
-        serialized separately.
-        """
-        _io.write_obj_to_mongodb_auxtree(self, mongodb_collection, result_id,
-                                         'auxfile_types', omit_attributes=() if write_protocol else ('protocol',),
-                                         additional_meta=additional_meta, session=session,
-                                         overwrite_existing=overwrite_existing)
+        _io.add_obj_auxtree_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name, 'auxfile_types',
+                                                     overwrite_existing=overwrite_existing)
+        #omit_attributes=() if write_protocol else ('protocol',),
+        #additional_meta={'directory_id': doc_id},
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb, doc_id, name, custom_collection_names=None, session=None):
-        """
-        Remove a :class:`ProtocolResults` object from a MongoDB database.
-
-        Returns
-        -------
-        bool
-            `True` if the specified data was removed, `False` if it didn't exist.
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        result_id = doc_id + '/' + name  # derive_child_id_from_parent_id(doc_id, name)
-        delcnt = _io.remove_auxtree_from_mongodb(mongodb[collection_names['results']], result_id, 'auxfile_types',
-                                                 session=session)
-        return bool(delcnt is not None and delcnt.deleted_count == 1)
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        doc = mongodb[collection_name].find_one({'_id': doc_id}, session=session)
+        if recursive.results:
+            _io.remove_auxtree_from_mongodb(mongodb, collection_name, doc_id, 'auxfile_types', session,
+                                            recursive=recursive)
+        _io.remove_data_from_mongodb(mongodb, doc['protocoldata_id'], session, recursive)
 
     def to_nameddict(self):
         """
@@ -2894,7 +2514,7 @@ class MultiPassResults(ProtocolResults):
         return cpy
 
 
-class ProtocolResultsDir(_TreeNode):
+class ProtocolResultsDir(_TreeNode, _MongoSerializable):
     """
     Holds a dictionary of :class:`ProtocolResults` objects.
 
@@ -2926,6 +2546,7 @@ class ProtocolResultsDir(_TreeNode):
         automatically created based upon the tree given by `data`.  (To
         avoid creating any children, you can pass an empty dict here.)
     """
+    collection_name = "pygsti_results_directories"
 
     @classmethod
     def from_dir(cls, dirname, parent=None, name=None, preloaded_data=None, quick_load=False):
@@ -2981,65 +2602,23 @@ class ProtocolResultsDir(_TreeNode):
         return ret
 
     @classmethod
-    def from_mongodb(cls, mongodb, doc_id, parent=None, name=None, preloaded_data=None, quick_load=False,
-                     custom_collection_names=None):
-        """
-        Initialize a new :class:`ProtocolResultsDir` object from a Mongo database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database
-            The MongoDB instance to load data from.
-
-        doc_id : str
-            The user-defined identifier of the protocol results directory to load.
-
-        parent : ProtocolData, optional
-            The parent data object, if there is one.  This is needed for
-            sub-results objects which reference/inherit their parent's dataset.
-            Primarily used internally - if in doubt, leave this as `None`.
-
-        name : str, optional
-            The sub-name of the object being loaded, i.e. the
-            key of this data object beneath `parent`.  Only used when
-            `parent` is not None.
-
-        preloaded_data : ProtocolData, optional
-            In the case that the :class:`ProtocolData` object for `doc_id`
-            is already loaded, it can be passed in here.  Otherwise leave this
-            as None and it will be loaded.
-
-        quick_load : bool, optional
-            Setting this to True skips the loading of components that may take
-            a long time, e.g. the actual raw data set(s). This can be useful
-            when loading takes a long time and all the information of interest
-            lies elsewhere, e.g. in an encompassing results object.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        Returns
-        -------
-        ProtocolResultsDir
-        """
+    def _create_obj_from_doc_and_mongodb(cls, doc, mongodb, parent=None, name=None,
+                                         quick_load=False, preloaded_data=None):
+        data_id = doc['protocoldata_id']
         data = parent.data[name] if (parent and name) else \
             (preloaded_data if preloaded_data is not None else
-             _io.read_data_from_mongodb(mongodb, doc_id, quick_load=quick_load, comm=None,
-                                        custom_collection_names=custom_collection_names))
+             _io.read_data_from_mongodb(mongodb, data_id, quick_load=quick_load, comm=None))
+        assert data._dbcoordinates[1] == data_id, "Inconsistent preloaded vs recorded ProtocolData ID!"
 
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-
-        #Load results with directory_id == doc_id
+        #Load results with same protocoldata_id as us (we don't actually use doc['result_ids'])
         results = {}
-        for res_doc in mongodb[collection_names['results']].find({'directory_id': doc_id}, ['name', 'type']):
-            results[res_doc['name']] = _io.metadir._class_for_name(res_doc['type']).from_mongodb(
-                mongodb, doc_id, res_doc['name'], preloaded_data=data, quick_load=quick_load,
-                custom_collection_names=custom_collection_names)
+        result_collection = ProtocolResults.collection_name  # could store this in db (?)
+        for res_doc in mongodb[result_collection].find({'protocoldata_id': data_id}):
+            results[res_doc['name']] = ProtocolResults.from_mongodb_doc(mongodb, res_doc, preloaded_data=data,
+                                                                        quick_load=quick_load)
 
         ret = cls(data, results, {})  # don't initialize children now
-        ret._init_children_from_mongodb(mongodb, None, doc_id, custom_collection_names,
-                                        quick_load=quick_load, preloaded_edesign=data.edesign)
+        ret._init_children_from_mongodb_doc(doc, mongodb, preloaded_data=data, quick_load=quick_load)
         return ret
 
     def __init__(self, data, protocol_results=None, children=None):
@@ -3088,12 +2667,12 @@ class ProtocolResultsDir(_TreeNode):
         else:
             children = children.copy()
 
-        super().__init__(self.data.edesign._dirs, children)
+        _MongoSerializable.__init__(self)
+        _TreeNode.__init__(self, self.data.edesign._dirs, children)
 
     def _create_childval(self, key):  # (this is how children are created on-demand)
         """ Create the value for `key` on demand. """
-        if self.data.edesign._loaded_from and isinstance(self.data.edesign._loaded_from, str) \
-           and key in self._dirs:
+        if self.data.edesign._loaded_from and key in self._dirs:
             dirname = _pathlib.Path(self.data.edesign._loaded_from)
             subdir = self._dirs[key]
             subobj_dir = dirname / subdir
@@ -3138,7 +2717,7 @@ class ProtocolResultsDir(_TreeNode):
         None
         """
         if dirname is None:
-            dirname = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, str) else None
+            dirname = self.data.edesign._loaded_from
             if dirname is None: raise ValueError("`dirname` must be given because there's no default directory")
 
         if parent is None and not data_already_written:  # assume parent writes data
@@ -3156,113 +2735,39 @@ class ProtocolResultsDir(_TreeNode):
 
         self._write_children(dirname, write_subdir_json=False)  # writes sub-nodes
 
-    def write_to_mongodb(self, mongodb, doc_id, parent=None, data_already_written=False,
-                         custom_collection_names=None, session=None, overwrite_existing=False):
-        """
-        Write this protocol results directory to a MongoDB database.
-
-        Parameters
-        ----------
-        mongodb : pymongo.database.Database, optional
-            The MongoDB instance to write data to.  Can be left as `None` if this
-            results directory was initialized from a MongoDB, e.g. with
-            :function:`pygsti.io.read_results_from_mongodb`, in which case the same
-            database used for the initial read-in is used.
-
-        doc_id : str, optional
-            The user-defined identifier of the protocol results directory to write.  Can be
-            left as `None` if this results directory was initialized from a MongoDB,
-            in which case the same document identifier that was used at read-in is used.
-
-        parent : ProtocolResultsDir, optional
-            The parent protocol results directory, when a parent is writing this
-            data as a sub-protocol-data object.  Otherwise leave as None.
-
-        data_already_written : bool, optional
-            If `True`, the data object within this results directory is not written to the
-            database, and it is left to the caller to ensure the data object is saved.
-
-        custom_collection_names : dict, optional
-            Overrides for the default MongoDB collection names used for storing different types of
-            pyGSTi objects.  In this case, the `"edesigns"` and `"data"` keys of this dictionary
-            are relevant.  Default values are given by :method:`pygsti.io.mongodb_collection_names`.
-
-        session : pymongo.client_session.ClientSession, optional
-            MongoDB session object to use when interacting with the MongoDB
-            database. This can be used to implement transactions
-            among other things.
-
-        overwrite_existing : bool, optional
-            Whether existing documents should be overwritten.  The default of `False` causes
-            a ValueError to be raised if a document with the given `doc_id` already exists and
-            doesn't match the document being written.  Setting this to `True` mimics the
-            behaviour of a typical filesystem, where writing to a path can be done regardless
-            of whether it already exists.
-
-        Returns
-        -------
-        None
-        """
-        loaded_from = self.data.edesign._loaded_from if isinstance(self.data.edesign._loaded_from, tuple) \
-            else None, None, None
-
-        if mongodb is None:
-            mongodb = loaded_from[0]
-            if mongodb is None: raise ValueError("`mongodb` must be given because there's no default!")
-
-        if doc_id is None:
-            doc_id = loaded_from[1]
-            if doc_id is None: raise ValueError("`doc_id` must be given because there's no default!")
-
-        if custom_collection_names is None and loaded_from[2] is not None and doc_id is None:
-            custom_collection_names = loaded_from[2]  # override if inferring document id
-
-        if parent is None and not data_already_written:  # assume parent writes data
-            self.data.write_to_mongodb(mongodb, doc_id, None, custom_collection_names, session,
-                                       overwrite_existing)
-
-        ##Write our class information to mongodb, even though we don't currently use this when loading
-        #_io.write_obj_to_mongodb_auxtree(self, mongodb[collection_names['resultdirs']], doc_id,
-        #                         auxfile_types_member=None,
-        #                         omit_attributes=[...],
-        #                         session=session, overwrite_existing=overwrite_existing)
+    def _add_auxiliary_write_ops_and_update_doc(self, doc, write_ops, mongodb, collection_name,
+                                                overwrite_existing, parent=None, name=None,
+                                                already_written_data_id=None):
+        if already_written_data_id is not None:
+            doc['protocoldata_id'] = already_written_data_id
+        elif parent is not None:  # assume parent has written data
+            doc['protocoldata_id'] = parent.data[name]._dbcoordinates[1]
+        else:
+            doc['protocoldata_id'] = self.data.write_to_mongodb(mongodb, write_ops.session, overwrite_existing)
+            # Not: self.data.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing), see edesign_id comment above
 
         #write the results
+        result_ids = {}
         for name, results in self.for_protocol.items():
             assert(results.name == name)
-            results.write_to_mongodb(mongodb, doc_id, data_already_written=True,  # (always True b/c we wrote it above)
-                                     custom_collection_names=custom_collection_names, session=session)
-        self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=False,
-                                        custom_collection_names=custom_collection_names,
-                                        session=session)  # writes sub-resultdirs
+            result_ids[name] = results.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing,
+                                                             already_written_data_id=doc['protocoldata_id'])
+        doc['result_ids'] = result_ids
+        self._add_children_write_ops_and_update_doc(doc, write_ops, mongodb, overwrite_existing)
 
     @classmethod
-    def remove_from_mongodb(cls, mongodb, doc_id, custom_collection_names=None, session=None):
-        """
-        Remove a protocol results directory from a MongoDB database.
+    def _remove_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        doc = mongodb[collection_name].find_one({'_id': doc_id}, session=session)
+        if recursive.children:
+            cls._remove_children_from_mongodb(mongodb, collection_name, doc_id, session, recursive)
 
-        Returns
-        -------
-        bool
-            `True` if the specified data was removed, `False` if it didn't exist.
-        """
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        cls._remove_children_from_mongodb(mongodb, None, doc_id, custom_collection_names, session)
-
-        delcnt = 0
-        for res_doc in mongodb[collection_names['results']].find(
-                {'directory_id': doc_id}, ['name']):
-            if _io.remove_results_from_mongodb(mongodb, doc_id, res_doc['name'], comm=None,
-                                               custom_collection_names=custom_collection_names, session=session):
-                delcnt += 1
+        if recursive.results:
+            for name, result_id in doc['result_ids'].items():
+                ProtocolResults.remove_from_mongodb(mongodb, result_id, session=session, recursive=recursive)
+            mongodb[collection_name].delete_one({'_id': doc_id}, session=session)  # delete main document
 
         # Perhaps parent has already done this, but try to remove data anyway
-        _io.remove_data_from_mongodb(mongodb, doc_id, custom_collection_names, session)
-
-        #FUTURE: if we use resultdirs:
-        #delcnt = _io.remove_auxtree_from_mongodb(mongodb[collection_names['resultdirs']], doc_id, 'auxfile_types',
-        #                                         session=session)
-        return bool(delcnt >= 1)
+        _io.remove_data_from_mongodb(mongodb, doc['protocoldata_id'], session, recursive)
 
     def _result_namedicts_on_this_node(self):
         nds = [v.to_nameddict() for v in self.for_protocol.values()]

--- a/pygsti/protocols/protocol.py
+++ b/pygsti/protocols/protocol.py
@@ -1030,7 +1030,8 @@ class ExperimentDesign(_TreeNode):
 
         collection_names = _io.mongodb_collection_names(custom_collection_names)
         _io.write_obj_to_mongodb_auxtree(self, mongodb[collection_names['edesigns']], doc_id, 'auxfile_types',
-                                         session=session, overwrite_existing=overwrite_existing)
+                                         session=session, overwrite_existing=overwrite_existing,
+                                         additional_meta={'children': {}})
         self._write_children_to_mongodb(mongodb, doc_id, update_children_in_edesign=True,
                                         custom_collection_names=custom_collection_names, session=session)
 

--- a/pygsti/protocols/treenode.py
+++ b/pygsti/protocols/treenode.py
@@ -93,44 +93,32 @@ class TreeNode(object):
                 instance = self.__class__  # no meta.json - default to same class as self
                 self._vals[nm] = instance.from_dir(subobj_dir, parent=self, name=nm, **kwargs)
 
-    def _init_children_from_mongodb(self, mongodb, child_collection_key, parent_id, custom_collection_names,
-                                    preloaded_edesign=None, **kwargs):
-        #dirname = _pathlib.Path(dirname)
-        #edesign_dir = dirname / 'edesign'  # because subdirs.json is always & only in 'edesign'
-        #with open(str(edesign_dir / 'subdirs.json'), 'r') as f:
-        #    meta = _json.load(f)
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
+    def _init_children_from_mongodb_doc(self, doc, mongodb, **kwargs):
+        #if preloaded_edesign is None:
+        #    edesign_doc = mongodb[collection_names['edesigns']].find_one({'_id': parent_id})
+        #
+        #    child_id_suffixes = {}
+        #    for child_id_suffix, nm in edesign_doc.get('children', {}).items():
+        #        if isinstance(nm, list): nm = tuple(nm)  # because json makes tuples->lists
+        #        child_id_suffixes[nm] = child_id_suffix
+        #else:  # just take from already-loaded edesign
+        #    child_id_suffixes = preloaded_edesign._dirs.copy()
 
-        if preloaded_edesign is None:
-            edesign_doc = mongodb[collection_names['edesigns']].find_one({'_id': parent_id})
-
-            child_id_suffixes = {}
-            for child_id_suffix, nm in edesign_doc.get('children', {}).items():
-                if isinstance(nm, list): nm = tuple(nm)  # because json makes tuples->lists
-                child_id_suffixes[nm] = child_id_suffix
-        else:  # just take from already-loaded edesign
-            child_id_suffixes = preloaded_edesign._dirs.copy()
-
-        self._dirs = child_id_suffixes  # held as _dirs because when serialized to disk these are dir names
+        self._dirs = {nm: subdir for subdir, nm in doc['children'].items()}
         self._vals = {}
 
-        for nm, child_id_suffix in child_id_suffixes.items():
-            child_id = parent_id + '/' + child_id_suffix  # derive_child_id_from_parent_id(parent_id, child_id_suffix
-
-            if child_collection_key is not None:
-                child_doc = mongodb[collection_names[child_collection_key]].find_one({'_id': child_id})
-                if child_doc is None:  # if there's no child document, generate the child value later
-                    continue  # don't load anything - create child value on demand
-            else:
-                child_doc = {}  # child_collection_key == None signals child records are not held in db (eg result dirs)
+        for subdir, child_id in doc['children_ids'].items():
+            child_nm = doc['children'][subdir]
+            child_doc = mongodb[doc['children_collection_name']].find_one({'_id': child_id})
+            if child_doc is None:  # if there's no child document, generate the child value later
+                continue  # don't load anything - create child value on demand
 
             if 'type' in child_doc:  # if child document contains information about what type of object it is
                 classobj = _io.metadir._class_for_name(child_doc['type'])
             else:
                 classobj = self.__class__
+            self._vals[child_nm] = classobj.from_mongodb(mongodb, child_id, parent=self, name=child_nm, **kwargs)
 
-            self._vals[nm] = classobj.from_mongodb(mongodb, child_id, parent=self, name=nm,
-                                                   custom_collection_names=custom_collection_names, **kwargs)
 
     def keys(self):
         """
@@ -298,46 +286,32 @@ class TreeNode(object):
             outdir.mkdir(exist_ok=True)
             self._vals[nm].write(outdir, parent=self)
 
-    def _write_children_to_mongodb(self, mongodb, parent_id, update_children_in_edesign=True,
-                                   custom_collection_names=None, session=None):
-        """
-        TODO: docstring
-        """
-        if update_children_in_edesign:
-            #update edesign_collection[parent_id]'s 'children' attribute
-            children = {dirname: subname for subname, dirname in self._dirs.items()}  # key (dirname) is id-suffix
-            # write self._dirs "backwards" b/c json doesn't allow tuple-like keys (sometimes keys are tuples)
-            collection_names = _io.mongodb_collection_names(custom_collection_names)
-            mongodb[collection_names['edesigns']].update_one({'_id': parent_id}, {'$set': {'children': children}},
-                                                             session=session)
-
+    def _add_children_write_ops_and_update_doc(self, doc, write_ops, mongodb, overwrite_existing, **kwargs):
+        # Note: this additional args to, e.g. write_to_mongodb
+        children_names_by_subdir = {dirname: subname for subname, dirname in self._dirs.items()}
+        children_ids_by_subdir = {}; child_collection_names = []
         for nm, val in self._vals.items():  # only write *existing* values
             subdir = self._dirs[nm]
-            child_id = parent_id + '/' + subdir  # derive_child_id_from_parent_id(parent_id, subdir)
-            self._vals[nm].write_to_mongodb(mongodb, child_id, parent=self,
-                                            custom_collection_names=custom_collection_names,
-                                            session=session)
+            child_id = val.add_mongodb_write_ops(write_ops, mongodb, overwrite_existing,
+                                                 parent=self, name=nm, **kwargs)
+            children_ids_by_subdir[subdir] = child_id
+            child_collection_names.append(val.collection_name)
+        doc['children'] = children_names_by_subdir
+        doc['children_ids'] = children_ids_by_subdir
+
+        if len(child_collection_names) > 0:
+            assert all([nm == child_collection_names[0] for nm in child_collection_names]), \
+                "Children must all be in same collection!"
+            doc['children_collection_name'] = child_collection_names[0]
+        else:
+            doc['children_collection_name'] = None
 
     @classmethod
-    def _remove_children_from_mongodb(cls, mongodb, child_collection_key, parent_id,
-                                      custom_collection_names=None, session=None):
-        collection_names = _io.mongodb_collection_names(custom_collection_names)
-        edesign_doc = mongodb[collection_names['edesigns']].find_one({'_id': parent_id}, ['children'], session=session)
-
-        if edesign_doc is None:
-            return
-
-        for child_id_suffix in edesign_doc.get('children', {}).keys():
-            child_id = parent_id + '/' + child_id_suffix  # derive_child_id_from_parent_id(parent_id, child_id_suffix
-            if child_collection_key is not None:
-                child_doc = mongodb[collection_names[child_collection_key]].find_one({'_id': child_id}, session=session)
-                if child_doc is None:
-                    continue
-            else:
-                child_doc = {}
-
-            if 'type' in child_doc:  # if child document contains information about what type of object it is
-                classobj = _io.metadir._class_for_name(child_doc['type'])
-            else:
-                classobj = cls
-            classobj.remove_from_mongodb(mongodb, child_id, parent_id, custom_collection_names, session=session)
+    def _remove_children_from_mongodb(cls, mongodb, collection_name, doc_id, session, recursive):
+        from pygsti.baseobjs.mongoserializable import MongoSerializable as _MongoSerializable
+        doc = mongodb[collection_name].find_one({'_id': doc_id})
+        if doc is not None:
+            for subdir, child_id in doc['children_ids'].items():
+                #print(f"DB: Removing {str(cls.__name__)} child dir: {subdir} (id {child_id})")
+                _MongoSerializable.remove_from_mongodb(mongodb, child_id, doc['children_collection_name'],
+                                                       session, recursive)

--- a/pygsti/tools/nameddict.py
+++ b/pygsti/tools/nameddict.py
@@ -72,7 +72,8 @@ class NamedDict(dict, _NicelySerializable):
         return head[None]
 
     def __init__(self, keyname=None, keytype=None, valname=None, valtype=None, items=()):
-        super().__init__(items)
+        dict.__init__(self, items)
+        _NicelySerializable.__init__(self)
         self.keyname = keyname
         self.valname = valname
         self.keytype = keytype

--- a/test/unit/io/test_mongo.py
+++ b/test/unit/io/test_mongo.py
@@ -29,15 +29,11 @@ class MongoDBTester(BaseCase):
         edesign = std.create_gst_experiment_design(1)
         #len(edesign.all_circuits_needing_data)  # 92
 
-        bRemoved = pygsti.protocols.ExperimentDesign.remove_from_mongodb(self.mydb, "my_test_edesign")
-        self.assertFalse(bRemoved)
-
-        edesign.write_to_mongodb(self.mydb, "my_test_edesign")
-        edesign2 = pygsti.io.read_edesign_from_mongodb(self.mydb, "my_test_edesign")
+        edesign_id = edesign.write_to_mongodb(self.mydb)
+        edesign2 = pygsti.io.read_edesign_from_mongodb(self.mydb, edesign_id)
         self.assertEqual(len(edesign2.all_circuits_needing_data), len(edesign.all_circuits_needing_data))
 
-        bRemoved = pygsti.protocols.ExperimentDesign.remove_from_mongodb(self.mydb, "my_test_edesign")
-        self.assertTrue(bRemoved)
+        edesign2.remove_me_from_mongodb(self.mydb)
 
     @unittest.skipUnless(PYMONGO_IMPORTED, "pymongo not installed")
     def test_mongodb_data(self):
@@ -46,16 +42,11 @@ class MongoDBTester(BaseCase):
         ds = pygsti.data.simulate_data(datagen_mdl, edesign, 1000, seed=123456)
         data = pygsti.protocols.ProtocolData(edesign, ds)
 
-        bRemoved = pygsti.protocols.ProtocolData.remove_from_mongodb(self.mydb, "my_test_data")
-        self.assertFalse(bRemoved)
-
-        data.write_to_mongodb(self.mydb, "my_test_data")
-        data2 = pygsti.io.read_data_from_mongodb(self.mydb, "my_test_data")
-        self.assertTrue(isinstance(data2.edesign._loaded_from[0], pymongo.database.Database))
+        data_id = data.write_to_mongodb(self.mydb)
+        data2 = pygsti.io.read_data_from_mongodb(self.mydb, data_id)
         self.assertEqual(len(data.dataset), len(data2.dataset))
 
-        bRemoved = pygsti.protocols.ProtocolData.remove_from_mongodb(self.mydb, "my_test_data")
-        self.assertTrue(bRemoved)
+        pygsti.protocols.ProtocolData.remove_from_mongodb(self.mydb, data_id)
 
     @unittest.skipUnless(PYMONGO_IMPORTED, "pymongo not installed")
     def test_mongodb_results(self):
@@ -67,13 +58,8 @@ class MongoDBTester(BaseCase):
         gst = pygsti.protocols.StandardGST('full TP')
         results = gst.run(data)
 
-        bRemoved = pygsti.protocols.ProtocolResultsDir.remove_from_mongodb(self.mydb, "my_test_results")
-        self.assertFalse(bRemoved)
-
-        results.write_to_mongodb(self.mydb, "my_test_results")
-        resultsdir2 = pygsti.io.read_results_from_mongodb(self.mydb, 'my_test_results')
-        results2 = resultsdir2.for_protocol['StandardGST']
+        results_id = results.write_to_mongodb(self.mydb)
+        results2 = pygsti.io.read_results_from_mongodb(self.mydb, results_id)
 
         self.assertTrue(isinstance(results2.estimates['full TP'].models['target'], pygsti.models.Model))
-        bRemoved = pygsti.protocols.ProtocolResultsDir.remove_from_mongodb(self.mydb, "my_test_results")
-        self.assertTrue(bRemoved)
+        results2.remove_me_from_mongodb(self.mydb)


### PR DESCRIPTION
**Upgrades MongoDB serialization framework to be more powerful and efficient**

Updates the structure of pyGSTi objects stored in a MongoDB database so that now:
1.  objects are identified by a normal `bson.objectid.ObjectId` identifier, rather than a filesystem-like path.
2.  a parent object holds the IDs of its child or attribute documents within its "main" document.

This results in a more typical data model and allows documents to serve in a many-to-one capacity, improving space efficiency.  For example, an experiment design can be linked to multiple protocol data objects and a circuit document can be referenced by multiple experiment designs and/or data sets.  This could result in massive data saving by not having to duplicate, e.g., circuits shared by many different experiment designs.

Internally, the `MongoSerializable` base class has been elevated in importance and now serves as the base class for both large (experiment design, protocol data, and results) objects and small `NicelySerializable`-derived objects.  This allows nearly all of pyGSTi's objects to be serialized to a MongoDB using the same interface.

This PR marks a point where the MongoDB support is much more complete and established than it was.  I expect we'll still want to tweak some things before the format stabilizes completely, but this seems to be almost there.  The biggest issue regards removing documents, which should be done with care as they can now be shared, e.g. have multiple parent objects.

Unit tests exist and have been updated, but are not very extensive at this point.