### PR TITLE
Replace deprecated function calls to inspect module

### DIFF
--- a/pygsti/report/workspace.py
+++ b/pygsti/report/workspace.py
@@ -268,17 +268,16 @@ class Workspace(object):
     def _makefactory(self, cls, autodisplay):  # , printer=_objs.VerbosityPrinter(1)):
         # XXX this indirection is so wild -- can we please rewrite directly?
         #Manipulate argument list of cls.__init__
-        argspec = _inspect.getargspec(cls.__init__)
-        argnames = argspec[0]
+        argspec = _inspect.getfullargspec(cls.__init__)
+        argsig = _inspect.signature(cls.__init__)
+        argnames = argspec.args
         assert(argnames[0] == 'self' and argnames[1] == 'ws'), \
             "__init__ must begin with (self, ws, ...)"
-
-        factoryfn_argnames = argnames[2:]  # strip off self & ws args
-        newargspec = (factoryfn_argnames,) + argspec[1:]
-
+        
+        newargsig = argsig.replace(parameters= list(argsig.parameters.values())[2:])
+        
         #Define a new factory function with appropriate signature
-        signature = _inspect.formatargspec(
-            formatvalue=lambda val: "", *newargspec)
+        signature = str(newargsig)
         signature = signature[1:-1]  # strip off parenthesis from ends of "(signature)"
 
         if autodisplay:


### PR DESCRIPTION
This PR patches some deprecated function calls from the python inspect module that have been deprecated as of python 3.11. Patch courtesy of @sserita.