### PR TITLE
Bugfix germsel initialization

### DIFF
--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -1479,8 +1479,7 @@ def find_germs_depthfirst(model_list, germs_list, randomize=True,
     if force:
         if force == "singletons":
             weights[_np.where(germLengths == 1)] = 1
-            goodGerms = [germ for germ
-                         in _np.array(germs_list)[_np.where(germLengths == 1)]]
+            goodGerms = [germ for i, germ in enumerate(germs_list) if germLengths[i] == 1]
         else:  # force should be a list of Circuits
             for opstr in force:
                 weights[germs_list.index(opstr)] = 1


### PR DESCRIPTION
This should fix the last two failing unit tests, which I believe were failing due to a numpy 1.24.0 related change (though not one easily ascertained from the changelog). These lines of codes haven't been touched in a very long time, so there isn't any other reason I can think of for them suddenly breaking.

Anyhow, I haven't yet resolved the other problem @enielse noticed when the list of forced germs is empty, but I don't think I'll get around to that until after we push the release (I can aim for whenever the first hotfix we push to master is).
