### PR TITLE
Develop merge of #671

### DIFF
--- a/jupyter_notebooks/Examples/Leakage-automagic.ipynb
+++ b/jupyter_notebooks/Examples/Leakage-automagic.ipynb
@@ -6,10 +6,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pygsti.modelpacks import smq1Q_XY, smq1Q_ZN\n",
+    "from pygsti.modelpacks import smq1Q_XYI as mp\n",
     "from pygsti.tools.leakage import leaky_qubit_model_from_pspec, construct_leakage_report\n",
     "from pygsti.data import simulate_data\n",
-    "from pygsti.protocols import StandardGST, ProtocolData"
+    "from pygsti.protocols import StandardGST, ProtocolData\n",
+    "import numpy as np\n",
+    "import scipy.linalg as la"
    ]
   },
   {
@@ -27,14 +29,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mp = smq1Q_XY\n",
-    "ed = mp.create_gst_experiment_design(max_max_length=32)\n",
+    "def with_leaky_gate(m, gate_label, strength):\n",
+    "    rng = np.random.default_rng(0)\n",
+    "    v = np.concatenate([[0.0], rng.standard_normal(size=(2,))])\n",
+    "    v /= la.norm(v)\n",
+    "    H = v.reshape((-1, 1)) @ v.reshape((1, -1))\n",
+    "    H *= strength\n",
+    "    U = la.expm(1j*H)\n",
+    "    m_copy = m.copy()\n",
+    "    G_ideal = m_copy.operations[gate_label]\n",
+    "    from pygsti.modelmembers.operations import ComposedOp, StaticUnitaryOp\n",
+    "    m_copy.operations[gate_label] = ComposedOp([G_ideal, StaticUnitaryOp(U, basis=m.basis)])\n",
+    "    return m_copy, v\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ed = mp.create_gst_experiment_design(max_max_length=8)\n",
+    "# ^ The default max length is small so we don't have to wait as long \n",
+    "#   for the GST fit (just for purposes of this notebook).\n",
     "tm3 = leaky_qubit_model_from_pspec(mp.processor_spec(), mx_basis='l2p1')\n",
-    "# ^ We could use basis = 'gm' instead of 'l2p1'. We prefer 'l2p1'\n",
-    "#   because it makes process matrices easier to interpret in leakage\n",
-    "#   modeling.\n",
-    "ds = simulate_data(tm3, ed.all_circuits_needing_data, num_samples=1000, seed=1997)\n",
-    "gst = StandardGST( modes=('CPTPLND',), target_model=tm3, verbosity=2)\n",
+    "# ^ Target model. \"Leaky\" is a bit of a misnomer here. The returned model\n",
+    "#   is simply a qutrit lift of the qubit model; leakage erorrs in the\n",
+    "#   qubit model can manifest as CPTP Markovian errors in the qutrit model.\n",
+    "dgm3, leaking_state = with_leaky_gate(tm3, ('Gxpi2', 0), strength=0.125)\n",
+    "# ^ Data generating model. \n",
+    "num_samples = 100_000\n",
+    "# ^ The number of samples is large to compensate for short circuit length.\n",
+    "#   Feel free to change the number of samples to something more \"realistic\"\n",
+    "#   if you'd like.\n",
+    "if num_samples > 10_000:\n",
+    "    from pygsti.objectivefns import objectivefns\n",
+    "    objectivefns.DEFAULT_MIN_PROB_CLIP = objectivefns.DEFAULT_RADIUS = 1e-12\n",
+    "    # ^ There are numerical thresholding rules in objective function evaluation\n",
+    "    #   that lead to errors when the number of samples is extremely large.\n",
+    "    #   The lines above change those thresholding rules to be appropriate in\n",
+    "    #   the unusual setting that is this notebook.\n",
+    "ds = simulate_data(dgm3, ed.all_circuits_needing_data, num_samples=num_samples, seed=1997)\n",
+    "gst = StandardGST(\n",
+    "    modes=('CPTPLND',), target_model=tm3, verbosity=2,\n",
+    "    badfit_options={'actions': ['wildcard1d'], 'threshold': 0.0}\n",
+    ")\n",
     "pd = ProtocolData(ed, ds)\n",
     "res = gst.run(pd)"
    ]

--- a/pygsti/modelmembers/operations/linearop.py
+++ b/pygsti/modelmembers/operations/linearop.py
@@ -10,14 +10,15 @@ The LinearOperator class and supporting functionality.
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+from __future__ import annotations
+
 import numpy as _np
 
 from pygsti.baseobjs.opcalc import bulk_eval_compact_polynomials_complex as _bulk_eval_compact_polynomials_complex
 from pygsti.modelmembers import modelmember as _modelmember
 from pygsti.tools import optools as _ot
+from pygsti.tools import matrixtools as _mt
 from pygsti import SpaceT
-
-from typing import Any
 
 #Note on initialization sequence of Operations within a Model:
 # 1) a Model is constructed (empty)
@@ -155,6 +156,14 @@ class LinearOperator(_modelmember.ModelMember):
         numpy.ndarray
         """
         raise NotImplementedError("to_dense(...) not implemented for %s objects!" % self.__class__.__name__)
+
+    def _to_transformed_dense(self, T_domain: _mt.OperatorLike, T_codomain: _mt.OperatorLike, on_space: SpaceT='minimal') -> _np.ndarray:
+        """
+        Return an array representation of the linear operator obtained by composing T_domain,
+        self.to_dense(), and T_codomain --- in that order.
+        """
+        out = T_codomain @ self.to_dense(on_space=on_space) @ T_domain
+        return out
 
     def acton(self, state, on_space='minimal'):
         """
@@ -390,96 +399,6 @@ class LinearOperator(_modelmember.ModelMember):
         #        import bpdb; bpdb.set_trace()
 
         return [t for t in terms_at_order if t.magnitude >= min_term_mag]
-
-    def frobeniusdist_squared(self, other_op, transform=None, inv_transform=None) -> _np.floating[Any]:
-        """
-        Return the squared frobenius difference between this operation and `other_op`
-
-        Optionally transforms this operation first using matrices
-        `transform` and `inv_transform`.  Specifically, this operation gets
-        transformed as: `O => inv_transform * O * transform` before comparison with
-        `other_op`.
-
-        Parameters
-        ----------
-        other_op : DenseOperator
-            The other operation.
-
-        transform : numpy.ndarray, optional
-            Transformation matrix.
-
-        inv_transform : numpy.ndarray, optional
-            Inverse of `transform`.
-
-        Returns
-        -------
-        float
-        """
-        self_mx = self.to_dense("minimal")
-        if transform is not None:
-            self_mx = self_mx @ transform
-        if inv_transform is not None:
-            self_mx = inv_transform @ self_mx
-        return _ot.frobeniusdist_squared(self_mx, other_op.to_dense("minimal"))
-
-
-    def frobeniusdist(self, other_op, transform=None, inv_transform=None):
-        """
-        Return the frobenius distance between this operation and `other_op`.
-
-        Optionally transforms this operation first using matrices
-        `transform` and `inv_transform`.  Specifically, this operation gets
-        transformed as: `O => inv_transform * O * transform` before comparison with
-        `other_op`.
-
-        Parameters
-        ----------
-        other_op : DenseOperator
-            The other operation.
-
-        transform : numpy.ndarray, optional
-            Transformation matrix.
-
-        inv_transform : numpy.ndarray, optional
-            Inverse of `transform`.
-
-        Returns
-        -------
-        float
-        """
-        return _np.sqrt(self.frobeniusdist_squared(other_op, transform, inv_transform))
-
-    def residuals(self, other_op, transform=None, inv_transform=None):
-        """
-        The per-element difference between this `DenseOperator` and `other_op`.
-
-        Optionally, tansforming this operation first as
-        `O => inv_transform * O * transform`.
-
-        Parameters
-        ----------
-        other_op : DenseOperator
-            The operation to compare against.
-
-        transform : numpy.ndarray, optional
-            Transformation matrix.
-
-        inv_transform : numpy.ndarray, optional
-            Inverse of `transform`.
-
-        Returns
-        -------
-        numpy.ndarray
-            A 1D-array of size equal to that of the flattened operation matrix.
-        """
-        dense_self = self.to_dense("minimal")
-        if transform is not None:
-            assert inv_transform is not None
-            dense_self = inv_transform @ (dense_self @ transform)
-        else:
-            assert inv_transform is None
-        return (dense_self - other_op.to_dense("minimal")).ravel()
-
 
     def jtracedist(self, other_op, transform=None, inv_transform=None):
         """

--- a/pygsti/modelmembers/states/state.py
+++ b/pygsti/modelmembers/states/state.py
@@ -16,7 +16,7 @@ import numpy as _np
 from pygsti.baseobjs.opcalc import bulk_eval_compact_polynomials_complex as _bulk_eval_compact_polynomials_complex
 from pygsti.modelmembers import modelmember as _modelmember
 from pygsti.baseobjs import _compatibility as _compat
-from pygsti.tools import optools as _ot
+from pygsti.tools import matrixtools as _mt
 from pygsti import SpaceT
 
 from typing import Any
@@ -129,6 +129,19 @@ class State(_modelmember.ModelMember):
         numpy.ndarray
         """
         raise NotImplementedError("to_dense(...) not implemented for %s objects!" % self.__class__.__name__)
