### PR TITLE
Fix numpy deprecation warnings

### DIFF
--- a/pygsti/modelmembers/operations/experrorgenop.py
+++ b/pygsti/modelmembers/operations/experrorgenop.py
@@ -11,6 +11,7 @@ The ExpErrorgenOp class and supporting functionality.
 #***************************************************************************************************
 
 import warnings as _warnings
+import math
 
 import numpy as _np
 import scipy.linalg as _spl
@@ -735,7 +736,7 @@ def _d_exp_series(x, dx):
             commutant = _np.tensordot(x, last_commutant, (1, 0)) - \
                 _np.transpose(_np.tensordot(last_commutant, x, (1, 0)), (0, 3, 1, 2))
 
-        term = 1 / _np.math.factorial(i) * commutant
+        term = 1 / math.factorial(i) * commutant
 
         #Uncomment some/all of this when you suspect an overflow due to x having large norm.
         #print("DB COMMUTANT NORM = ",_np.linalg.norm(commutant)) # sometimes this increases w/iter -> divergence => NaN
@@ -749,7 +750,7 @@ def _d_exp_series(x, dx):
         #    #WARNING: stopping early b/c of NaNs!!! - usually caused by infs
         #    break
 
-        series += term  # 1/_np.math.factorial(i) * commutant
+        series += term  # 1/ math.factorial(i) * commutant
         last_commutant = commutant; i += 1
     return series
 
@@ -784,8 +785,8 @@ def _d2_exp_series(x, dx, d2x):
             commutant2B = _np.einsum("ik,kjabqr->ijabqr", x, last_commutant2) - \
                 _np.einsum("ikabqr,kj->ijabqr", last_commutant2, x)
 
-        term = 1 / _np.math.factorial(i) * commutant
-        term2 = 1 / _np.math.factorial(i) * (commutant2A + commutant2B)
+        term = 1 / math.factorial(i) * commutant
+        term2 = 1 / math.factorial(i) * (commutant2A + commutant2B)
         series += term
         series2 += term2
         last_commutant = commutant

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -87,7 +87,7 @@ def fidelity(a, b):
         ivec = _np.argmax(evals)
         vec = U[:, ivec:(ivec + 1)]
         F = evals[ivec].real * _np.dot(_np.conjugate(_np.transpose(vec)), _np.dot(b, vec)).real  # vec^T * b * vec
-        return float(F)
+        return float(F[0, 0])
 
     evals, U = _np.linalg.eig(b)
     if len([ev for ev in evals if abs(ev) > 1e-8]) == 1:
@@ -95,7 +95,7 @@ def fidelity(a, b):
         ivec = _np.argmax(evals)
         vec = U[:, ivec:(ivec + 1)]
         F = evals[ivec].real * _np.dot(_np.conjugate(_np.transpose(vec)), _np.dot(a, vec)).real  # vec^T * a * vec
-        return float(F)
+        return float(F[0, 0])
 
     #if _np.array_equal(a, b): return 1.0  # HACK - some cases when a and b are perfecty equal sqrtm(a) fails...
     sqrtA = _hack_sqrtm(a)  # _spl.sqrtm(a)


### PR DESCRIPTION
* `np.math` was an alias for the stdlib math module and has been deprecated
* Conversion of an array with ndim > 0 to a scalar is deprecated
