### PR TITLE
Bugfix numpy deprecations

### DIFF
--- a/pygsti/baseobjs/qubitgraph.py
+++ b/pygsti/baseobjs/qubitgraph.py
@@ -188,12 +188,12 @@ class QubitGraph(_NicelySerializable):
 
         #Determine whether we'll be using directions or not: set self.directions
         if initial_connectivity is not None:
-            if initial_connectivity.dtype == _np.bool:
+            if initial_connectivity.dtype == _np.bool_:
                 assert(direction_names is None), \
                     "`initial_connectivity` must hold *integer* direction-indices when `direction_names` is non-None"
             else:
                 #TODO: fix numpy integer-type test here
-                assert(initial_connectivity.dtype == _np.int or initial_connectivity.dtype == _np.int64), \
+                assert(initial_connectivity.dtype == _np.int_ or initial_connectivity.dtype == _np.int64), \
                     ("`initial_connectivity` can only have dtype == bool or "
                      "int (but has dtype=%s)") % str(initial_connectivity.dtype)
                 assert(direction_names is not None), \

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -75,7 +75,7 @@ def _np_to_quil_def_str(name, input_array):
 def _num_to_rqc_str(num):
     """Convert float to string to be included in RQC quil DEFGATE block
     (as written by _np_to_quil_def_str)."""
-    num = _np.complex(_np.real_if_close(num))
+    num = _np.complex_(_np.real_if_close(num))
     if _np.imag(num) == 0:
         output = str(_np.real(num))
         return output

--- a/pygsti/circuits/circuitstructure.py
+++ b/pygsti/circuits/circuitstructure.py
@@ -152,7 +152,7 @@ class CircuitPlaquette(_NicelySerializable):
                 ret[i, j] = sum(elementvec[layout.indices(opstr)])
         elif '%' in mergeop:
             fmt = mergeop
-            ret = _np.nan * _np.ones((self.num_rows, self.num_cols), dtype=_np.object)
+            ret = _np.nan * _np.ones((self.num_rows, self.num_cols), dtype=_np.object_)
             for (i, j), opstr in self.elements.items():
                 ret[i, j] = ", ".join(["NaN" if _np.isnan(x) else
                                        (fmt % x) for x in elementvec[layout.indices(opstr)]])

--- a/pygsti/data/datacomparator.py
+++ b/pygsti/data/datacomparator.py
@@ -75,11 +75,11 @@ def _loglikelihood_ratio(n_list_list):
         The log-likehood ratio for this model comparison.
     """
     nListC = _np.sum(n_list_list, axis=0)
-    pListC = nListC / _np.float(_np.sum(nListC))
+    pListC = nListC / _np.float_(_np.sum(nListC))
     lC = _loglikelihood(pListC, nListC)
     li_list = []
     for nList in n_list_list:
-        pList = _np.array(nList) / _np.float(_np.sum(nList))
+        pList = _np.array(nList) / _np.float_(_np.sum(nList))
         li_list.append(_loglikelihood(pList, nList))
     lS = _np.sum(li_list)
     return -2 * (lC - lS)

--- a/pygsti/extras/crosstalk/core.py
+++ b/pygsti/extras/crosstalk/core.py
@@ -937,7 +937,7 @@ def pairwise_indep_expts(q):
     for i in range(q):
         for a in range(q):
             for b in range(q):
-                vals[a*q+b,i] = _np.int(_np.mod(a*i+b,q))
+                vals[a*q+b,i] = _np.int_(_np.mod(a*i+b,q))
 
     length = _np.shape(vals)[0]
     return length, vals

--- a/pygsti/report/workspace.py
+++ b/pygsti/report/workspace.py
@@ -1426,7 +1426,7 @@ class SwitchValue(object):
         self.dependencies = dependencies
 
         shape = [len(self.parent.positionLabels[i]) for i in dependencies]
-        self.base = _np.empty(shape, dtype=_np.object)
+        self.base = _np.empty(shape, dtype=_np.object_)
         index_all = (slice(None, None),) * len(shape)
         self.base[index_all] = NotApplicable(self.ws)
 

--- a/pygsti/report/workspaceplots.py
+++ b/pygsti/report/workspaceplots.py
@@ -1956,7 +1956,7 @@ def _outcome_to_str(x):  # same function as in writers.py
 
 
 def _addl_mx_fn_outcomes(plaq, x, y, layout):
-    slmx = _np.empty((plaq.num_rows, plaq.num_cols), dtype=_np.object)
+    slmx = _np.empty((plaq.num_rows, plaq.num_cols), dtype=_np.object_)
     for i, j, opstr in plaq:
         slmx[i, j] = ", ".join([_outcome_to_str(ol) for ol in layout.outcomes(opstr)])
     return slmx

--- a/pygsti/tools/group.py
+++ b/pygsti/tools/group.py
@@ -29,7 +29,7 @@ def is_integer(x):
     bool
     """
     #TODO: combine with compattools.isint(x) ??
