### PR TITLE
Germ Selection Gate Penalty

### DIFF
--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -10,6 +10,7 @@ Functions for selecting a complete set of germs for a GST analysis.
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+from __future__ import annotations
 import warnings as _warnings
 
 import numpy as _np

--- a/test/unit/algorithms/test_germselection.py
+++ b/test/unit/algorithms/test_germselection.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 import numpy as np
-
 import pygsti.circuits as pc
 from pygsti.circuits import Circuit
 from pygsti.baseobjs import Label


### PR DESCRIPTION
We recently ran into a scenario where it was desirable to perform germ selection in a manner which minimized the number of applications of a particularly expensive gate operation. To support that sort of use case this PR adds a new `algorithm_kwarg` option called `gate_penalty` for `find_germs` which is compatible with the 'greedy' and 'grasp' search algorithms which allows a user to specify and additional penalty factors for the number of instances of particular gates in a candidate germ set. Also included are some additional unit tests for both this new gate penalty as well as tests for the existing `op_penalty` option (which penalized the total number of gate operations overall).
