### PR TITLE
Fix ReadTheDocs Build Failure

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,9 @@ import logging
 import os
 import sys
 
-from pkg_resources import get_distribution
+from importlib.metadata import version as _version
+
+
 
 # autoclass sometimes wants stubs that aren't needed, so suppress unneccessary log spam
 logging.getLogger('sphinx').addFilter(lambda r: not r.msg.startswith("autosummary: stub file not found"))
@@ -79,7 +81,12 @@ author = u'Erik Nielsen, Kenneth Rudinger, John King Gamble, Robin Blume-Kohout'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_distribution('pygsti').version
+try:
+    # Get the version of a specific package, e.g., 'requests'
+    release = _version("pygsti")
+except:
+    print("The 'pygsti' package was not found.")
+
 # The short X.Y.Z version.
 version = '.'.join((release.split('.') + ['0'] * 2)[:3])
 

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -5,6 +5,6 @@ plotly
 pandas
 networkx
 numpydoc
-sphinx==6.2.1
-sphinx_rtd_theme>=1.2.2
+sphinx
+sphinx_rtd_theme
 sphinx-autoapi


### PR DESCRIPTION
As was reported in issue #680, the documentation on readthedocs didn't get built properly with the release of 0.9.14.2 a couple weeks ago. Based on the build logs this was because the AutoAPI extension for sphinx was failing to read the source files. Poking around I noticed that a couple years ago I pinned the version of sphinx we were using, apparently to address a versioning compatibility that was present at that time. Given that I tried the easiest thing first and simply unpinned this version in the hopes it might just be a versioning incompatibility between that oldish version of sphinx and the newer versions of the extensions being pulled down. Look like this did the trick, so this PR unpins the sphinx version (whatever problem was happening two-years ago seems to have been fixed in the intervening time).

Also addresses a deprecation warning for a setuptools submodule in the documentation build.