### PR TITLE
Ensure that gauge optimization incorporates instruments

### DIFF
--- a/pygsti/algorithms/gaugeopt.py
+++ b/pygsti/algorithms/gaugeopt.py
@@ -24,6 +24,7 @@ from pygsti.models.gaugegroup import (
     TrivialGaugeGroupElement as _TrivialGaugeGroupElement,
     GaugeGroupElement as _GaugeGroupElement
 )
+from pygsti.models import ExplicitOpModel
 from pygsti.modelmembers.operations import LinearOperator as _LinearOperator
 
 from typing import Callable, Union, Optional
@@ -628,7 +629,7 @@ def _create_objective_fn(model, target_model, item_weights: Optional[dict[LabelL
             # ^ It would be equivalent to set this to a pair of IdentityOperator objects.
 
         def _objective_fn(gauge_group_el, oob_check):
-            mdl = _transform_with_oob_check(model, gauge_group_el, oob_check)
+            mdl : ExplicitOpModel = _transform_with_oob_check(model, gauge_group_el, oob_check)
             mdl_ops : dict[_baseobjs.Label, _LinearOperator] = mdl._excalc().operations
             tgt_ops : dict[_baseobjs.Label, _LinearOperator] = dict()
             if target_model is not None:
@@ -656,7 +657,7 @@ def _create_objective_fn(model, target_model, item_weights: Optional[dict[LabelL
                 else:
                     non_gates = {'spam'}.union(set(mdl.preps)).union(set(mdl.povms))
                     temp_wts = {k: (0.0 if k in non_gates else v) for (k, v) in item_weights.items()}
-                    val = mdl.frobeniusdist(target_model, transform_mx_arg, temp_wts, n_leak)
+                    val = mdl.frobeniusdist(target_model, transform_mx_arg, temp_wts)
                 if "squared" in gates_metric:
                     val = val ** 2
                 ret += val

--- a/pygsti/modelmembers/operations/linearop.py
+++ b/pygsti/modelmembers/operations/linearop.py
@@ -506,9 +506,8 @@ class LinearOperator(_modelmember.ModelMember):
         if transform is None and inv_transform is None:
             return _ot.jtracedist(self.to_dense("minimal"), other_op.to_dense("minimal"))
         else:
-            return _ot.jtracedist(_np.dot(
-                inv_transform, _np.dot(self.to_dense("minimal"), transform)),
-                other_op.to_dense("minimal"))
+            arg = inv_transform @ self.to_dense("minimal") @ transform
+            return _ot.jtracedist(arg, other_op.to_dense("minimal"))
 
     def diamonddist(self, other_op, transform=None, inv_transform=None):
         """
@@ -535,9 +534,8 @@ class LinearOperator(_modelmember.ModelMember):
         if transform is None and inv_transform is None:
             return _ot.diamonddist(self.to_dense("minimal"), other_op.to_dense("minimal"))
         else:
-            return _ot.diamonddist(_np.dot(
-                inv_transform, _np.dot(self.to_dense("minimal"), transform)),
-                other_op.to_dense("minimal"))
+            arg = inv_transform @ self.to_dense("minimal") @ transform
+            return _ot.diamonddist(arg, other_op.to_dense("minimal"))
 
     def transform_inplace(self, s):
         """
@@ -563,7 +561,7 @@ class LinearOperator(_modelmember.ModelMember):
         """
         Smx = s.transform_matrix
         Si = s.transform_matrix_inverse
-        self.set_dense(_np.dot(Si, _np.dot(self.to_dense("minimal"), Smx)))
+        self.set_dense(Si @ self.to_dense("minimal") @ Smx)
 
     def spam_transform_inplace(self, s, typ):
         """
@@ -591,9 +589,9 @@ class LinearOperator(_modelmember.ModelMember):
         None
         """
         if typ == 'prep':
-            self.set_dense(_np.dot(s.transform_matrix_inverse, self.to_dense("minimal")))
+            self.set_dense(s.transform_matrix_inverse @ self.to_dense("minimal"))
         elif typ == 'effect':
-            self.set_dense(_np.dot(self.to_dense("minimal"), s.transform_matrix))
+            self.set_dense(self.to_dense("minimal") @ s.transform_matrix)
         else:
             raise ValueError("Invalid `typ` argument: %s" % typ)
 
@@ -627,7 +625,7 @@ class LinearOperator(_modelmember.ModelMember):
         else:
             assert(len(amount) == self.dim - 1)
             D = _np.diag([1] + list(1.0 - _np.array(amount, 'd')))
-        self.set_dense(_np.dot(D, self.to_dense("minimal")))
+        self.set_dense(D @  self.to_dense("minimal"))
 
     def rotate(self, amount, mx_basis="gm"):
         """
@@ -658,7 +656,7 @@ class LinearOperator(_modelmember.ModelMember):
         None
         """
         rotnMx = _ot.rotation_gate_mx(amount, mx_basis)
-        self.set_dense(_np.dot(rotnMx, self.to_dense("minimal")))
+        self.set_dense(rotnMx @ self.to_dense("minimal"))
 
     def deriv_wrt_params(self, wrt_filter=None):
         """

--- a/pygsti/models/explicitcalc.py
+++ b/pygsti/models/explicitcalc.py
@@ -239,14 +239,12 @@ class ExplicitOpModelCalc(object):
             The (weighted) number of elements accounted for by the residuals.
         """
         resids = []
-        T = transform_mx
         nSummands = 0.0
         if item_weights is None: item_weights = {}
         sqrt_itemWeights = {k: _np.sqrt(v) for k, v in item_weights.items()}
         opWeight = sqrt_itemWeights.get('gates', 1.0)
         spamWeight = sqrt_itemWeights.get('spam', 1.0)
-        Ti = None if T is None else _np.linalg.pinv(T)
-        # ^ TODO: generalize inverse op (call T.inverse() if T were a "transform" object?)
+        T, Ti = to_transform_mx_pair(transform_mx)
 
         for opLabel, gate in self.operations.items():
             wt = sqrt_itemWeights.get(opLabel, opWeight)

--- a/pygsti/models/explicitcalc.py
+++ b/pygsti/models/explicitcalc.py
@@ -23,7 +23,24 @@ from pygsti.tools import matrixtools as _mt
 
 from typing import Union
 
-TransformMxPair = tuple[_np.ndarray, Union[_np.ndarray, _mt.IdentityOperator]]
+
+TransformMxPair = tuple[
+    Union[_np.ndarray, _mt.IdentityOperator],
+    Union[_np.ndarray, _mt.IdentityOperator]
+]
+
+
+def to_transform_mx_pair(tmx_arg: Union[None, _np.ndarray, TransformMxPair]) -> TransformMxPair:
+    if tmx_arg is None:
+        P = invP = _mt.IdentityOperator()
+    elif isinstance(tmx_arg, _np.ndarray):
+        P = tmx_arg
+        invP = _np.linalg.pinv(P)
+    else:
+        P, invP = tmx_arg
+        assert _mt.is_operatorlike(P)
+        assert _mt.is_operatorlike(invP)
+    return P, invP
 
 # Tolerace for matrix_rank when finding rank of a *normalized* projection
 # matrix.  This is a legitimate tolerace since a normalized projection matrix
@@ -156,16 +173,7 @@ class ExplicitOpModelCalc(object):
         -------
         float
         """
-        if transform_mx is None:
-            P, invP = None, None
-            # ^ It would be equivalent to use P = invP = _mt.IdentityOperator()
-        elif isinstance(transform_mx, _np.ndarray):
-            P = transform_mx
-            invP = _np.linalg.pinv(P)
-        else:
-            P, invP = transform_mx
-            assert _mt.is_operatorlike(P)
-            assert _mt.is_operatorlike(invP)
+        P, invP = to_transform_mx_pair(transform_mx)
 
         d = 0.0
         nSummands = 0.0
@@ -293,40 +301,23 @@ class ExplicitOpModelCalc(object):
         -------
         float
         """
-        T = transform_mx
+        T, Ti = to_transform_mx_pair(transform_mx)
         d = 0  # spam difference
         nSummands = 0  # for spam terms
 
-        if T is not None:
-            Ti = _np.linalg.inv(T)
-            dists = [gate.jtracedist(other_calc.operations[lbl], T, Ti)
-                     for lbl, gate in self.operations.items()]
+        dists = [gate.jtracedist(other_calc.operations[lbl], T, Ti)
+                    for lbl, gate in self.operations.items()]
 
-            #Just use frobenius distance between spam vecs, since jtracedist
-            # doesn't really make sense
-            if include_spam:
-                for lbl, rhoV in self.preps.items():
-                    d += rhoV.frobeniusdist_squared(other_calc.preps[lbl], T, Ti)
-                    nSummands += rhoV.dim
+        # Just use frobenius distance between spam vecs, since jtracedist
+        # doesn't really make sense
+        if include_spam:
+            for lbl, rhoV in self.preps.items():
+                d += rhoV.frobeniusdist_squared(other_calc.preps[lbl], T, Ti)
+                nSummands += rhoV.dim
 
-                for lbl, Evec in self.effects.items():
-                    d += Evec.frobeniusdist_squared(other_calc.effects[lbl], T, Ti)
-                    nSummands += Evec.dim
-
-        else:
-            dists = [gate.jtracedist(other_calc.operations[lbl])
-                     for lbl, gate in self.operations.items()]
-
-            #Just use frobenius distance between spam vecs, since jtracedist
-            # doesn't really make sense
-            if include_spam:
-                for lbl, rhoV in self.preps.items():
-                    d += rhoV.frobeniusdist_squared(other_calc.preps[lbl])
-                    nSummands += rhoV.dim
-
-                for lbl, Evec in self.effects.items():
-                    d += Evec.frobeniusdist_squared(other_calc.effects[lbl])
-                    nSummands += Evec.dim
+            for lbl, Evec in self.effects.items():
+                d += Evec.frobeniusdist_squared(other_calc.effects[lbl], T, Ti)
+                nSummands += Evec.dim
 
         spamVal = _np.sqrt(d / nSummands) if (nSummands > 0) else 0
         return max(dists) + spamVal
@@ -358,39 +349,22 @@ class ExplicitOpModelCalc(object):
         -------
         float
         """
-        T = transform_mx
+        T, Ti = to_transform_mx_pair(transform_mx)
         d = 0  # spam difference
         nSummands = 0  # for spam terms
 
-        if T is not None:
-            Ti = _np.linalg.inv(T)
-            dists = [gate.diamonddist(other_calc.operations[lbl], T, Ti)
-                     for lbl, gate in self.operations.items()]
+        dists = [gate.diamonddist(other_calc.operations[lbl], T, Ti)
+                    for lbl, gate in self.operations.items()]
 
-            #Just use frobenius distance between spam vecs, since jtracedist
-            # doesn't really make sense
-            if include_spam:
-                for lbl, rhoV in self.preps.items():
-                    d += rhoV.frobeniusdist_squared(other_calc.preps[lbl], T, Ti)
-                    nSummands += rhoV.dim
+        # Just use frobenius distance between spam vecs, since diamonddist
+        # doesn't really make sense
+        if include_spam:
+            for lbl, rhoV in self.preps.items():
+                d += rhoV.frobeniusdist_squared(other_calc.preps[lbl], T, Ti)
+                nSummands += rhoV.dim
 
-                for lbl, Evec in self.effects.items():
+            for lbl, Evec in self.effects.items():
                     d += Evec.frobeniusdist_squared(other_calc.effects[lbl], T, Ti)
-                    nSummands += Evec.dim
-
-        else:
-            dists = [gate.diamonddist(other_calc.operations[lbl])
-                     for lbl, gate in self.operations.items()]
-
-            #Just use frobenius distance between spam vecs, since jtracedist
-            # doesn't really make sense
-            if include_spam:
-                for lbl, rhoV in self.preps.items():
-                    d += rhoV.frobeniusdist_squared(other_calc.preps[lbl])
-                    nSummands += rhoV.dim
-
-                for lbl, Evec in self.effects.items():
-                    d += Evec.frobeniusdist_squared(other_calc.effects[lbl])
                     nSummands += Evec.dim
 
         spamVal = _np.sqrt(d / nSummands) if (nSummands > 0) else 0
@@ -420,7 +394,7 @@ class ExplicitOpModelCalc(object):
             eo += obj.hilbert_schmidt_size
 
         if self.interposer is not None:
-            deriv = _np.dot(deriv, self.interposer.deriv_op_params_wrt_model_params())
+            deriv = deriv @ self.interposer.deriv_op_params_wrt_model_params()
 
         return deriv
 
@@ -499,14 +473,13 @@ class ExplicitOpModelCalc(object):
             for j in range(dim):  # *generator* mx, not gauge mx itself
                 unitMx = _bc.mut(i, j, dim)
                 for lbl, rhoVec in self_preps.items():
-                    mdlDeriv_preps[lbl] = _np.dot(unitMx, rhoVec)
+                    mdlDeriv_preps[lbl] = unitMx @ rhoVec
                 for lbl, EVec in self_effects.items():
-                    mdlDeriv_effects[lbl] = -_np.dot(EVec.T, unitMx).T
+                    mdlDeriv_effects[lbl] = -(EVec.T @ unitMx).T
 
                 for lbl, gate in self_operations.items():
                     #if isinstance(gate,_op.DenseOperator):
-                    mdlDeriv_ops[lbl] = _np.dot(unitMx, gate) - \
-                        _np.dot(gate, unitMx)
+                    mdlDeriv_ops[lbl] = (unitMx @ gate) - (gate @ unitMx)
                     #else:
                     #    #use acton... maybe throw error if dim is too large (maybe above?)
                     #    deriv = _np.zeros((dim,dim),'d')
@@ -566,7 +539,7 @@ class ExplicitOpModelCalc(object):
             #for each column of gen_dG, which is a gauge direction in model parameter space,
             # we add some amount of non-gauge direction, given by coefficients of the
             # numNonGaugeParams non-gauge directions.
-            orthog_to = gauge_space + _np.dot(nonGaugeDirections, non_gauge_mix_mx)  # add non-gauge components in
+            orthog_to = gauge_space + nonGaugeDirections @ non_gauge_mix_mx  # add non-gauge components in
             # dims: (nParams,n_gauge_params) + (nParams,n_non_gauge_params) * (n_non_gauge_params,n_gauge_params)
             # non_gauge_mix_mx is a (n_non_gauge_params,n_gauge_params) matrix whose i-th column specifies the
             #  coefficients to multiply each of the non-gauge directions by before adding them to the i-th
@@ -583,7 +556,7 @@ class ExplicitOpModelCalc(object):
                 metric_diag[vec.gpindices] = item_weights.get(lbl, spamWeight)
             metric = _np.diag(metric_diag)
             #OLD: gen_ndG = _mt.nullspace(_np.dot(gen_dG.T,metric))
-            orthog_to = _np.dot(metric.T, gauge_space)
+            orthog_to = metric.T @ gauge_space
 
         else:
             orthog_to = gauge_space
@@ -663,9 +636,9 @@ class ExplicitOpModelCalc(object):
                         unitMx_j = _bc.mut(j1, j2, dim)
                         antiComm = (unitMx_i @ unitMx_j + unitMx_j @ unitMx_i)
                         for lbl, rhoVec in self_preps.items():
-                            mdlHess_preps[lbl] = 0.5 * _np.dot(antiComm, rhoVec)
+                            mdlHess_preps[lbl] = 0.5 * (antiComm @ rhoVec)
                         for lbl, EVec in self_effects.items():
-                            mdlHess_effects[lbl] = 0.5 * _np.dot(EVec.T, antiComm).T
+                            mdlHess_effects[lbl] = 0.5 * (EVec.T @ antiComm).T
                         for lbl, gate in self_operations.items():
                             mdlHess_ops[lbl] = 0.5 * (antiComm @ gate + gate @ antiComm) \
                                 - unitMx_i @ gate @ unitMx_j - unitMx_j @ gate @ unitMx_i
@@ -785,8 +758,8 @@ class ExplicitOpModelCalc(object):
 
         # ORIG WAY: use pseudo-inverse to normalize projector.  Ran into problems where
         #  default rcond == 1e-15 didn't work for 2-qubit case, but still more stable than inv method below
-        P = _np.dot(gen_ndG, _np.transpose(gen_ndG))  # almost a projector, but cols of dG are not orthonormal
-        Pp = _np.dot(_np.linalg.pinv(P, rcond=1e-7), P)  # make P into a true projector (onto gauge space)
+        P = gen_ndG @ gen_ndG.T  # almost a projector, but cols of dG are not orthonormal
+        Pp = _np.linalg.pinv(P, rcond=1e-7) @ P  # make P into a true projector (onto gauge space)
 
         # ALT WAY: use inverse of dG^T*dG to normalize projector (see wikipedia on projectors, dG => A)
         #  This *should* give the same thing as above, but numerical differences indicate the pinv method

--- a/pygsti/optimize/optimize.py
+++ b/pygsti/optimize/optimize.py
@@ -150,7 +150,20 @@ def minimize(fn, x0, method='cg', callback=None,
         solution = _fmin_evolutionary(fn, x0, num_generations=maxiter, num_individuals=500, printer=printer)
 
     else:
-        # Set options for different algorithms
+        # We're calling scipy.minimize.
+
+        # Step 1. Check if addl_kwargs has passthrough arguments for scipy.optimize; make
+        # sure that any such arguments don't contradict kwargs passed to this function.
+        scipy_args = addl_kwargs.get('scipy', dict())
+        if 'method' in scipy_args:
+            scipy_method = scipy_args.pop('method')
+            assert method == scipy_method
+        if isinstance(jac, str):
+            scipy_jac = scipy_args.pop('jac', None)
+            if isinstance(scipy_jac, str):
+                assert jac == scipy_jac
+        
+        # Step 2. Set default options (method-dependent), then clobber as needed.
         opts = {'maxiter': maxiter, 'disp': False}
         if method == "BFGS":
             opts['gtol'] = tol
@@ -159,8 +172,19 @@ def minimize(fn, x0, method='cg', callback=None,
             opts.pop('disp')  # SciPy deprecated this for L-BFGS-B.
         elif method == "Nelder-Mead":
             opts['maxfev'] = maxfev  # max fn evals (note: ftol and xtol can also be set)
+        opts.update(scipy_args.get('options', dict()))
 
-        solution = _spo.minimize(fn, x0, options=opts, method=method, tol=tol, callback=callback, jac=jac)  
+        # Step 3. Actually call scipy.minimize. If the first call fails, then we'll try again
+        # with different settings.
+        solution = _spo.minimize(fn, x0, method=method, options=opts, tol=tol, callback=callback, jac=jac)
+        if not solution.success:
+            tempsol = _spo.minimize(fn, x0, method='COBYLA', options=opts)
+            # ^ It's wise to pass through `opts` in case it contains bound constraints.
+            if not hasattr(jac, '__call__'):
+                jac = '3-point'  # more expensive than the default 2-point finite-difference, but more reliable.
+            tempsol = _spo.minimize(fn, tempsol.x, method=method, options=opts, tol=tol, callback=callback, jac=jac)
+            if tempsol.fun < solution.fun:
+                solution = tempsol
 
     return solution
 

--- a/test/unit/algorithms/test_gaugeopt_correctness.py
+++ b/test/unit/algorithms/test_gaugeopt_correctness.py
@@ -13,6 +13,8 @@ import pygsti.tools.optools as pgo
 import pygsti.baseobjs.label as pgl
 import pygsti.baseobjs.basisconstructors as pgbc
 import pygsti.algorithms.gaugeopt as gop
+from pygsti.models import ExplicitOpModel
+import pytest
 
 
 
@@ -69,8 +71,7 @@ def check_gate_metrics_near_zero(metrics, tol):
     return
 
 
-
-class sm1QXYI_FindPerfectGauge:
+class FindPerfectGauge_sm1QXYI:
 
     @property
     def default_gauge_group(self):
@@ -97,10 +98,15 @@ class sm1QXYI_FindPerfectGauge:
         return self._gauge_space_name
 
     def setUp(self):
+        # The end of this function raises an error! The function is here just to be
+        # a template for usable implementations.
         np.random.seed(0)
         target = smq1Q_XYI.target_model()
         self.target = target.depolarize(op_noise=0.01, spam_noise=0.001)
+        # ^ That's a noisy data-generating model. We'll gauge-optimize to this noisy
+        #   data-generating model rather than to an ideal model.
         self.model = None
+        # ^ We'll initialize that later on as something that's gauge-equivalent to target.
         self._default_gauge_group = None
         self._gauge_grp_el_class = None
         self._gauge_space_name = ''
@@ -156,13 +162,11 @@ class sm1QXYI_FindPerfectGauge:
         print(f'GaugeOpt over {self.gauge_space_name} w.r.t. Frobenius dist, using LS    : {times}.')
         return
 
-    pass
 
-
-"""
-This class' test for minimizing trace distance with L-BFGS takes excessively long (about 5 seconds).
-"""
-class FindPerfectGauge_TPGroup_Tester(BaseCase, sm1QXYI_FindPerfectGauge):
+class FindPerfectGauge_TPGroup_Tester(BaseCase, FindPerfectGauge_sm1QXYI):
+    """
+    This class' test for minimizing trace distance with L-BFGS takes excessively long (about 5 seconds).
+    """
 
     def setUp(self):
         np.random.seed(0)
@@ -174,14 +178,9 @@ class FindPerfectGauge_TPGroup_Tester(BaseCase, sm1QXYI_FindPerfectGauge):
         self._gauge_space_name = 'TPGaugeGroup'
         self.N_REPS = 1
         return
-    
-    def gauge_transform_model(self, seed):
-        sm1QXYI_FindPerfectGauge.gauge_transform_model(self, seed)
-        # ^ That sets self.model
-        return
 
 
-class FindPerfectGauge_UnitaryGroup_Tester(BaseCase, sm1QXYI_FindPerfectGauge):
+class FindPerfectGauge_UnitaryGroup_Tester(BaseCase, FindPerfectGauge_sm1QXYI):
 
     def setUp(self):
         np.random.seed(0)
@@ -194,17 +193,12 @@ class FindPerfectGauge_UnitaryGroup_Tester(BaseCase, sm1QXYI_FindPerfectGauge):
         self.N_REPS = 3
         # ^ This is fast, so we can afford more tests.
         return
-    
-    def gauge_transform_model(self, seed):
-        sm1QXYI_FindPerfectGauge.gauge_transform_model(self, seed)
-        # ^ That sets self.model
-        return
 
 
-"""
-This class' test for minimizing trace distance with L-BFGS takes excessively long (about 5 seconds).
-"""
-class FindPerfectGauge_FullGroup_Tester(BaseCase, sm1QXYI_FindPerfectGauge):
+class FindPerfectGauge_FullGroup_Tester(BaseCase, FindPerfectGauge_sm1QXYI):
+    """
+    This class' test for minimizing trace distance with L-BFGS takes excessively long (about 5 seconds).
+    """
 
     def setUp(self):
         np.random.seed(0)
@@ -217,7 +211,85 @@ class FindPerfectGauge_FullGroup_Tester(BaseCase, sm1QXYI_FindPerfectGauge):
         self.N_REPS = 1
         return
 
-    def gauge_transform_model(self, seed):
-        sm1QXYI_FindPerfectGauge.gauge_transform_model(self, seed)
-        # ^ That sets self.model
+
+class FindPerfectGauge_Instruments_Tester(BaseCase):
+
+    def setUp(self, seed: int = 0):
+        from pygsti.baseobjs import QubitSpace
+        from pygsti.modelmembers.povms import TPPOVM
+        from pygsti.modelmembers.instruments import Instrument
+        from pygsti.tools.basistools import stdmx_to_ppvec
+        from pygsti.tools.optools import unitary_to_superop
+
+        ss = QubitSpace(1)
+        target = ExplicitOpModel(ss, basis='pp')
+        E0 = np.array([[1,0],[0,0]], dtype=np.cdouble)
+        target.preps['rho0'] = stdmx_to_ppvec(E0)
+        E1 = np.eye(2) - E0
+        target.povms['Mdefault'] = TPPOVM({'0': stdmx_to_ppvec(E0), '1': stdmx_to_ppvec(E1)}, state_space=ss, evotype='default')
+
+        rng = np.random.default_rng(seed)
+        U = la.qr(rng.standard_normal((2,2)) + 1j*rng.standard_normal((2,2)))[0]
+        G = unitary_to_superop(U, 'pp')
+        target.instruments['I_trivial'] = Instrument({'p0': 0.25*G, 'p1': 0.75*G})
+        target.default_gauge_group = UnitaryGaugeGroup(target.state_space, target.basis)
+
+        self.target = target
+        self.model : ExplicitOpModel = target.copy() # type: ignore
+        tweak = 1.0 + 0.5j
+        tweak /= abs(tweak)
+        ggel = UnitaryGaugeGroupElement(unitary_to_superop(np.array([[1,0], [0, tweak]])))
+        self.model.transform_inplace(ggel)
+
+        self.dist_initial = self.model.frobeniusdist(self.target)
+        self.assertGreaterEqual(self.dist_initial, 1e-2)
         return
+
+    def _main_tester(self, method, seed, test_tol, alg_tol, gop_objective):
+        assert gop_objective in {'frobenius', 'frobenius_squared', 'tracedist', 'fidelity'}
+        self.setUp(seed)
+        tic = time.time()
+        item_weights = {'spam': 1.0, 'gates': 1.0} if gop_objective == 'tracedist' else None
+        newmodel : ExplicitOpModel = gop.gaugeopt_to_target(
+            self.model, self.target, item_weights=item_weights, method=method,
+            tol=alg_tol, spam_metric=gop_objective, gates_metric=gop_objective
+        ) # type: ignore
+        toc = time.time()
+        dt = toc - tic
+        dist_final = newmodel.frobeniusdist(self.target)
+        self.assertLessEqual(dist_final, test_tol)
+        return dt
+    
+    def test_lbfgs_frodist(self):
+        times = []
+        for seed in range(3):
+            dt = self._main_tester('L-BFGS-B', seed, test_tol=1e-6, alg_tol=1e-8, gop_objective='frobenius')
+            times.append(dt)
+        print(f'L-BFGS GaugeOpt over UnitaryGaugeGroup w.r.t. Frobenius dist: {times}.')
+        return
+    
+    def test_lbfgs_tracedist(self):
+        times = []
+        for seed in range(1, 3):
+            dt = self._main_tester('L-BFGS-B', seed, test_tol=1e-6, alg_tol=1e-8, gop_objective='tracedist')
+            times.append(dt)
+        print(f'L-BFGS GaugeOpt over UnitaryGaugeGroup w.r.t. trace dist: {times}.')
+        return
+    
+    @pytest.mark.skip('See https://github.com/sandialabs/pyGSTi/pull/672#issuecomment-3428804478.')
+    def test_lbfgs_fidelity(self):
+        times = []
+        for seed in range(3):
+            dt = self._main_tester('L-BFGS-B', seed, test_tol=1e-6, alg_tol=1e-8, gop_objective='fidelity')
+            times.append(dt)
+        print(f'L-BFGS GaugeOpt over UnitaryGaugeGroup w.r.t. fidelity : {times}.')
+        return
+
+    def test_ls(self):
+        times = []
+        for seed in range(3):
+            dt = self._main_tester('ls', seed, test_tol=1e-6, alg_tol=1e-15, gop_objective='frobenius')
+            times.append(dt)
+        print(f'LS GaugeOpt over UnitaryGaugeGroup : {times}.')
+        return
+


### PR DESCRIPTION
This resolves #644. The fix was easier than I expected for two reasons. First, gauge optimization w.r.t. the Frobenius norm already incorporated instruments by way of ExplicitOpModelCalc.frobeniusdist and ExplicitOpModelCalc.residuals. Second, gauge optimization w.r.t. trace distance or infidelity can incorporate instruments just by working with operation dicts from ``target_model._excalc()`` and ``mdl._excalc()``, rather than the operation dicts in ``target_model`` and ``mdl``.

While I was making these changes, I (1) replaced instances of np.dot with the matmul infix operator, and (2) simplified branching in explicitcalc.py.