-    return bool(isinstance(x, int) or isinstance(x, _np.integer))
+    return bool(isinstance(x, int) or isinstance(x, _np.int_))
 
 
 def construct_1q_clifford_group():

--- a/test/unit/objects/test_qibo_evotype.py
+++ b/test/unit/objects/test_qibo_evotype.py
@@ -25,7 +25,7 @@ try:
     import qibo as _qibo
     if version.parse(_qibo.__version__) < version.parse("0.1.7"):
         _qibo = None  # version too low - doesn't contain all the builtin gates, e.g. qibo.gates.S
-except ImportError, AttributeError:
+except (ImportError, AttributeError):
     _qibo = None
 
 

--- a/test/unit/objects/test_qibo_evotype.py
+++ b/test/unit/objects/test_qibo_evotype.py
@@ -8,7 +8,14 @@ from pygsti.models import create_crosstalk_free_model
 from pygsti.circuits import Circuit
 from pygsti.modelpacks import smq2Q_XYI as std
 from pygsti.modelpacks import smq1Q_XYI as std1Q
-from pygsti.evotypes import qibo as evo_qibo  # don't clobber qibo!
+
+#Deprecated numpy calls are currently breaking the qibo import
+#so add in a catch for this exception and skip this test if that happens.
+try:
+    from pygsti.evotypes import qibo as evo_qibo  # don't clobber qibo!
+except AttributeError:
+    _qibo = None
+
 from pygsti.evotypes.densitymx_slow.opreps import OpRepIdentityPlusErrorgen
 from pygsti.evotypes.densitymx.opreps import OpRepDenseSuperop
 from ..util import BaseCase

--- a/test/unit/objects/test_qibo_evotype.py
+++ b/test/unit/objects/test_qibo_evotype.py
@@ -20,11 +20,12 @@ from pygsti.evotypes.densitymx_slow.opreps import OpRepIdentityPlusErrorgen
 from pygsti.evotypes.densitymx.opreps import OpRepDenseSuperop
 from ..util import BaseCase
 
+#also catch the attribute error here
 try:
     import qibo as _qibo
     if version.parse(_qibo.__version__) < version.parse("0.1.7"):
         _qibo = None  # version too low - doesn't contain all the builtin gates, e.g. qibo.gates.S
-except ImportError:
+except ImportError, AttributeError:
     _qibo = None
 
 


### PR DESCRIPTION
I took an initial pass at fixing the calls to the newly deprecated dtype aliases. I think I got everything in our codebase, but there are some broken calls in qibo that cause the import to die, and related unit tests to fail, so these have been temporarily disabled. There are a couple more unit tests that are failing, but these are related to germ selection and seem to be broken for a different reason (I suspect for a disjoint numpy change given the error messages). For the sake of having a clean commit history I am going to fix those problems on another branch where I also look into the edge case @enielse showed me about when the initial set of germs in germ selection is empty. So I'm requesting we merge this in even though there are still some failing tests.