### PR TITLE
Bugfix pspec instrument stdgst

### DIFF
--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -1565,10 +1565,12 @@ class ExplicitOpModel(_mdl.OpModel):
 
         if all([udim == 2 for udim in all_udims]):
             return _QubitProcessorSpec(nqudits, list(gate_unitaries.keys()), gate_unitaries, availability,
-                                       qubit_labels=qudit_labels)
+                                       qubit_labels=qudit_labels,
+                                       instrument_names=list(self.instruments.keys()), nonstd_instruments=self.instruments)
         else:
             return _QuditProcessorSpec(qudit_labels, all_udims, list(gate_unitaries.keys()), gate_unitaries,
-                                       availability)
+                                       availability,
+                                       instrument_names=list(self.instruments.keys()), nonstd_instruments=self.instruments)
 
     def create_modelmember_graph(self):
         return _MMGraph({

--- a/pygsti/models/modelconstruction.py
+++ b/pygsti/models/modelconstruction.py
@@ -936,13 +936,18 @@ def _create_explicit_model(processor_spec, modelnoise, custom_gates=None, evotyp
                 inst_members = {}
                 for k, lst in instrument_spec.items():
                     member = None
-                    for effect_spec, prep_spec in lst:
-                        effect_vec = _spec_to_densevec(effect_spec, is_prep=False)
-                        prep_vec = _spec_to_densevec(prep_spec, is_prep=True)
-                        if member is None:
-                            member = _np.outer(effect_vec, prep_vec)
-                        else:
-                            member += _np.outer(effect_vec, prep_vec)
+                    if len(lst) == 2:
+                        for effect_spec, prep_spec in lst:
+                            effect_vec = _spec_to_densevec(effect_spec, is_prep=False)
+                            prep_vec = _spec_to_densevec(prep_spec, is_prep=True)
+                            if member is None:
+                                member = _np.outer(effect_vec, prep_vec)
+                            else:
+                                member += _np.outer(effect_vec, prep_vec)
+                    else: # elements are key, array of outer product already
+                        # TODO: This appears to be the new standard format. Deprecate outer prod code above?
+                        # But old code could still be useful.
+                        member = lst.copy()
 
                     assert (member is not None), \
                         "You must provide at least one rank-1 specifier for each instrument member!"

--- a/pygsti/report/reportables.py
+++ b/pygsti/report/reportables.py
@@ -2547,15 +2547,16 @@ def instrument_half_diamond_norm(a, b, mx_basis):
     float
     """
     #Turn instrument into a CPTP map on qubit + classical space.
-    mx_basis = _Basis.cast(mx_basis, dim=a.dim)
+    adim = a.state_space.dim
+    mx_basis = _Basis.cast(mx_basis, dim=adim)
     nComps = len(a.keys())
     sumbasis = _DirectSumBasis([mx_basis] * nComps)
-    composite_op = _np.zeros((a.dim * nComps, a.dim * nComps), 'd')
-    composite_top = _np.zeros((a.dim * nComps, a.dim * nComps), 'd')
+    composite_op = _np.zeros((adim * nComps, adim * nComps), 'd')
+    composite_top = _np.zeros((adim * nComps, adim * nComps), 'd')
     for i, clbl in enumerate(a.keys()):
-        aa, bb = i * a.dim, (i + 1) * a.dim
+        aa, bb = i * adim, (i + 1) * adim
         for j in range(nComps):
-            cc, dd = j * a.dim, (j + 1) * a.dim
+            cc, dd = j * adim, (j + 1) * adim
             composite_op[aa:bb, cc:dd] = a[clbl].to_dense(on_space='HilbertSchmidt')
             composite_top[aa:bb, cc:dd] = b[clbl].to_dense(on_space='HilbertSchmidt')
     return half_diamond_norm(composite_op, composite_top, sumbasis)


### PR DESCRIPTION
Several small fixes to allow StandardGST protocols and reports to work with models that use instruments. Includes several fixes for converting between explicit models and processor specs to no longer drop instruments.