### PR TITLE
Bugfix forced germs

### DIFF
--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -3823,7 +3823,10 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
             first_outer_iter_log= False
             printer.log('Initial germ list is AC, concluding search: ' + str(goodGerms), 2)
         else:
-            initN=None
+            #less than ideal, but it looks like initN needs to be initialized to 1 instead of None
+            #as the placeholder if I don't want to dive into the score calculation code again to
+            #fix things at a high-effort to low-reward ratio (I don't).
+            initN=1
             first_outer_iter_log= True
             printer.log('Initial germ list is not AC, beginning greedy search loop.', 2)
     else:

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -220,6 +220,19 @@ def find_germs(target_model, randomize=True, randomization_strength=1e-2,
     
     printer.log('Length Available Germ List After Dropping Random Fraction: '+ str(len(availableGermsList)), 1)
     
+    #If we have specified a user specified germs to force inclusion of then there is a chance
+    #they got removed by the deduping and removal of random circuits above. The right way to fix this
+    #would be to add some logic to those subroutines that prevent this, but for now I am going to just 
+    #manually add them back in (this will result almost suredly in a couple duplicate circuits, but oh well).
+    if force is not None:
+        #iterate through the list of forced germs to check for inclusion and
+        #if missing append to the list of available germs.
+        if isinstance(force, list):
+            for forced_germ in force:
+                if not forced_germ in availableGermsList:
+                    availableGermsList.append(forced_germ)
+        printer.log('Length Available Germ List After Adding Back In Forced Germs: '+ str(len(availableGermsList)), 1)
+    
     #Add some checks related to the new option to switch up data types:
     if not assume_real:
         if not (float_type is _np.cdouble or float_type is _np.csingle):
@@ -3585,6 +3598,7 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
             for opstr in force:
                 weights[germs_list.index(opstr)] = 1
             goodGerms = force[:]
+            printer.log('Adding User-Specified Germs By Default: '+ str(goodGerms) ,1)
             
     #We should do the memory estimates before the pretest:
     FLOATSIZE= float_type(0).itemsize

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -3799,9 +3799,16 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
         raise ValueError("Invalid mode: %s" % mode)  # pragma: no cover
 
     initN = 1
+    #add a flag to fix a logging bug
+    first_outer_iter=True
     while _np.any(weights == 0):
-        printer.log("Outer iteration: %d of %d amplified, %d germs" %
-                    (initN, numNonGaugeParams, len(goodGerms)), 2)
+        if first_outer_iter:
+            printer.log("Outer iteration: %d germs" %
+                        (len(goodGerms)), 2)
+            first_outer_iter=False
+        else:
+            printer.log("Outer iteration: %d of %d amplified, %d germs" %
+                        (initN, numNonGaugeParams, len(goodGerms)), 2)
         # As long as there are some unused germs, see if you need to add
         # another one.
         if initN == numNonGaugeParams:

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -3786,14 +3786,12 @@ def find_germs_breadthfirst_greedy(model_list, germs_list, randomize=True,
         nonzero_weight_indices= nonzero_weight_indices[0]
         for i, derivDaggerDeriv in enumerate(twirledDerivDaggerDerivList):
             #reconstruct the needed J^T J matrices
-            temp_DDD = None
             for j, idx in enumerate(nonzero_weight_indices):
                 if j==0:
                     temp_DDD = derivDaggerDeriv[idx] @ derivDaggerDeriv[idx].T
                 else:
                     temp_DDD += derivDaggerDeriv[idx] @ derivDaggerDeriv[idx].T
-            if temp_DDD is not None:
-                currentDDDList.append(temp_DDD)
+            currentDDDList.append(temp_DDD)
 
     else:  # should be unreachable since we set 'mode' internally above
         raise ValueError("Invalid mode: %s" % mode)  # pragma: no cover

--- a/test/unit/algorithms/test_germselection.py
+++ b/test/unit/algorithms/test_germselection.py
@@ -339,3 +339,31 @@ class GreedyGermSelectionTester(GermSelectionWithNeighbors, BaseCase):
                                    candidate_germ_counts={3: 'all upto', 4: 10, 5:10, 6:10},
                                    randomize=False, algorithm='greedy', mode='compactEVD',
                                    assume_real=True, float_type=np.double,  verbosity=1)
+                                   
+    def test_forced_germs_none(self):
+        # TODO assert correctness
+        #make sure that the germ selection doesn't die with force is None
+        germs_compactEVD = germsel.find_germs(std.target_model(), seed=2017, 
+                                   candidate_germ_counts={3: 'all upto', 4: 10, 5:10, 6:10},
+                                   randomize=False, algorithm='greedy', mode='compactEVD',
+                                   assume_real=True, float_type=np.double,  verbosity=1, force=None)
+        germs_allJac = germsel.find_germs(std.target_model(), seed=2017, 
+                                   candidate_germ_counts={3: 'all upto', 4: 10, 5:10, 6:10},
+                                   randomize=False, algorithm='greedy', mode='all-Jac',
+                                   assume_real=True, float_type=np.double,  verbosity=1, force=None)
+        germs_singleJac = germsel.find_germs(std.target_model(), seed=2017, 
+                                   candidate_germ_counts={3: 'all upto', 4: 10, 5:10, 6:10},
+                                   randomize=False, algorithm='greedy', mode='single-Jac',
+                                   assume_real=True, float_type=np.double,  verbosity=1, force=None)
+    
+    def test_force_germs_outside_candidate_set(self):
+        #TODO assert correctness
+        #make sure that the germ selection doesn't die when the list of forced germs includes circuits
+        #outside the initially specified candidate set.
+        germs = germsel.find_germs(std.target_model(), seed=2017, 
+                                   candidate_germ_counts={3: 'all upto', 4: 10, 5:10, 6:10},
+                                   randomize=False, algorithm='greedy', mode='compactEVD',
+                                   assume_real=True, float_type=np.double,  verbosity=1, 
+                                   force=pc.list_random_circuits_onelen(fixtures.opLabels, length=7, count=2, seed=_SEED))
+                                   
+        


### PR DESCRIPTION
This PR adds bugfixes related to the handling of the 'force' argument in the germ selection algorithms. Three different issues were identified and have been patched:

1. There was no support for the case where force=None, and as such the initial germ set fed into the greedy search loop was empty. This case is now fully supported, with the algorithm doing a greedy initialization (choosing the germ from the candidate list with the highest score) to select the first germ.
2. When passing in a user-specified list of germs for the value of force an edge case arose when, for various possible reasons, the user-specified list included circuits that were not part of the search space. There is now logic to detect when this happens and explicitly add these extra germs to the search space if required.
3. There is now an extra check, following the initial germ set construction but before the main optimization loop, for whether the initially constructed germ set is already itself amplificationally complete. Before, the first time this was checked was at the end of the first iteration of the greedy search loop, meaning that you'd always go through one round of greedy search (and add one additional germ to the set) before checking whether the set was AC for the first time. Most of the time this is fine in practice, since usually the initial set isn't AC, but an edge case that broke in the interpygate test suite highlighted that this wasn't what would be considered expected behavior. If the initial set is AC we now return that set and short-circuit the rest of the search. This check can be disabled with a kwarg passed to the greedy search algorithm, which can save some computation time when a users knows the initial set won't be AC.

Finally, there are a couple extra unit tests to cover cases 1 and 2 above.