+
+    def _to_transformed_dense(self, T_domain: _mt.OperatorLike, T_codomain: _mt.OperatorLike, on_space: SpaceT='minimal') -> _np.ndarray:
+        """
+        Return an array representation of the linear operator obtained by composing
+        self.to_dense() and T_codomain. The representation interprets states as vectors
+        in Hilbert(--Schmidt) space; it uses the canonical identification of a vector
+        `v` with a linear map `lambda c: c*v` that takes scalars to vectors.
+
+        T_domain (ignored) is only here for consistency across the ModelMember API.
+        """
+        X = self.to_dense(on_space=on_space)
+        out = T_codomain @ X
+        return out
 
     def taylor_order_terms(self, order, max_polynomial_vars=100, return_coeff_polys=False):
         """
@@ -299,62 +312,6 @@ class State(_modelmember.ModelMember):
             cpolys[0], cpolys[1], v, (len(terms_at_order),))  # an array of coeffs
         terms_at_order = [t.copy_with_magnitude(abs(coeff)) for coeff, t in zip(coeffs, terms_at_order)]
         return [t for t in terms_at_order if t.magnitude >= min_term_mag]
-
-    def frobeniusdist_squared(self, other_spam_vec, transform=None, inv_transform=None) -> _np.floating[Any]:
-        """
-        Return the squared frobenius difference between this operation and `other_spam_vec`.
-
-        Optionally transforms this vector first using `inv_transform`.
-
-        Parameters
-        ----------
-        other_spam_vec : State
-            The other spam vector
-
-        transform : numpy.ndarray, optional
-            Ignored. (We keep this as a positional argument for consistency with
-            the frobeniusdist_squared method of pyGSTi's LinearOperator objects.)
-
-        inv_transform : numpy.ndarray, optional
-            Named for consistency with the frobeniusdist_squared method of pyGSTi's
-            LinearOperator objects.
-
-        Returns
-        -------
-        float
-        """
-        vec = self.to_dense("minimal")
-        if inv_transform is not None:
-            vec = inv_transform @ vec
-        return _ot.frobeniusdist_squared(vec, other_spam_vec.to_dense("minimal"))
-
-    def residuals(self, other_spam_vec, transform=None, inv_transform=None):
-        """
-        Return a vector of residuals between this spam vector and `other_spam_vec`.
-
-        Optionally transforms this vector first using `transform` and
-        `inv_transform`.
-
-        Parameters
-        ----------
-        other_spam_vec : State
-            The other spam vector
-
-        transform : numpy.ndarray, optional
-            Transformation matrix.
-
-        inv_transform : numpy.ndarray, optional
-            Inverse of `tranform`.
-
-        Returns
-        -------
-        float
-        """
-        vec = self.to_dense("minimal")
-        if inv_transform is not None:
-            vec = inv_transform @ vec
-        return (vec - other_spam_vec.to_dense("minimal")).ravel()
-
 
     def transform_inplace(self, s):
         """

--- a/pygsti/models/explicitcalc.py
+++ b/pygsti/models/explicitcalc.py
@@ -24,10 +24,7 @@ from pygsti.tools import matrixtools as _mt
 from typing import Union
 
 
-TransformMxPair = tuple[
-    Union[_np.ndarray, _mt.IdentityOperator],
-    Union[_np.ndarray, _mt.IdentityOperator]
-]
+TransformMxPair = tuple[_mt.OperatorLike, _mt.OperatorLike]
 
 
 def to_transform_mx_pair(tmx_arg: Union[None, _np.ndarray, TransformMxPair]) -> TransformMxPair:
@@ -38,8 +35,8 @@ def to_transform_mx_pair(tmx_arg: Union[None, _np.ndarray, TransformMxPair]) -> 
         invP = _np.linalg.pinv(P)
     else:
         P, invP = tmx_arg
-        assert _mt.is_operatorlike(P)
-        assert _mt.is_operatorlike(invP)
+        assert isinstance(P,    _mt.OperatorLike)
+        assert isinstance(invP, _mt.OperatorLike)
     return P, invP
 
 # Tolerace for matrix_rank when finding rank of a *normalized* projection

--- a/pygsti/objectivefns/objectivefns.py
+++ b/pygsti/objectivefns/objectivefns.py
@@ -10,6 +10,8 @@ Defines objective-function objects
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+from typing import Optional
+
 import itertools as _itertools
 import sys as _sys
 import time as _time
@@ -28,6 +30,11 @@ from pygsti.baseobjs.nicelyserializable import NicelySerializable as _NicelySeri
 from pygsti.baseobjs.verbosityprinter import VerbosityPrinter as _VerbosityPrinter
 from pygsti.models.model import OpModel as _OpModel
 from pygsti import SpaceT
+
+
+DEFAULT_MIN_PROB_CLIP = 1e-4
+DEFAULT_RADIUS        = 1e-4
+
 
 def _objfn(objfn_cls, model, dataset, circuits=None,
            regularization=None, penalties=None, op_label_aliases=None,
@@ -186,24 +193,25 @@ class ObjectiveFunctionBuilder(_NicelySerializable):
         """
         if objective == "chi2":
             if freq_weighted_chi2:
+                mpc = RawFreqWeightedChi2Function.DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING
                 builder = FreqWeightedChi2Function.builder(
                     name='fwchi2',
                     description="Freq-weighted sum of Chi^2",
-                    regularization={'min_freq_clip_for_weighting': 1e-4})
+                    regularization={'min_freq_clip_for_weighting': mpc})
+
             else:
+                mpc = RawChi2Function.DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING
                 builder = Chi2Function.builder(
                     name='chi2',
                     description="Sum of Chi^2",
-                    regularization={'min_prob_clip_for_weighting': 1e-4})
+                    regularization={'min_prob_clip_for_weighting': mpc})
 
         elif objective == "logl":
             builder = PoissonPicDeltaLogLFunction.builder(
                 name='dlogl',
                 description="2*Delta(log(L))",
-                regularization={'min_prob_clip': 1e-4,
-                                'radius': 1e-4},
-                penalties={'cptp_penalty_factor': 0,
-                           'spam_penalty_factor': 0})
+                regularization={'min_prob_clip': DEFAULT_MIN_PROB_CLIP, 'radius': DEFAULT_RADIUS},
+                penalties={'cptp_penalty_factor': 0, 'spam_penalty_factor': 0})
 
         elif objective == "tvd":
             builder = TVDFunction.builder(
@@ -1660,6 +1668,9 @@ class RawChi2Function(RawObjectiveFunction):
     verbosity : int, optional
         Level of detail to print to stdout.
     """
+
+    DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING = DEFAULT_MIN_PROB_CLIP
+
     def __init__(self, regularization=None, resource_alloc=None, name="chi2", description="Sum of Chi^2", verbosity=0):
         super().__init__(regularization, resource_alloc, name, description, verbosity)
 
@@ -1678,7 +1689,7 @@ class RawChi2Function(RawObjectiveFunction):
         """
         return objective_function_value
 
-    def set_regularization(self, min_prob_clip_for_weighting=1e-4):
+    def set_regularization(self, min_prob_clip_for_weighting: Optional[float]=None):
         """
         Set regularization values.
 
@@ -1692,7 +1703,11 @@ class RawChi2Function(RawObjectiveFunction):
         -------
         None
         """
-        self.min_prob_clip_for_weighting = min_prob_clip_for_weighting
+        if min_prob_clip_for_weighting is not None:
+            self.min_prob_clip_for_weighting = min_prob_clip_for_weighting
+        else:
+            self.min_prob_clip_for_weighting = RawChi2Function.DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING
+        return
 
     def lsvec(self, probs, counts, total_counts, freqs, intermediates=None):
         """
@@ -2286,7 +2301,6 @@ class RawChiAlphaFunction(RawObjectiveFunction):
 
 # negative lsvec possible
 class RawFreqWeightedChi2Function(RawChi2Function):
-
     """
     The function `N(p-f)^2 / f`
 
@@ -2307,6 +2321,9 @@ class RawFreqWeightedChi2Function(RawChi2Function):
     verbosity : int, optional
         Level of detail to print to stdout.
     """
+
+    DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING = RawChi2Function.DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING
+
     def __init__(self, regularization=None, resource_alloc=None, name="fwchi2",
                  description="Sum of freq-weighted Chi^2", verbosity=0):
         super().__init__(regularization, resource_alloc, name, description, verbosity)
@@ -2326,7 +2343,7 @@ class RawFreqWeightedChi2Function(RawChi2Function):
         """
         return objective_function_value  # default is to assume the value *is* chi2_k distributed
 
-    def set_regularization(self, min_freq_clip_for_weighting=1e-4):
+    def set_regularization(self, min_freq_clip_for_weighting: Optional[float]=None):
         """
         Set regularization values.
 
@@ -2340,7 +2357,11 @@ class RawFreqWeightedChi2Function(RawChi2Function):
         -------
         None
         """
-        self.min_freq_clip_for_weighting = min_freq_clip_for_weighting
+        if min_freq_clip_for_weighting is not None:
+            self.min_freq_clip_for_weighting = min_freq_clip_for_weighting
+        else:
+            self.min_freq_clip_for_weighting = RawFreqWeightedChi2Function.DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING
+        return
 
     def _weights(self, p, f, total_counts):
         #Note: this could be computed once and cached?
@@ -2744,8 +2765,10 @@ class RawPoissonPicDeltaLogLFunction(RawObjectiveFunction):
         """
         return 2 * objective_function_value  # 2 * deltaLogL is what is chi2_k distributed
 
-    def set_regularization(self, min_prob_clip=1e-4, pfratio_stitchpt=None, pfratio_derivpt=None,
-                           radius=1e-4, fmin=None):
+    def set_regularization(self,
+            min_prob_clip=DEFAULT_MIN_PROB_CLIP, pfratio_stitchpt=None, pfratio_derivpt=None,
+            radius=DEFAULT_RADIUS, fmin=None
+        ):
         """
         Set regularization values.
 
@@ -3144,7 +3167,7 @@ class RawDeltaLogLFunction(RawObjectiveFunction):
         """
         return 2 * objective_function_value  # 2 * deltaLogL is what is chi2_k distributed
 
-    def set_regularization(self, min_prob_clip=1e-4, pfratio_stitchpt=None, pfratio_derivpt=None):
+    def set_regularization(self, min_prob_clip=DEFAULT_MIN_PROB_CLIP, pfratio_stitchpt=None, pfratio_derivpt=None):
         """
         Set regularization values.
 
@@ -5421,7 +5444,7 @@ class TimeDependentChi2Function(TimeDependentMDCObjectiveFunction):
         if method_name == 'dlsvec': return fsim._array_types_for_method('bulk_fill_timedep_dchi2')
         return super()._array_types_for_method(method_name, fsim)
 
-    def set_regularization(self, min_prob_clip_for_weighting=1e-4, radius=1e-4):
+    def set_regularization(self, min_prob_clip_for_weighting: Optional[float]=None, radius: float = DEFAULT_RADIUS):
         """
         Set regularization values.
 
@@ -5438,6 +5461,9 @@ class TimeDependentChi2Function(TimeDependentMDCObjectiveFunction):
         -------
         None
         """
+        if min_prob_clip_for_weighting is None:
+            mpc = getattr(self.raw_objfn, 'DEFAULT_MIN_PROB_CLIP_FOR_WEIGHTING', DEFAULT_MIN_PROB_CLIP)
+            min_prob_clip_for_weighting = mpc            
         self.min_prob_clip_for_weighting = min_prob_clip_for_weighting
         self.radius = radius  # parameterizes "roundness" of f == 0 terms
 
@@ -5580,7 +5606,7 @@ class TimeDependentPoissonPicLogLFunction(TimeDependentMDCObjectiveFunction):
         if method_name == 'dlsvec': return fsim._array_types_for_method('bulk_fill_timedep_dloglpp')
         return super()._array_types_for_method(method_name, fsim)
 
-    def set_regularization(self, min_prob_clip=1e-4, radius=1e-4):
+    def set_regularization(self, min_prob_clip=DEFAULT_MIN_PROB_CLIP, radius=DEFAULT_RADIUS):
         """
         Set regularization values.
 
@@ -5836,7 +5862,7 @@ def _paramvec_norm_penalty(reg_factor, paramvec):
     return out
 
 
-def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis, wrt_slice):
+def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis, wrt_slice, error_tol=1e-4):
     """
     Helper function - jacobian of CPTP penalty (sum of tracenorms of gates)
     Returns a (real) array of shape (len(mdl.operations), n_params).
@@ -5850,7 +5876,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
         #get sgn(chi-matrix) == d(|chi|_Tr)/dchi in std basis
         # so sgnchi == d(|chi_std|_Tr)/dchi_std
         chi = _tools.fast_jamiolkowski_iso_std(gate, op_basis)
-        assert(_np.linalg.norm(chi - chi.T.conjugate()) < 1e-4), \
+        assert(_np.linalg.norm(chi - chi.T.conjugate()) < error_tol), \
             "chi should be Hermitian!"
 
         # Alt#1 way to compute sgnchi (evals) - works equally well to svd below
@@ -5863,7 +5889,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
         #        _spl.sqrtm(_np.matrix(_np.dot(chi.T.conjugate(),chi)))))
 
         sgnchi = _tools.matrix_sign(chi)
-        assert(_np.linalg.norm(sgnchi - sgnchi.T.conjugate()) < 1e-4), \
+        assert(_np.linalg.norm(sgnchi - sgnchi.T.conjugate()) < error_tol), \
             "sgnchi should be Hermitian!"
 
         # get d(gate)/dp in op_basis [shape == (nP,dim,dim)]
@@ -5880,7 +5906,8 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
         m_dgate_dp_std = _np.empty((nparams, mdl.dim, mdl.dim), 'complex')
         for p in range(nparams):  # p indexes param
             m_dgate_dp_std[p] = _tools.fast_jamiolkowski_iso_std(dgate_dp[p], op_basis)  # now "M(dGdp_std)"
-            assert(_np.linalg.norm(m_dgate_dp_std[p] - m_dgate_dp_std[p].T.conjugate()) < 1e-8)  # check hermitian
+            assert(_np.linalg.norm(m_dgate_dp_std[p] - m_dgate_dp_std[p].T.conjugate()) < error_tol**2)  # check hermitian
+            # Riley note: not clear to me why we're using the square of error_tol in the above.
 
         m_dgate_dp_std = _np.conjugate(m_dgate_dp_std)  # so element-wise multiply
         # of complex number (einsum below) results in separately adding
@@ -5891,7 +5918,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
         #v =  _np.einsum("ij,aij->a",sgnchi,MdGdp_std)
         v = _np.tensordot(sgnchi, m_dgate_dp_std, ((0, 1), (1, 2)))
         v *= prefactor * (0.5 / _np.sqrt(_tools.tracenorm(chi)))  # add 0.5/|chi|_Tr factor
-        assert(_np.linalg.norm(v.imag) < 1e-4)
+        assert(_np.linalg.norm(v.imag) < error_tol)
         cp_penalty_vec_grad_to_fill[i, :] = 0.0
 
         gate_gpinds_subset, within_wrtslice, within_gpinds = _slct.intersect_within(wrt_slice, gate.gpindices)
@@ -5902,7 +5929,7 @@ def _cptp_penalty_jac_fill(cp_penalty_vec_grad_to_fill, mdl, prefactor, op_basis
     return len(mdl.operations)  # the number of leading-dim indicies we filled in
 
 
-def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_basis, wrt_slice):
+def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_basis, wrt_slice, error_tol=1e-4):
     """
     Helper function - jacobian of CPTP penalty (sum of tracenorms of gates)
     Returns a (real) array of shape ( _spam_penalty_size(mdl), n_params).
