### PR TITLE
Switch from cirq to cirq-core in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ extras = {
         'seaborn',
         'ply',
         'qibo<=0.1.7',
-        'cirq',
+        'cirq-core',
         'notebook',
         'ipython'
     ]


### PR DESCRIPTION
This commit switches the cirq dependency to cirq-core from cirq. Recently we've begun having pip installation issues due to unresolvable dependency conflicts (both locally and on the github runners). I traced this back to cirq, and while I haven't definitively proven this I think that it is specifically a dependency issue with the cirq-rigetti submodule. When installing cirq it will by default include all of the optional submodules, most of which are specific hardware platform interface code which isn't needed for our purposes (which is just the ability to output cirq circuit objects). So we should be fine switching to cirq-core (which includes all of the core functionality we need) and avoiding installation of all of the extra submodules altogether. If a user wants that they can figure out the dependency issues for whichever hardware backend they want to connect to with cirq on their end.