### PR TITLE
Changes to definitions of named gauge optimization suites, resolve (unnecessary) warnings, robustify report generation

### DIFF
--- a/pygsti/optimize/optimize.py
+++ b/pygsti/optimize/optimize.py
@@ -159,10 +159,7 @@ def minimize(fn, x0, method='cg', callback=None,
         elif method == "L-BFGS-B": opts['gtol'] = opts['ftol'] = tol  # gradient norm and fractional y-tolerance
         elif method == "Nelder-Mead": opts['maxfev'] = maxfev  # max fn evals (note: ftol and xtol can also be set)
 
-        if method in ("BFGS", "CG", "Newton-CG", "L-BFGS-B", "TNC", "SLSQP", "dogleg", "trust-ncg"):  # use jacobian
-            solution = _spo.minimize(fn, x0, options=opts, method=method, tol=tol, callback=callback, jac=jac)
-        else:
-            solution = _spo.minimize(fn, x0, options=opts, method=method, tol=tol, callback=callback)
+        solution = _spo.minimize(fn, x0, options=opts, method=method, tol=tol, callback=callback, jac=jac)  
 
     return solution
 

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -857,6 +857,14 @@ class GSTGaugeOptSuite(_NicelySerializable):
         given by the target model, which are used as the default when
         `gaugeopt_target` is None.
     """
+
+    STANDARD_SUITENAMES = ("stdgaugeopt", "stdgaugeopt-unreliable2Q", "stdgaugeopt-tt", "stdgaugeopt-safe",
+                          "stdgaugeopt-noconversion", "stdgaugeopt-noconversion-safe")
+    
+    SPECIAL_SUITENAMES = ("varySpam", "varySpamWt", "varyValidSpamWt", "toggleValidSpam",
+                          "varySpam-unreliable2Q", "varySpamWt-unreliable2Q",
+                           "varyValidSpamWt-unreliable2Q", "toggleValidSpam-unreliable2Q")
+
     @classmethod
     def cast(cls, obj):
         if obj is None:
@@ -985,10 +993,9 @@ class GSTGaugeOptSuite(_NicelySerializable):
         return gaugeopt_suite_dict
 
     @staticmethod
-    def _update_gaugeopt_dict_from_suitename(gaugeopt_suite_dict, root_lbl, suite_name, model,
-                                             unreliable_ops, printer):
-        if suite_name in ("stdgaugeopt", "stdgaugeopt-unreliable2Q", "stdgaugeopt-tt", "stdgaugeopt-safe",
-                          "stdgaugeopt-noconversion", "stdgaugeopt-noconversion-safe"):
+    def _update_gaugeopt_dict_from_suitename(gaugeopt_suite_dict, root_lbl, suite_name, model, unreliable_ops, printer):
+    
+        if suite_name in GSTGaugeOptSuite.STANDARD_SUITENAMES:
 
             stages = []  # multi-stage gauge opt
             gg = model.default_gauge_group
@@ -1061,14 +1068,12 @@ class GSTGaugeOptSuite(_NicelySerializable):
                 else:
                     gaugeopt_suite_dict[root_lbl] = stages  # can be a list of stage dictionaries
 
-        elif suite_name in ("varySpam", "varySpamWt", "varyValidSpamWt", "toggleValidSpam") or \
-            suite_name in ("varySpam-unreliable2Q", "varySpamWt-unreliable2Q",
-                           "varyValidSpamWt-unreliable2Q", "toggleValidSpam-unreliable2Q"):
+        elif suite_name in GSTGaugeOptSuite.SPECIAL_SUITENAMES:
 
-            base_wts = {'gates': 1}
+            base_wts = {'gates': 1.0}
             if suite_name.endswith("unreliable2Q") and model.dim == 16:
                 if any([gl in model.operations.keys() for gl in unreliable_ops]):
-                    base = {'gates': 1}
+                    base = {'gates': 1.0}
                     for gl in unreliable_ops:
                         if gl in model.operations.keys(): base[gl] = 0.01
                     base_wts = base

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1097,9 +1097,6 @@ class GSTGaugeOptSuite(_NicelySerializable):
                         'item_weights': item_weights,
                         'spam_penalty_factor': valid_spam, 'verbosity': printer}
 
-        elif suite_name == "unreliable2Q":
-            raise ValueError(("unreliable2Q is no longer a separate 'suite'.  You should precede it with the suite"
-                              " name, e.g. 'stdgaugeopt-unreliable2Q' or 'varySpam-unreliable2Q'"))
         elif suite_name == 'none':
             gaugeopt_suite_dict[root_lbl] = None
         else:

--- a/pygsti/tools/basistools.py
+++ b/pygsti/tools/basistools.py
@@ -15,8 +15,8 @@ from functools import partial, lru_cache
 import numpy as _np
 
 from pygsti.baseobjs.basisconstructors import _basis_constructor_dict
-# from ..baseobjs.basis import Basis, BuiltinBasis, DirectSumBasis
 from pygsti.baseobjs import basis as _basis
+
 
 @lru_cache(maxsize=1)
 def basis_matrices(name_or_basis, dim, sparse=False):

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -163,13 +163,6 @@ def fidelity(a, b):
             """
             _warnings.warn(message)
         evals[evals < 0] = 0.0
-        tr = _np.sum(evals)
-        if abs(tr - 1) > __VECTOR_TOL__:
-            message = f"""
-            The PSD part of the input matrix is not trace-1 up to tolerance {__VECTOR_TOL__}.
-            Beware result!
-            """
-            _warnings.warn(message)
         sqrt_mat = U @ (_np.sqrt(evals).reshape((-1, 1)) * U.T.conj())
         return sqrt_mat
     
@@ -1031,9 +1024,14 @@ def povm_diamonddist(model, target_model, povmlbl):
     -------
     float
     """
-    povm_mx = compute_povm_map(model, povmlbl)
-    target_povm_mx = compute_povm_map(target_model, povmlbl)
-    return diamonddist(povm_mx, target_povm_mx, target_model.basis)
+    try:
+        povm_mx = compute_povm_map(model, povmlbl)
+        target_povm_mx = compute_povm_map(target_model, povmlbl)
+        return diamonddist(povm_mx, target_povm_mx, target_model.basis)
+    except AssertionError as e:
+        assert '`dim` must be a perfect square' in str(e)
+        return _np.NaN
+
 
 def instrument_infidelity(a, b, mx_basis):
     """

--- a/test/unit/tools/test_optools.py
+++ b/test/unit/tools/test_optools.py
@@ -48,7 +48,7 @@ class OpToolsTester(BaseCase):
         # U_2Q is 4x4 unitary matrix operating on isolated two-qubit space (CX(pi) rotation)
 
         op_2Q = ot.unitary_to_pauligate(U_2Q)
-        op_2Q_inv = ot.process_mx_to_unitary(bt.change_basis(op_2Q, 'pp', 'std'))
+        op_2Q_inv = ot.std_process_mx_to_unitary(bt.change_basis(op_2Q, 'pp', 'std'))
         self.assertArraysAlmostEqual(U_2Q, op_2Q_inv)
 
     def test_decompose_gate_matrix(self):


### PR DESCRIPTION
The main change in this PR is to take the following line(s) in GSTGaugeOptSuite._update_gaugeopt_suite_from_suitename
```python
convert_to = {'to_type': "full TP", 'flatten_structure': True, 'set_default_gauge_group': True} \
                if ('noconversion' not in suite_name and gg.name not in ("Full", "TP")) else None
```
and replace ``'to_type': "full TP"`` with ``'to_type': "full"``. It's preferable to use "full" rather than "full TP" because the latter only works for some bases in Hilbert--Schmidt space. 

See individual file comments for explanation of changes to other files.