@@ -5925,11 +5952,11 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_bas
         #get sgn(denMx) == d(|denMx|_Tr)/d(denMx) in std basis
         # dmDim = denMx.shape[0]
         denmx = _tools.vec_to_stdmx(prepvec, op_basis)
-        assert(_np.linalg.norm(denmx - denmx.T.conjugate()) < 1e-4), \
+        assert(_np.linalg.norm(denmx - denmx.T.conjugate()) < error_tol), \
             "denMx should be Hermitian!"
 
         sgndm = _tools.matrix_sign(denmx)
-        assert(_np.linalg.norm(sgndm - sgndm.T.conjugate()) < 1e-4), \
+        assert(_np.linalg.norm(sgndm - sgndm.T.conjugate()) < error_tol), \
             "sgndm should be Hermitian!"
 
         # get d(prepvec)/dp in op_basis [shape == (nP,dim)]
@@ -5944,7 +5971,7 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_bas
         #v =  _np.einsum("ij,aij,ab->b",sgndm,ddenMxdV,dVdp)
         v = _np.tensordot(_np.tensordot(sgndm, ddenmx_dv, ((0, 1), (1, 2))), dv_dp, (0, 0))
         v *= prefactor * (0.5 / _np.sqrt(_tools.tracenorm(denmx)))  # add 0.5/|denMx|_Tr factor
