### PR TITLE
Bugfix neverending windows integers

### DIFF
--- a/pygsti/baseobjs/qubitgraph.py
+++ b/pygsti/baseobjs/qubitgraph.py
@@ -188,7 +188,7 @@ class QubitGraph(_NicelySerializable):
 
         #Determine whether we'll be using directions or not: set self.directions
         if initial_connectivity is not None:
-            if initial_connectivity.dtype == _np.bool:
+            if initial_connectivity.dtype == _np.bool_:
                 assert(direction_names is None), \
                     "`initial_connectivity` must hold *integer* direction-indices when `direction_names` is non-None"
             else:

--- a/pygsti/tools/sharedmemtools.py
+++ b/pygsti/tools/sharedmemtools.py
@@ -138,7 +138,9 @@ def create_shared_ndarray(resource_alloc, shape, dtype, zero_out=False, memory_t
     else:
         if memory_tracker: memory_tracker.add_tracked_memory(nelements // hostcomm.size)
         if hostcomm.rank == 0:
-            shm = _shared_memory.SharedMemory(create=True, size=nelements * _np.dtype(dtype).itemsize)
+            #SharedMemory expects the size to be a python integer of the same type used as
+            #system default.
+            shm = _shared_memory.SharedMemory(create=True, size= int(nelements * _np.dtype(dtype).itemsize))
             assert(shm.size >= nelements * _np.dtype(dtype).itemsize)  # Note: not always == (minimum shm.size?)
             hostcomm.bcast(shm.name, root=0)
         else:


### PR DESCRIPTION
Straightforward bugfix related to the shared memory module of the multiprocessing library expecting default system integers for the size argument for some reason, which on windows are 32-bit. I think the second fix has already been subsumed by other numpy dtype fixes.