### PR TITLE
Enhances EmbeddingOpFactory to be used to create target-qubit-dependent operation factories

### DIFF
--- a/jupyter_notebooks/Tutorials/objects/advanced/OperationFactories.ipynb
+++ b/jupyter_notebooks/Tutorials/objects/advanced/OperationFactories.ipynb
@@ -93,7 +93,7 @@
     "        op.OpFactory.__init__(self, state_space=1, evotype=\"densitymx\")\n",
     "        \n",
     "    def create_object(self, args=None, sslbls=None):\n",
-    "        assert(sslbls is None) # don't worry about sslbls for now -- these are for factories that can create gates placed at arbitrary circuit locations\n",
+    "        # Note: don't worry about sslbls (unused) -- this argument allow factories to create different operations on different target qubits\n",
     "        assert(len(args) == 1)\n",
     "        theta = float(args[0])/2.0  #note we convert to float b/c the args can be strings depending on how the circuit is specified\n",
     "        b = 2*np.cos(theta)*np.sin(theta)\n",
@@ -147,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above is readily extensible to systems with more qubits.  The only nontrivial addition is that our factory, which creates 1-qubit gates, must be \"embedded\" within a larger collection of qubits to result in a n-qubit-gate factory.  This step is easily accomplished using the builtin `EmbeddingOpFactory` object, which takes a tuple of all the qubits, e.g. `(0,1)` and a tuple of the subset of qubits therein to embed into, e.g. `(0,)`.  This is illustrated below for the 2-qubit case, along with a demonstration of how a more complex 2-qubit circuit can be simulated:"
+    "The above is readily extensible to systems with more qubits.  The only nontrivial addition is that our factory, which creates 1-qubit gates, must be \"embedded\" within a larger collection of qubits to result in a n-qubit-gate factory.  This step is easily accomplished using the builtin `EmbeddedOpFactory` object, which takes a tuple of all the qubits, e.g. `(0,1)` and a tuple of the subset of qubits therein to embed into, e.g. `(0,)`.  This is illustrated below for the 2-qubit case, along with a demonstration of how a more complex 2-qubit circuit can be simulated:"
    ]
   },
   {
@@ -193,7 +193,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/pygsti/modelmembers/operations/opfactory.py
+++ b/pygsti/modelmembers/operations/opfactory.py
@@ -504,7 +504,10 @@ class EmbeddingOpFactory(OpFactory):
             raise ValueError("Not allowed to embed onto sslbls=" + str(sslbls))
 
         if self.embeds_factory:
-            op = self.embedded_factory_or_op.create_op(args, None)  # Note: will have its gpindices set already
+            #Even though the produced op is (or should be) just a local op on `sslbls` (self.embedded_factory_or_op
+            # should not return an op embedded on `sslbls`) it may still depend on `sslbls` and so is passed to
+            # create_op call here.
+            op = self.embedded_factory_or_op.create_op(args, sslbls)  # Note: will have its gpindices set already
         else:
             op = self.embedded_factory_or_op
         embedded_op = _EmbeddedOp(self.state_space, sslbls, op)
@@ -820,7 +823,8 @@ class UnitaryOpFactory(OpFactory):
             Can be any type of operation, e.g. a LinearOperator, State,
             Instrument, or POVM, depending on the label requested.
         """
-        assert(sslbls is None), "UnitaryOpFactory.create_object must be called with `sslbls=None`!"
+        # Note: sslbls is unused, and may be None or non-None depending on the context this UnitaryOpFactory is
+        #  used in (e.g. it will be none when used with an EmbeddedOpFactory but not with an EmbeddingOpFactory).
         U = self.fn(args)
 
         # Expanded call to _bt.change_basis(_ot.unitary_to_std_process_mx(U), 'std', self.basis) for speed


### PR DESCRIPTION
**Alters behavior of `EmbeddingOpFactory` to pass state space labels of operations being created through to a contained (embedded) operation factory object.**

Previously, when an EmbeddingOpFactory would "blank out" (set to `None`) the `sslbls` argument passed to the contained op-factory's `create_op` call.  Now this argument receives the original `sslbls` and so the contained factory can use this information to create different operations depending on what the operation's target qubits are.

This PR updates assertions in `UnitaryOpFactory` and an example in the operation factory tutorial that no longer hold in generatlity.