-        assert(_np.linalg.norm(v.imag) < 1e-4)
+        assert(_np.linalg.norm(v.imag) < error_tol)
         spam_penalty_vec_grad_to_fill[i, :] = 0.0
         gpinds_subset, within_wrtslice, within_gpinds = _slct.intersect_within(wrt_slice, prepvec.gpindices)
         spam_penalty_vec_grad_to_fill[i, within_wrtslice] = v.real[within_gpinds]  # slice or array index works!
@@ -5961,11 +5988,11 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_bas
             #get sgn(EMx) == d(|EMx|_Tr)/d(EMx) in std basis
             emx = _tools.vec_to_stdmx(effectvec, op_basis)
             # dmDim = EMx.shape[0]
-            assert(_np.linalg.norm(emx - emx.T.conjugate()) < 1e-4), \
+            assert(_np.linalg.norm(emx - emx.T.conjugate()) < error_tol), \
                 "EMx should be Hermitian!"
 
             sgn_e = _tools.matrix_sign(emx)
-            assert(_np.linalg.norm(sgn_e - sgn_e.T.conjugate()) < 1e-4), \
+            assert(_np.linalg.norm(sgn_e - sgn_e.T.conjugate()) < error_tol), \
                 "sgnE should be Hermitian!"
 
             # get d(prepvec)/dp in op_basis [shape == (nP,dim)]
@@ -5980,7 +6007,7 @@ def _spam_penalty_jac_fill(spam_penalty_vec_grad_to_fill, mdl, prefactor, op_bas
             #v =  _np.einsum("ij,aij,ab->b",sgnE,dEMxdV,dVdp)
             v = _np.tensordot(_np.tensordot(sgn_e, demx_dv, ((0, 1), (1, 2))), dv_dp, (0, 0))
             v *= prefactor * (0.5 / _np.sqrt(_tools.tracenorm(emx)))  # add 0.5/|EMx|_Tr factor
-            assert(_np.linalg.norm(v.imag) < 1e-4)
+            assert(_np.linalg.norm(v.imag) < error_tol)
 
             spam_penalty_vec_grad_to_fill[i, :] = 0.0
             gpinds_subset, within_wrtslice, within_gpinds = _slct.intersect_within(wrt_slice, effectvec.gpindices)

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1,3 +1,4 @@
+
 """
 GST Protocol objects
 """
@@ -678,7 +679,7 @@ class GSTBadFitOptions(_NicelySerializable):
                  wildcard_budget_includes_spam=True,
                  wildcard_L1_weights=None, wildcard_primitive_op_labels=None,
                  wildcard_initial_budget=None, wildcard_methods=('neldermead',),
-                 wildcard_inadmissable_action='print', wildcard1d_reference='diamond distance'):
+                 wildcard_inadmissable_action='print'):
         super().__init__()
         valid_actions = ('wildcard', 'wildcard1d', 'Robust+', 'Robust', 'robust+', 'robust', 'do nothing')
         if not all([(action in valid_actions) for action in actions]):
@@ -691,7 +692,29 @@ class GSTBadFitOptions(_NicelySerializable):
         self.wildcard_initial_budget = wildcard_initial_budget
         self.wildcard_methods = wildcard_methods
         self.wildcard_inadmissable_action = wildcard_inadmissable_action  # can be 'raise' or 'print'
-        self.wildcard1d_reference = wildcard1d_reference
+
+    @property
+    def wildcard1d_reference(self):
+        msg = """
+        Users can no longer choose the metrics used in wildcard analysis.
+        This function returns the string "diamond distance", as the current
+        behavior of wildcard analysis is the same as though this string had
+        been specified in earlier versions of pyGSTi.
+        """
+        _warnings.warn(msg)
+        return 'diamond distance'
+    
+    @wildcard1d_reference.setter
+    def wildcard1d_reference(self, val):
+        if val == 'diamond distance':
+            return
+        msg = f"""
+        Users can no longer choose the metrics used in wildcard analysis.
+        The only supported behavior is what used to be specified with the
+        string "diamond distance". The provided value, {val}, is not equal
+        to this string.
+        """
+        raise RuntimeError(msg)
 
     def _to_nice_serialization(self):
         state = super()._to_nice_serialization()
@@ -702,8 +725,7 @@ class GSTBadFitOptions(_NicelySerializable):
                                    'primitive_op_labels': self.wildcard_primitive_op_labels,
                                    'initial_budget': self.wildcard_initial_budget,  # serializable?
                                    'methods': self.wildcard_methods,
-                                   'indadmissable_action': self.wildcard_inadmissable_action,
-                                   '1d_reference': self.wildcard1d_reference},
+                                   'indadmissable_action': self.wildcard_inadmissable_action},
                       })
         return state
 
@@ -716,8 +738,7 @@ class GSTBadFitOptions(_NicelySerializable):
                    wildcard.get('primitive_op_labels', None),
                    wildcard.get('initial_budget', None),
                    tuple(wildcard.get('methods', ['neldermead'])),
-                   wildcard.get('inadmissable_action', 'print'),
-                   wildcard.get('1d_reference', 'diamond distance'))
+                   wildcard.get('inadmissable_action', 'print'))
 
 
 class GSTObjFnBuilders(_NicelySerializable):
@@ -1511,6 +1532,7 @@ class GateSetTomography(_proto.Protocol):
         
         return ret
 
