### PR TITLE
Revert "Add `tqdm` as a proper dependency"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,7 @@ dependencies=[
     'stim',
     'plotly>=3.8.0',
     'pandas',
-    'networkx',
-    'tqdm>=4.42.0'
+    'networkx'
 ]
 requires-python='>=3.9'
 keywords=[
@@ -60,6 +59,7 @@ html_reports = ['jinja2', 'MarkupSafe']
 ibmq = [
     'qiskit>1',
     'qiskit-ibm-runtime>=0.17.1',
+    'tqdm>=4.42.0',
     'dill'
 ]
 interpygate = ['csaps']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ plotly
 pandas
 networkx
 stim
-tqdm


### PR DESCRIPTION
Reverts sandialabs/pyGSTi#653

The target branch should have been develop.