### PR TITLE
Fixes gpindices initialization issue in TPPOVM.

### DIFF
--- a/pygsti/modelmembers/povms/complementeffect.py
+++ b/pygsti/modelmembers/povms/complementeffect.py
@@ -43,7 +43,7 @@ class ComplementPOVMEffect(_ConjugatedStatePOVMEffect):
         "complement" POVM effect vector.
     """
 
-    def __init__(self, identity, other_effects):
+    def __init__(self, identity, other_effects, called_from_reduce=False):
         evotype = other_effects[0]._evotype
         state_space = other_effects[0].state_space
 
@@ -62,8 +62,11 @@ class ComplementPOVMEffect(_ConjugatedStatePOVMEffect):
         # 2) set the gpindices of the elements of other_spamvecs so
         #    that they index into our local parameter vector.
 
-        _ConjugatedStatePOVMEffect.__init__(self, self.identity.copy())
-        self.init_gpindices()  # initialize our gpindices based on sub-members
+        _ConjugatedStatePOVMEffect.__init__(self, self.identity.copy(), called_from_reduce)
+        if not called_from_reduce:
+            self.init_gpindices()  # initialize our gpindices based on sub-members
+        else:
+            self.allocate_gpindices(10000, None, submembers_already_allocated=True)
         self._construct_vector()  # reset's self.base
 
     def _construct_vector(self):

--- a/pygsti/modelmembers/povms/conjugatedeffect.py
+++ b/pygsti/modelmembers/povms/conjugatedeffect.py
@@ -139,12 +139,15 @@ class ConjugatedStatePOVMEffect(DenseEffectInterface, _POVMEffect):
         i.e, a (dim,1)-shaped array.
     """
 
-    def __init__(self, state):
+    def __init__(self, state, called_from_reduce=False):
         self.state = state
         evotype = state._evotype
         rep = evotype.create_conjugatedstate_effect_rep(state._rep)
         _POVMEffect.__init__(self, rep, evotype)
-        self.init_gpindices()  # initialize our gpindices based on sub-members
+        if not called_from_reduce:
+            self.init_gpindices()  # initialize our gpindices based on sub-members
+        else:
+            self.allocate_gpindices(10000, None, submembers_already_allocated=True)
 
     @property
     def _basis(self):


### PR DESCRIPTION
Plumbs the 'called_from_reduce' argument of TPPOVM.__init__ into ComplementPOVMEffect and ConjugatedStatePOVMEffect so that effect gpindices aren't allocated during the intialization of a TPPOVM that originates via a __reduce__ call.  Also adds logic to BasePOVM to avoid copying effect vectors, which would reset their gpindices and cause allocation down the line.  This bugfix may also fix issues with copying TPPOVM objects via, e.g., deepcopy, as this uses the same control path as pickle.  Lightly tested on a 1Q TP-parameterized model.