+
 class LinearGateSetTomography(_proto.Protocol):
     """
     The linear gate set tomography protocol.
@@ -1971,13 +1993,6 @@ def _load_pspec(processorspec_filename_or_obj):
         return processorspec_filename_or_obj
 
 
-def _load_model(model_filename_or_obj):
-    if isinstance(model_filename_or_obj, str):
-        return _io.load_model(model_filename_or_obj)
-    else:
-        return model_filename_or_obj  # assume a Model object
-
-
 def _load_pspec_or_model(processorspec_or_model_filename_or_obj):
     if isinstance(processorspec_or_model_filename_or_obj, str):
         # if a filename is given, just try to load a processor spec (can't load a model file yet)
@@ -2008,25 +2023,6 @@ def _load_fiducials_and_germs(prep_fiducial_list_or_filename,
     else: germs = germ_list_or_filename
 
     return prep_fiducials, meas_fiducials, germs
-
-
-def _load_dataset(data_filename_or_set, comm, verbosity):
-    """Loads a DataSet from the data_filename_or_set argument of functions in this module."""
-    printer = _baseobjs.VerbosityPrinter.create_printer(verbosity, comm)
-    if isinstance(data_filename_or_set, str):
-        if comm is None or comm.Get_rank() == 0:
-            if _os.path.splitext(data_filename_or_set)[1] == ".pkl":
-                with open(data_filename_or_set, 'rb') as pklfile:
-                    ds = _pickle.load(pklfile)
-            else:
-                ds = _io.read_dataset(data_filename_or_set, True, "aggregate", printer)
-            if comm is not None: comm.bcast(ds, root=0)
-        else:
-            ds = comm.bcast(None, root=0)
-    else:
-        ds = data_filename_or_set  # assume a Dataset object
-
-    return ds
 
 
 def _add_gaugeopt_and_badfit(results, estlbl, target_model, gaugeopt_suite,
@@ -2243,19 +2239,16 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
             #If this estimate is the target model then skip adding the diamond distance wildcard.
             if base_estimate_label != 'Target':
                 try:
-                    budget = _compute_wildcard_budget_1d_model(base_estimate, objfn_cache, mdc_objfn, parameters,
-                                                               badfit_options, printer - 1, gaugeopt_suite)
-                    
+                    budget = _compute_wildcard_budget_1d_model(base_estimate, mdc_objfn, printer - 1, gaugeopt_suite)
                     #if gaugeopt_labels is None then budget with be a PrimitiveOpsSingleScaleWildcardBudget
                     #if it was non-empty though then we'll instead have budge as a dictionary with keys
                     #corresponding to the elements of gaugeopt_labels. In this case let's  make
                     #base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] a dictionary of
                     #the serialized PrimitiveOpsSingleScaleWildcardBudget elements
-                    if gaugeopt_suite is not None and gaugeopt_suite.gaugeopt_suite_names is not None:
-                        gaugeopt_labels = gaugeopt_suite.gaugeopt_suite_names
+                    if gaugeopt_suite is not None:
+                        gaugeopt_labels = budget.keys()
                         base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = {lbl: budget[lbl].to_nice_serialization() for lbl in gaugeopt_labels} 
-                        base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] \
-                            = None
+                        base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] = None
 
                         base_estimate.extra_parameters["unmodeled_error"] = {lbl: budget[lbl].to_nice_serialization() for lbl in gaugeopt_labels}
                         base_estimate.extra_parameters["unmodeled_active_constraints"] = None
@@ -2316,7 +2309,7 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
                     gauge_opt_params.copy(), go_gs_final, gokey, comm, printer - 1)
 
 
-def _compute_wildcard_budget_1d_model(estimate, objfn_cache, mdc_objfn, parameters, badfit_options, verbosity, gaugeopt_suite=None):
+def _compute_wildcard_budget_1d_model(estimate, mdc_objfn, verbosity, gaugeopt_suite):
     """
     Create a wildcard budget for a model estimate. This version of the function produces a wildcard estimate
     using the model introduced in https://doi.org/10.1038/s41534-023-00764-y.
