### PR TITLE
Improve performance of GST

### DIFF
--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -779,7 +779,6 @@ class LindbladCoefficientBlock(_NicelySerializable):
         v : numpy.ndarray
             A 1D array of real parameter values.
         """
-
         if self._param_mode == 'static':
             assert(len(v) == 0), "'static' paramterized blocks should have zero parameters!"
             return  # self.block_data remains the same - no update

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -779,6 +779,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
         v : numpy.ndarray
             A 1D array of real parameter values.
         """
+
         if self._param_mode == 'static':
             assert(len(v) == 0), "'static' paramterized blocks should have zero parameters!"
             return  # self.block_data remains the same - no update
@@ -817,10 +818,10 @@ class LindbladCoefficientBlock(_NicelySerializable):
                 #  cache_mx[i,i] = params[i,i]
                 #  cache_mx[i,j] = params[i,j] + 1j*params[j,i] (i > j)
                 cache_mx = self._cache_mx
+                iparams = 1j * params
                 for i in range(num_bels):
                     cache_mx[i, i] = params[i, i]
-                    for j in range(i):
-                        cache_mx[i, j] = params[i, j] + 1j * params[j, i]
+                    cache_mx[i, :i] = params[i, :i] + iparams[:i, i]
 
                 #The matrix of (complex) "other"-coefficients is build by assuming
                 # cache_mx is its Cholesky decomp; means otherCoeffs is pos-def.
@@ -839,11 +840,11 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
             elif self._param_mode == "elements":  # params mx stores block_data (hermitian) directly
                 #params holds block_data real and imaginary parts directly
+                iparams = 1j * params
                 for i in range(num_bels):
                     self.block_data[i, i] = params[i, i]
-                    for j in range(i):
-                        self.block_data[i, j] = params[i, j] + 1j * params[j, i]
-                        self.block_data[j, i] = params[i, j] - 1j * params[j, i]
+                    self.block_data[i, :i] = params[i, :i] + iparams[:i, i]
+                    self.block_data[:i, i] = params[i, :i] - iparams[:i, i]
             else:
                 raise ValueError("Internal error: invalid parameter mode (%s) for block type %s!"
                                  % (self._param_mode, self._block_type))

--- a/pygsti/objectivefns/objectivefns.py
+++ b/pygsti/objectivefns/objectivefns.py
@@ -4561,7 +4561,7 @@ class TimeIndependentMDCObjectiveFunction(MDCObjectiveFunction):
         -------
         numpy.ndarray
         """
-        omitted_probs = 1.0 - _np.array([_np.sum(probs[self.layout.indices_for_index(i)])
+        omitted_probs = 1.0 - _np.array([probs[self.layout.indices_for_index(i)].sum()
                                          for i in self.indicesOfCircuitsWithOmittedData])
         return self.raw_objfn.zero_freq_terms(self.total_counts[self.firsts], omitted_probs)
 


### PR DESCRIPTION
This PR improves performance of 2-qubit GST 

* Vectorize `LindbladCoefficientBlock.from_vector`. Replacing the loop over `i` reduces the overhead for 2-qubit gst (where `num_bels=15`). In microbenchmarks this is a factor 6 faster
* Replace call to `_np.sum` to direct call of `sum()`. In microbencmark this is 33% faster.
