### PR TITLE
Safeguards for ModelMember.parent and ModelMember.is_equivalent

### DIFF
--- a/test/unit/modelmembers/test_operation.py
+++ b/test/unit/modelmembers/test_operation.py
@@ -394,6 +394,26 @@ class TPOpTester(MutableDenseOpBase, BaseCase):
         conv = op.convert(self.gate, "full TP", "gm")
         # TODO assert correctness
 
+    def test_deepcopy(self):
+        # Issue #651 showed that an infinite recursion error is possible
+        # when deep-copying a FullTPOp whose ._parent field is not None.
+        # This test triggers that code path. It should pass after applying
+        # the proposed fix in #651.
+        #
+        # In order to use m1.is_equivalent(m2) in the correctness check
+        # we had to resolve GitHub issue #600.
+        import copy
+        from pygsti.modelpacks import smq1Q_XY
+        m1  = smq1Q_XY.target_model('full TP')
+        o1 = m1.operations[('Gxpi2',0)]
+        o2 = copy.deepcopy(o1)
+        m2 = o2.parent
+        assert id(o1) != id(o2)
+        assert id(m1) != id(m2)
+        res = m1.is_equivalent(m2, rtol=0, atol=0)
+        assert res
+        return
+
     def test_first_row_read_only(self):
         # check that first row is read-only
         e1 = self.gate[0, 0]


### PR DESCRIPTION
This PR resolves #600 and #651.

These issues could also be resolved by completing #589. However, #589 is delicate, and the changes here would remain valid even when #589 is merged. So I suggest we merge these changes now.