@@ -2326,19 +2319,11 @@ def _compute_wildcard_budget_1d_model(estimate, objfn_cache, mdc_objfn, paramete
     estimate : Estimate
         The estimate object containing the model and data to be used.
 
-    objfn_cache : ObjectiveFunctionCache
-        A cache for objective function evaluations.
-
     mdc_objfn : ModelDatasetCircuitsStore
         An object that stores the model, dataset, and circuits to be used in the computation.
 
     parameters : dict
         Various parameters of the estimate at hand.
-
-    badfit_options : GSTBadFitOptions, optional
-        Options specifying what post-processing actions should be performed when
-        a fit is unsatisfactory. Contains detailed parameters for wildcard budget
-        creation.
 
     verbosity : int, optional
         Level of detail printed to stdout.
@@ -2351,12 +2336,10 @@ def _compute_wildcard_budget_1d_model(estimate, objfn_cache, mdc_objfn, paramete
     Returns
     -------
     PrimitiveOpsWildcardBudget or dict
-        The computed wildcard budget. If gauge optimization is applied, a dictionary of 
-        budgets keyed by gauge optimization labels is returned.
+        A dictionary of budgets keyed by gauge optimization labels.
 
     """
     printer = _baseobjs.VerbosityPrinter.create_printer(verbosity, mdc_objfn.resource_alloc)
-    badfit_options = GSTBadFitOptions.cast(badfit_options)
     model = mdc_objfn.model
     ds = mdc_objfn.dataset
     global_circuits_to_use = mdc_objfn.global_circuits
@@ -2378,152 +2361,149 @@ def _compute_wildcard_budget_1d_model(estimate, objfn_cache, mdc_objfn, paramete
     two_dlogl_threshold = _chi2.ppf(1 - percentile, max(ds_dof - nparams, 1))
     redbox_threshold = _chi2.ppf(1 - percentile / nboxes, 1)
 
-    ref, reference_name = _compute_1d_reference_values_and_name(estimate, badfit_options, gaugeopt_suite)
+    target = gaugeopt_suite.gaugeopt_target
+    if target is None:
+        target = estimate.models['target']
 
-    if gaugeopt_suite is None or gaugeopt_suite.gaugeopt_suite_names is None:
-        gaugeopt_labels = None
-        primitive_ops = list(ref.keys())
-        if sum([v**2 for v in ref.values()]) < 1e-4:
-            _warnings.warn("Reference values for 1D wildcard budget are all near-zero!"
-                           " This usually indicates an incorrect target model and will likely cause problems computing alpha.")
+    # Getting the dict of gauge-optimized models is very annoying.
+    if gaugeopt_suite.gaugeopt_argument_dicts is None:
+        gaugeopt_suite.gaugeopt_argument_dicts = dict()
+        # ^ We make that assignment because _compute_1d_reference_values
+        #   queries this dict with the `.get(k, default_value)` syntax.
+    gop_dicts = gaugeopt_suite.gaugeopt_argument_dicts
+    gop_names = gaugeopt_suite.gaugeopt_suite_names
+    if gop_names is None:
+        gop_names = [gn for gn in gop_dicts if gn in estimate.models]
 
-    else:
-        gaugeopt_labels = gaugeopt_suite.gaugeopt_suite_names
-        primitive_ops = list(ref[list(gaugeopt_labels)[0]].keys())
-        if sum([v**2 for v in ref[list(gaugeopt_labels)[0]].values()]) < 1e-4:
-            _warnings.warn("Reference values for 1D wildcard budget are all near-zero!"
-                           " This usually indicates an incorrect target model and will likely cause problems computing alpha.")
+    goped_models = {lbl: estimate.models[lbl] for lbl in gop_names}
+    if len(goped_models) == 0:
+        final_iter_model = estimate.models['final iteration estimate']
+        if isinstance(final_iter_model, _ExplicitOpModel):
+            goped_model = _alg.gaugeopt_to_target(final_iter_model, target)
+            goped_models['simple gaugeopt'] = goped_model
+        else:
+            goped_models['no gaugeopt'] = final_iter_model
 
-    if gaugeopt_labels is None:
-        wcm = _wild.PrimitiveOpsSingleScaleWildcardBudget(primitive_ops, [ref[k] for k in primitive_ops],
-                                                      reference_name=reference_name)
-        _opt.wildcardopt.optimize_wildcard_bisect_alpha(wcm, mdc_objfn, two_dlogl_threshold, redbox_threshold, printer,
+    from pygsti.baseobjs.label import Label
+    ref : dict[str,dict[Label, float]] = _compute_1d_reference_values(target, goped_models, gaugeopt_suite)
+    reference_name = 'diamond distance'
+
+    gaugeopt_labels = list(ref.keys())
+    primitive_ops   = list(ref[gaugeopt_labels[0]].keys())
+    if sum([v**2 for v in  ref[gaugeopt_labels[0]].values()]) < 1e-4:
+         _warnings.warn("Reference values for 1D wildcard budget are all near-zero!"
+                        " This usually indicates an incorrect target model and will likely cause problems computing alpha.")
+
+    wcm = {lbl:_wild.PrimitiveOpsSingleScaleWildcardBudget(primitive_ops, [ref[lbl][k] for k in primitive_ops],
+                                                    reference_name=reference_name) for lbl in gaugeopt_labels}
+    for budget_to_optimize in wcm.values():
+        _opt.wildcardopt.optimize_wildcard_bisect_alpha(budget_to_optimize, mdc_objfn, two_dlogl_threshold, redbox_threshold, printer,
                                                 guess=0.1, tol=1e-3)  # results in optimized wcm
-    else:
-        wcm = {lbl:_wild.PrimitiveOpsSingleScaleWildcardBudget(primitive_ops, [ref[lbl][k] for k in primitive_ops],
-                                                      reference_name=reference_name) for lbl in gaugeopt_labels}
-        for budget_to_optimize in wcm.values():
-            _opt.wildcardopt.optimize_wildcard_bisect_alpha(budget_to_optimize, mdc_objfn, two_dlogl_threshold, redbox_threshold, printer,
-                                                    guess=0.1, tol=1e-3)  # results in optimized wcm
 
     return wcm
 
 
-def _compute_1d_reference_values_and_name(estimate, badfit_options, gaugeopt_suite=None):
+def _compute_1d_reference_values(target_model: _ExplicitOpModel, gopped_models: dict[str, _ExplicitOpModel], gaugeopt_suite: GSTGaugeOptSuite):
     """
-    Compute the reference values and name for the 1D wildcard budget.
+    Compute the reference values the 1D wildcard budget.
 
     Parameters
     ----------
-    estimate : Estimate
-        The estimate object containing the models to be used.
+    target_model: _ExplicitOpModel
 
-    badfit_options : GSTBadFitOptions
-        Options specifying what post-processing actions should be performed when
-        a fit is unsatisfactory. Contains detailed parameters for wildcard budget
-        creation.
+    gopped_models: dict[str, ExplicitOpModel]
+        This is more or less a subset of `est.models` for some ModelEstimateResults `est`,
+        where values in gopped_models has been somehow gauge-optimized to target_model.
 
-    gaugeopt_suite : GSTGaugeOptSuite, optional (default None)
-        The gauge optimization suite used by the estimate. If None, final iteration
-        estimate will be used.
+    gaugeopt_suite : GSTGaugeOptSuite
+        The gauge optimization suite used by some parent ModelEstimatResults object.
+        It is expected, but not required, that gopped_models.keys() coincide with
+        gaugeopt_suite.gaugeopt_argument_dicts.keys().
 
     Returns
     -------
-    dict or dict of dicts
-        The computed reference values for the 1D wildcard budget. If gauge optimization is applied,
-        a dictionary of reference values keyed by gauge optimization labels is returned.
-
-    str
-        The name of the reference metric used.
+    dict of dicts
+        A dictionary of 1D wildcard budget reference values, sharing the same keys as gopped_models.
     """
-    if badfit_options.wildcard1d_reference == 'diamond distance':
-        if gaugeopt_suite is None or gaugeopt_suite.gaugeopt_suite_names is None:
-            final_model = estimate.models['final iteration estimate']
-            target_model = estimate.models['target']
+    assert isinstance(gopped_models, dict)
+    assert all([isinstance(k, str) for k in gopped_models])
 
-            if isinstance(final_model, _ExplicitOpModel):
-                gaugeopt_model = _alg.gaugeopt_to_target(final_model, target_model)
-                operations_dict = gaugeopt_model.operations
-                targetops_dict = target_model.operations 
-                preps_dict = gaugeopt_model.preps
-                targetpreps_dict = target_model.preps
-                povmops_dict = gaugeopt_model.povms
-                insts_dict = gaugeopt_model.instruments
-                targetinsts_dict = target_model.instruments
-
-            else:
-                # Local/cloud noise models don't have default_gauge_group attribute and can't be gauge
-                #  optimized - at least not easily.
-                gaugeopt_model = final_model
-                operations_dict = gaugeopt_model.operation_blks['gates']
-                targetops_dict = target_model.operation_blks['gates']
-                preps_dict = gaugeopt_model.prep_blks['layers']
-                targetpreps_dict = target_model.prep_blks['layers']
-                povmops_dict = {}  # HACK - need to rewrite povm_diamonddist below to work
-                insts_dict = gaugeopt_model.instrument_blks['layers']
-                targetinsts_dict = target_model.instrument_blks['layers']
-
-            dd = {}
-            for key, op in operations_dict.items():
-                dd[key] = 0.5 * _tools.diamonddist(op.to_dense(), targetops_dict[key].to_dense())
-                if dd[key] < 0:  # indicates that diamonddist failed (cvxpy failure)
-                    _warnings.warn(("Diamond distance failed to compute %s reference value for 1D wildcard budget!"
-                                    " Falling back to trace distance.") % str(key))
-                    dd[key] = _tools.jtracedist(op.to_dense(), targetops_dict[key].to_dense())
-            
-            for key, op in insts_dict.items():
-                inst_dd = 0.5* _tools.instrument_diamonddist(op, targetinsts_dict[key])
-                if inst_dd < 0: # indicates that instrument_diamonddist failed
-                    _warnings.warn(("Diamond distance failed to compute %s reference value for 1D wildcard budget!"
-                                    "No fallback presently available for instruments, so skipping.") % str(key))
-                else:
-                    dd[key] = inst_dd
-
-            spamdd = {}
-            for key, op in preps_dict.items():
-                spamdd[key] = _tools.tracedist(_tools.vec_to_stdmx(op.to_dense(), 'pp'),
-                                               _tools.vec_to_stdmx(targetpreps_dict[key].to_dense(), 'pp'))
-
-            for key in povmops_dict.keys():
-                spamdd[key] = 0.5 * _tools.optools.povm_diamonddist(gaugeopt_model, target_model, key)
-
-            dd['SPAM'] = sum(spamdd.values())
-
+    def _memberdicts(_m) -> tuple[dict,dict,dict,dict]:
+        if isinstance(_m, _ExplicitOpModel):
+            ops   = _m.operations
+            preps = _m.preps
+            povms = _m.povms
+            insts = _m.instruments
         else:
-            #pull the target model from the gaugeopt suite. The GSTGaugeOptSuite doesn't currently
-            #support multiple targets, so this is safe for now.
-            target_model = gaugeopt_suite.gaugeopt_target
-            gaugeopt_models = [estimate.models[lbl] for lbl in gaugeopt_suite.gaugeopt_suite_names]
-            dd = {lbl: {} for lbl in gaugeopt_suite.gaugeopt_suite_names}
-            for gaugeopt_model, lbl in zip(gaugeopt_models, gaugeopt_suite.gaugeopt_suite_names):
-                for key, op in gaugeopt_model.operations.items():
-                    dd[lbl][key] = 0.5 * _tools.diamonddist(op.to_dense(), target_model.operations[key].to_dense())
-                    if dd[lbl][key] < 0:  # indicates that diamonddist failed (cvxpy failure)
-                        _warnings.warn(("Diamond distance failed to compute %s reference value for 1D wildcard budget!"
-                                        " Falling back to trace distance.") % str(key))
-                        dd[lbl][key] = _tools.jtracedist(op.to_dense(), target_model.operations[key].to_dense())
+            ops   = _m.operation_blks['gates']
+            preps = _m.prep_blks['layers']
+            povms = {} # disabled until povm_diamonddist can handle non-ExplicitOpModels.
+            insts = _m.instrument_blks['layers']
+        return ops, preps, povms, insts
 
-                for key, op in gaugeopt_model.instruments.items():
-                    inst_dd = 0.5* _tools.instrument_diamonddist(op, target_model.instruments[key], gaugeopt_model.basis)
-                    if inst_dd < 0: # indicates that instrument_diamonddist failed
-                        _warnings.warn(("Diamond distance failed to compute %s reference value for 1D wildcard budget!"
-                                        "No fallback presently available for instruments, so skipping.") % str(key))
-                    else:
-                        dd[lbl][key] = inst_dd
-                spamdd = {}
-                for key, op in gaugeopt_model.preps.items():
-                    spamdd[key] = _tools.tracedist(_tools.vec_to_stdmx(op.to_dense(), 'pp'),
-                                                _tools.vec_to_stdmx(target_model.preps[key].to_dense(), 'pp'))
+    target_ops, target_preps, target_povms, target_insts = _memberdicts(target_model)
 
-                for key in gaugeopt_model.povms.keys():
-                    spamdd[key] = 0.5 * _tools.optools.povm_diamonddist(gaugeopt_model, target_model, key)
+    dd = {lbl: dict() for lbl in gopped_models}
+    for lbl, gaugeopt_model in gopped_models.items():
 
-                dd[lbl]['SPAM'] = sum(spamdd.values())
+        argdicts = gaugeopt_suite.gaugeopt_argument_dicts.get(lbl, dict())
+        n_leak: int = 0
+        if isinstance(argdicts, list) and len(argdicts) > 0:
+            n_leak = argdicts[0].get('n_leak', n_leak)
 
-        return dd, 'diamond distance'
-    else:
-        raise ValueError("Invalid wildcard1d_reference value (%s) in bad-fit options!"
-                         % str(badfit_options.wildcard1d_reference))
+        basis = gaugeopt_model.basis
+        udim = int(_np.round(_np.sqrt(basis.dim)))
+        I = _tools.matrixtools.IdentityOperator()
+        if n_leak == 0:
+            P = I
+        elif n_leak > 0:
+            U = _tools.leading_dxd_submatrix_basis_vectors(udim - n_leak, udim, basis)
+            P = U @ U.T.conj()
+            P = P.real
+
+        ops, preps, _, insts = _memberdicts(gaugeopt_model)
+
+        for key, op in ops.items():
+            X = op.to_dense()
+            Y = target_ops[key].to_dense()
+            X_restricted = X @ P
+            Y_restricted = Y @ P
+            dd[lbl][key] : float = 0.5 * _tools.diamonddist(X_restricted, Y_restricted, mx_basis=basis) # type: ignore
+            if dd[lbl][key] < 0:  # indicates that diamonddist failed (cvxpy failure)
+                msg = f"""
+                Diamond distance failed to compute {key} reference value for 1D wildcard budget!
+                Falling back to trace distance.
+                """
+                _warnings.warn(msg)
+                dd[lbl][key] = _tools.subspace_jtracedist(X, Y, basis, n_leak=n_leak)
+        
+        for key, op in insts.items():
+            inst_dd : float = 0.5* _tools.instrument_diamonddist(
+                op, target_insts[key], mx_basis=basis, _premultiplier=P # type: ignore
+            )
+            if inst_dd < 0: # indicates that instrument_diamonddist failed
+                msg = f"""
+                Diamond distance failed to compute {key} reference value for 1D wildcard budget!
+                No fallback presently available for instruments, so skipping.
+                """
+                _warnings.warn(msg)
+            else:
+                dd[lbl][key] = inst_dd
+
+        spamdd = {}
+        for key, op in preps.items():
+            rho1 = _tools.vec_to_stdmx(op.to_dense(), basis=basis)
+            rho2 = _tools.vec_to_stdmx(target_preps[key].to_dense(), basis=basis)
+            spamdd[key] = _tools.tracedist(rho1, rho2)
+
+        for key in target_povms:
+            spamdd[key] = 0.5 * _tools.optools.povm_diamonddist(
+                gaugeopt_model, target_model, key, _premultiplier=P  # type: ignore
+            )
+
+        dd[lbl]['SPAM'] = sum(spamdd.values())
+
+    return dd
 
 
 def _compute_robust_scaling(scale_typ, objfn_cache, mdc_objfn):
@@ -3301,6 +3281,11 @@ def _add_param_preserving_gauge_opt(results: ModelEstimateResults, est_key: str,
             ggel = gop_dictorlist['_gaugeGroupEl']
         model_implicit_gauge = transform_composed_model(est.models['final iteration estimate'], ggel)
         est.models[gop_name] = model_implicit_gauge
+    protocol = est.parameters['protocol']
+    badfit_options = protocol.badfit_options
+    optimizer = protocol.optimizer
+    resource_alloc = _baseobjs.resourceallocation.ResourceAllocation()
+    _add_badfit_estimates(results, est_key, badfit_options, optimizer, resource_alloc, verbosity, gaugeopt_suite=gop_params)
     return
 
 

--- a/pygsti/tools/matrixtools.py
+++ b/pygsti/tools/matrixtools.py
@@ -13,7 +13,8 @@ Matrix related utility functions
 import functools as _functools
 import itertools as _itertools
 import warnings as _warnings
-import typing as _typing
+
+from typing import Protocol, Any, runtime_checkable, TypeVar
 
 import numpy as _np
 import scipy.linalg as _spl
@@ -2397,8 +2398,25 @@ def sign_fix_qr(q, r, tol=1e-6):
     return qq, rr
 
 
-def is_operatorlike(obj: _typing.Any) -> bool:
-    return hasattr(obj, '__matmul__') and hasattr(obj, '__rmatmul__') and hasattr(obj, 'T') and hasattr(obj, 'conj')
+# a TypeVar to allow methods to return "self"
+_T = TypeVar("_T", bound="OperatorLike")
+
+
+@runtime_checkable
+class OperatorLike(Protocol[_T]): # type: ignore
+
+    @property
+    def T(self) -> _T:
+        ...
+
+    def __matmul__(self, other: Any) -> Any:
+        ...
+
+    def __rmatmul__(self, other: Any) -> Any:
+        ...
+
+    def conj(self) -> _T:
+        ...
 
 
 class IdentityOperator:
@@ -2422,10 +2440,10 @@ class IdentityOperator:
     #   has __array_priority__ of 10). 
     #
 
-    def __matmul__(self, other: _typing.Any) -> _typing.Any:
+    def __matmul__(self, other: Any) -> Any:
         return other
     
-    def __rmatmul__(self, other: _typing.Any) -> _typing.Any:
+    def __rmatmul__(self, other: Any) -> Any:
         return other
     
     @property
@@ -2434,3 +2452,12 @@ class IdentityOperator:
     
     def conj(self):
         return self
+
+
+def to_operatorlike(obj):
+    if obj is None:
+        return IdentityOperator()
+    elif isinstance(obj, OperatorLike):
+        return obj
+    else:
+        raise ValueError()

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -980,7 +980,7 @@ def povm_jtracedist(model, target_model, povmlbl):
         return _np.nan
 
 
-def povm_diamonddist(model, target_model, povmlbl):
+def povm_diamonddist(model, target_model, povmlbl, _premultiplier=None):
     """
     Computes the diamond distance between POVM maps using :func:`diamonddist`.
 
@@ -998,10 +998,19 @@ def povm_diamonddist(model, target_model, povmlbl):
     Returns
     -------
     float
+
+    Notes
+    -----
+    _premultiplier is not in the public API. It's here for the time being
+    to facilitate leakage modeling. When present, it's a projector built
+    from pygsti.tools.leading_dxd_submatrix_basis_vectors.
     """
     try:
         povm_mx = compute_povm_map(model, povmlbl)
         target_povm_mx = compute_povm_map(target_model, povmlbl)
+        if isinstance(_premultiplier, _np.ndarray):
+            povm_mx = povm_mx @ _premultiplier
+            target_povm_mx = target_povm_mx @ _premultiplier
         return diamonddist(povm_mx, target_povm_mx, target_model.basis)
     except AssertionError as e:
         assert '`dim` must be a perfect square' in str(e)
@@ -1032,7 +1041,7 @@ def instrument_infidelity(a, b, mx_basis):
     return 1 - sum(sqrt_component_fidelities)**2
 
 
-def instrument_diamonddist(a, b, mx_basis):
+def instrument_diamonddist(a, b, mx_basis, _premultiplier=None):
     """
     The diamond distance between instruments a and b.
 
@@ -1050,6 +1059,12 @@ def instrument_diamonddist(a, b, mx_basis):
     Returns
     -------
     float
+
+    Notes
+    -----
+    _premultiplier is not in the public API. It's here for the time being
+    to facilitate leakage modeling. When present, it's a projector built
+    from pygsti.tools.leading_dxd_submatrix_basis_vectors.
     """
     #Turn instrument into a CPTP map on qubit + classical space.
     adim = a.state_space.dim
@@ -1064,6 +1079,11 @@ def instrument_diamonddist(a, b, mx_basis):
             cc, dd = j * adim, (j + 1) * adim
             composite_op[aa:bb, cc:dd] = a[clbl].to_dense("HilbertSchmidt")
             composite_top[aa:bb, cc:dd] = b[clbl].to_dense("HilbertSchmidt")
+    if isinstance(_premultiplier, _np.ndarray):
+        P = _np.kron(_np.eye(nComps), _premultiplier)
+        composite_op  = composite_op  @ P
+        composite_top = composite_top @ P
+
     return diamonddist(composite_op, composite_top, sumbasis)
 
 

--- a/test/unit/tools/test_leakage_gst_pipeline.py
+++ b/test/unit/tools/test_leakage_gst_pipeline.py
@@ -1,28 +1,104 @@
 
 
-from pygsti.modelpacks import smq1Q_XY
+from pygsti.modelpacks import smq1Q_XYI
 from pygsti.tools.leakage import leaky_qubit_model_from_pspec, construct_leakage_report
 from pygsti.data import simulate_data
 from pygsti.protocols import StandardGST, ProtocolData
 import unittest
+import numpy as np
+import scipy.linalg as la
+
+
+def with_leaky_gate(m, gate_label, strength):
+    rng = np.random.default_rng(0)
+    v = np.concatenate([[0.0], rng.standard_normal(size=(2,))])
+    v /= la.norm(v)
+    H = v.reshape((-1, 1)) @ v.reshape((1, -1))
+    H *= strength
+    U = la.expm(1j*H)
+    m_copy = m.copy()
+    G_ideal = m_copy.operations[gate_label]
+    from pygsti.modelmembers.operations import ComposedOp, StaticUnitaryOp
+    m_copy.operations[gate_label] = ComposedOp([G_ideal, StaticUnitaryOp(U, basis=m.basis)])
+    return m_copy, v
 
 
 class TestLeakageGSTPipeline(unittest.TestCase):
     """
-    This is a system-integration smoke test for our leakage modeling abilities.
+    This is a simple system-integration test for our leakage modeling abilities;
+    it takes just under 1 minute to run on an Apple M2 Max machine.
     """
 
-    def test_smoke(self):
+    def test_pipeline_1Q_XYI(self):
         # This is adapted from the Leakage-automagic ipython notebook.
-        mp = smq1Q_XY
-        ed = mp.create_gst_experiment_design(max_max_length=32)
-        tm3 = leaky_qubit_model_from_pspec(mp.processor_spec(), mx_basis='l2p1')
-        ds = simulate_data(tm3, ed.all_circuits_needing_data, num_samples=1000, seed=1997)
-        gst = StandardGST( modes=('CPTPLND',), target_model=tm3, verbosity=2)
+        mp = smq1Q_XYI
+        ed = mp.create_gst_experiment_design(max_max_length=8)
+        # ^ The max length is small so we don't have to wait as long for the GST fit.
+        tm3 = leaky_qubit_model_from_pspec(mp.processor_spec())
+        # ^ Target model.
+        dgm3, _ = with_leaky_gate(tm3, ('Gxpi2', 0), strength=0.125)
+        # ^ Data generating model. 
+        num_samples = 100_000
+        # ^ The number of samples is large to compensate for short circuit length.
+        from pygsti.objectivefns import objectivefns
+        objectivefns.DEFAULT_MIN_PROB_CLIP = objectivefns.DEFAULT_RADIUS = 1e-12
+        # ^ The lines above change numerical thresholding rules in objective evaluation
+        #   to be appropriate when the number of shots/circuit is extremely large.
+        ds = simulate_data(dgm3, ed.all_circuits_needing_data, num_samples=num_samples, seed=1997)
+        gst = StandardGST(
+            modes=('CPTPLND',), target_model=tm3, verbosity=2,
+            badfit_options={'actions': ['wildcard1d'], 'threshold': 0.0}
+        )
         pd = ProtocolData(ed, ds)
         res = gst.run(pd)
         _, updated_res = construct_leakage_report(res, title='easy leakage analysis!')
+        # ^ we do that as a smoke test for construct_leakage_report and to get our hands
+        #   on the results updated with leakage-aware gauge optimization.
         est = updated_res.estimates['CPTPLND']
-        assert 'LAGO' in est.models
-        # ^ That's the leakage-aware version of 'stdgaugeopt'
+
+        """
+        Original results are shown below. We don't rely on the exact numbers here. What matters is
+        qualitative aspects of how Gxpi2 and Gypi2 deviate from their respective targets. Since our
+        data generating model only applied leakage to Gxpi2, a "good" result reports much more error
+        in Gxpi2 than Gypi2. (It's not clear to me why stdgaugeopt lacks wildcard error.)
+
+        Leakage-aware guage optimization.
+
+            | Gate    | ent. infidelity | 1/2 trace dist | 1/2 diamond dist | Max TOP  | Unmodeled error |
+            |---------|-----------------|----------------|------------------|----------|-----------------|
+            | []      | 0.000001        | 0.000522       | 0.000729         | 0.000384 | 0.000001        |
+            | Gxpi2:0 | 0.00207         | 0.045378       | 0.062144         | 0.048625 | 0.003824        |
+            | Gypi2:0 | 0.000188        | 0.013716       | 0.016257         | 0.010192 | 0.000152        |
+        
+        Standard gauge optimization
+
+            | Gate    | ent. infidelity | 1/2 trace dist | 1/2 diamond dist | Max TOP  |
+            |---------|-----------------|----------------|------------------|----------|
+            | []      | 0.000006        | 0.002033       | 0.002866         | 0.002749 |
+            | Gxpi2:0 | 0.00061         | 0.024568       | 0.032364         | 0.024514 |
+            | Gypi2:0 | 0.000602        | 0.024526       | 0.033052         | 0.023098 |
+
+        We'll run tests with subspace entanglement infidelity.
+
+            * For LAGO, infidelity of Gxpi2 is 10x larger than that of Gypi2;
+              we'll test for a 5x difference.
+            
+            * For standard gauge optimization, Gxpi2 and Gypi2 have almost identical infidelities;
+              we'll test for a factor 1.1x there.
+        """
+        from pygsti.tools.leakage import subspace_entanglement_fidelity as fidelity
+        
+        mdls = {lbl: est.models[lbl] for lbl in {'target', 'LAGO', 'stdgaugeopt'}}
+        assert mdls['target'].basis.name == mdls['stdgaugeopt'].basis.name == mdls['LAGO'].basis.name == 'l2p1'
+
+        gates = dict()
+        for lbl, mdl in mdls.items():
+            gates[lbl] = {g: mdl.operations[(f'G{g}pi2',0)].to_dense() for g in ['x', 'y']}
+
+        infids = dict()
+        for lbl in ['LAGO', 'stdgaugeopt']:
+            infids[lbl] = {g: 1 - fidelity(gates[lbl][g], gates['target'][g], 'l2p1', n_leak=1) for g in ['x', 'y'] } 
+
+        self.assertGreater( infids['LAGO']['x'],        5.0 * infids['LAGO']['y']        )
+        self.assertLess(    infids['stdgaugeopt']['x'], 1.1 * infids['stdgaugeopt']['y'] )
         return


### PR DESCRIPTION
The auto-merge of #671 from bugfix into develop failed, so this PR is handling that manually.

Description from bugfix merge below.

> This PR is split off from #664. It fixes how wildcard error is computed in leakage modeling. When merged it will resolve #652. It also includes changes to the default leakage-aware gauge optimization suite. The latter changes are needed to prevent gauge optimization from trying to spuriously "spread out" relational errors across available gates.
> 
> This PR adds a meaningful correctness test for leakage GST modeling. To reduce the time of the test I used a huge number of shots per circuit in the simulated dataset. This led to errors with "min_prob_clip" constants in objective function evaluation. In order to resolve those errors I replaced hard-coded instances of that constant's default value (1e-4) to values of a module-wide constant; I made similar changes for "radius" constants in objective functions.
> 
> Finally, this PR adds implementations of frobeniusdist, frobeniusdist_squared, and residual to ModelMember, and removes the implementation of these functions from all child classes. Removing the child class implementation become possible because the ModelMember.residual implementation relies on a new method, ModelMember._to_transformed_dense(...), that child classes must implement. The semantics of _to_transformed_dense are documented in ModelMember. I provided implementations for base classes for POVM effects, states, and linear operators. 
> 
> (This PR is a superset of the since-closed PR #670, which started from develop instead of bugfix.)