### PR TITLE
Leakage modeling: confidence intervals and more robust gauge optimization

### DIFF
--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -480,6 +480,33 @@ class Estimate(_MongoSerializable):
         if ky in self.confidence_region_factories:
             _warnings.warn("Confidence region factory for %s already exists - overwriting!" % str(ky))
 
+        fie = 'final iteration estimate'
+        if model_label != fie and fie in self.models and circuits_label == 'final':
+            mdl_fie = self.models[fie]
+            mdl     = self.models[model_label]
+            if mdl_fie.num_params != mdl.num_params:
+                if mdl.num_params > mdl_fie.num_params:
+                    quantity = 'more'
+                    danger   = ('extremely', 'Extreme caution')
+                else:
+                    quantity = 'fewer'
+                    danger   = ('', 'Caution')
+                msg = \
+                f"""
+                The model labeled '{model_label}' has {quantity} parameters than the
+                model labeled 'final iteration estimate'. By convention, the latter
+                model is the final model from GST model fitting for which optimization
+                was performed. This makes it {danger[0]} unlikely that the former model
+                is actually optimal (e.g., in the sense of log-likelihood) among its
+                entire hypothesis class. Suboptimality of '{model_label}' within its
+                hypothesis class invalidates most statistical assumptions required to
+                compute confidence regions.
+                
+                {danger[1]} should be used when interpeting confidence regions for
+                model '{model_label}'.
+                """
+                _warnings.warn(msg, UserWarning)
+
         new_crf = _ConfidenceRegionFactory(self, model_label, circuits_label)
         self.confidence_region_factories[ky] = new_crf
         return new_crf

--- a/pygsti/report/factory.py
+++ b/pygsti/report/factory.py
@@ -18,6 +18,8 @@ import zipfile as _zipfile
 
 import numpy as _np
 
+from typing import Union
+
 from pygsti.report import Report as _Report
 from pygsti.report import autotitle as _autotitle
 from pygsti.report import merge_helpers as _merge
@@ -1125,6 +1127,24 @@ def find_std_clifford_compilation(model, verbosity=0):
     return None
 
 
+def _validated_confidence_level(cl: Union[float, int, None]):
+    if cl is None:
+        return cl
+    if cl < 1:
+        msg = \
+        f"""
+        Confidence level should be specified as a percent from 0 to 100. Reasonable
+        values for this argument are usually between 80 and 99.5.
+        
+        We received confidence level={cl}, which we assume was accidentally passed as
+        a proportion. We'll multiply by 100 and proceed. 
+        """
+        _warnings.warn(msg)
+        cl = cl * 100
+    assert 0 < cl and cl < 100
+    return cl
+
+
 # TODO these factories should really be Report subclasses
 def construct_standard_report(results, title="auto",
                               confidence_level=None, comm=None, ws=None,
@@ -1228,6 +1248,7 @@ def construct_standard_report(results, title="auto",
 
     printer = _VerbosityPrinter.create_printer(verbosity, comm=comm)
     ws = ws or _ws.Workspace()
+    confidence_level = _validated_confidence_level(confidence_level)
 
     advanced_options = advanced_options or {}
     n_leak = advanced_options.get('n_leak', 0)

--- a/pygsti/tools/leakage.py
+++ b/pygsti/tools/leakage.py
@@ -542,7 +542,9 @@ def _add_all_hessians(mer: ModelEstimateResults, kwargs_for_projhess=None):
         kwargs_for_projhess = {'projection_type': 'intrinsic error'}
 
     from pygsti.forwardsims import MatrixForwardSimulator, MapForwardSimulator
-    for est in mer.estimates.values():
+    for estname, est in mer.estimates.items():
+        if estname == 'Target':
+            continue
         for gop_name in est.goparameters:
             mdl = est.models[gop_name]
             if isinstance(mdl.sim, MatrixForwardSimulator):

--- a/pygsti/tools/leakage.py
+++ b/pygsti/tools/leakage.py
@@ -431,8 +431,13 @@ def lagoified_gopparams_dicts(gopparams_dicts: List[Dict]) -> List[Dict]:
     from pygsti.models.gaugegroup import UnitaryGaugeGroup
     tm = gopparams_dicts[0]['target_model']
     gopparams_dicts = [gp for gp in gopparams_dicts if 'TPSpam' not in str(type(gp['_gaugeGroupEl']))]
+    # ^ That list will __usually__ be length-1.
+
     gopparams_dicts = copy.deepcopy(gopparams_dicts)
     for inner_dict in gopparams_dicts:
+        inner_dict['method'] = 'L-BFGS-B'
+        # ^ We need this optimizer because it doesn't require a gradient oracle.
+        #
         inner_dict['n_leak'] = 1
         # ^ This function could accept n_leak as an argument instead. However,
         #   downstream functions for gauge optimization only support n_leak=0 or 1.
@@ -441,24 +446,27 @@ def lagoified_gopparams_dicts(gopparams_dicts: List[Dict]) -> List[Dict]:
         #   about mismatches between an estimate and a target when restricted to the
         #   computational subspace. We have code for evaluating the loss functions
         #   themselves, but not their gradients.
-        inner_dict['gates_metric'] = 'frobenius squared'
-        inner_dict['spam_metric']  = 'frobenius squared'
-        inner_dict['item_weights'] = {'gates': 0.0, 'spam': 1.0}
+        #
         gg = UnitaryGaugeGroup(tm.basis.state_space, tm.basis)
         inner_dict['gauge_group'] = gg
         inner_dict['_gaugeGroupEl'] = gg.compute_element(gg.initial_params)
-        # ^ We start with gauge optimization over the full unitary group, minimizing
-        #   SPAM differences between the estimate and the target on the computational
-        #   subspace. Our last step of gauge optimization (which is after this loop)
-        #   includes gates.
-        inner_dict['method'] = 'L-BFGS-B'
-        # ^ We need this optimizer because it doesn't require a gradient oracle.
-        inner_dict['convert_model_to']['to_type'] = 'full'
-        # ^ The natural basis for Hilbert-Schmidt space in leakage modeling doesn't
-        #   have the identity matrix as its first element. This means we can't use
-        #   the full TP parameterization. There's no real harm in taking "full" as
-        #   our default because add_lago_models uses parameterization-preserving
-        #   gauge optimization.
+        # ^ We insist on the unitary gauge group because other common gauge groups
+        #   (e.g., FullTPGaugeGroup) impose requirements on tm.basis.
+        #
+        inner_dict['gates_metric'] = 'frobenius'
+        inner_dict['spam_metric']  = 'frobenius'
+        # ^ We use Frobenius rather than Frobenius squared to avoid biasing toward
+        #   gauges where the leakage is "spread out" across multiple gates.
+        #
+        inner_dict['item_weights'] = {'gates': 1.0, 'spam': 1.0}
+        # ^ The precise weights here are somewhat arbitrary. We place weight on
+        #   SPAM because SPAM plays a distinguished role in defining the 
+        #   computational subspace.
+    
+    # Below, we add a final gauge optimization step that preserves separation between 
+    # what we've identified as the computational subspace and leakage space. This
+    # step uses squared Frobenius norm as an objective, since that's better-behaved
+    # than plain Frobenius norm.
     inner_dict = inner_dict.copy()
     gg = _direct_sum_unitary_group([Basis.cast('pp', 4), Basis.cast('pp', 1)], tm.basis)
     inner_dict['gauge_group'] = gg
@@ -498,7 +506,7 @@ def add_lago_models(results: ModelEstimateResults, est_key: Optional[str] = None
     appropriate modifications to either the estimate's existing 'stdgaugeopt' suite
     (if that exists) or to the 'stdgaugeopt' suite induced by the target model.
     """
-    from pygsti.protocols.gst import GSTGaugeOptSuite, _add_param_preserving_gauge_opt
+    from pygsti.protocols.gst import GSTGaugeOptSuite, _add_param_preserving_gauge_opt, _add_gauge_opt
     if isinstance(est_key, str):
         if gos is None:
             existing_est  = results.estimates[est_key]
@@ -509,7 +517,14 @@ def add_lago_models(results: ModelEstimateResults, est_key: Optional[str] = None
             else:
                 gop_params = std_lago_gopsuite(results.estimates[est_key].models['target'])
             gos = GSTGaugeOptSuite(gaugeopt_argument_dicts=gop_params)
-        _add_param_preserving_gauge_opt(results, est_key, gos, verbosity)
+        try:
+            _add_param_preserving_gauge_opt(results, est_key, gos, verbosity)
+        except:
+            # parameterization-preserving gauge optimization fails if the seed model
+            # uses members other than ComposedState, ComposedOp, ComposedPOVM, etc..
+            # So we add a non-preserving gauge optimization here.
+            tm = results.estimates[est_key].models['target']
+            _add_gauge_opt(results, est_key, gos, tm, tuple())
     elif est_key is None:
         for est_key in results.estimates.keys():
             add_lago_models(results, est_key, gos, verbosity)
@@ -556,6 +571,9 @@ def construct_leakage_report(
     est_key = results.estimates.keys()
     for ek in est_key:
         assert isinstance(ek, str)
+        if ek == 'Target':
+            # There's no need to gauge-optimize in this case.
+            continue
         add_lago_models(results, ek, verbosity=gaugeopt_verbosity)
     from pygsti.report import construct_standard_report
     report = construct_standard_report(

--- a/pygsti/tools/leakage.py
+++ b/pygsti/tools/leakage.py
@@ -384,7 +384,7 @@ def leaky_qubit_model_from_pspec(
     return tm_3level
 
 
-# MARK: gauge optimization
+# MARK: gaugeopt
 
 def lagoified_gopparams_dicts(gopparams_dicts: List[Dict]) -> List[Dict]:
     """
@@ -539,7 +539,7 @@ def add_lago_models(results: ModelEstimateResults, est_key: Optional[str] = None
 def _add_all_hessians(mer: ModelEstimateResults, kwargs_for_projhess=None):
     # NOTE: this function is not leakage-specific.
     if kwargs_for_projhess is None:
-        kwargs_for_projhess = {'projection_type': 'instrinsic error'}
+        kwargs_for_projhess = {'projection_type': 'intrinsic error'}
 
     from pygsti.forwardsims import MatrixForwardSimulator, MapForwardSimulator
     for est in mer.estimates.values():

--- a/test/unit/tools/test_leakage_gst_pipeline.py
+++ b/test/unit/tools/test_leakage_gst_pipeline.py
@@ -66,9 +66,9 @@ class TestLeakageGSTPipeline(unittest.TestCase):
 
             | Gate    | ent. infidelity | 1/2 trace dist | 1/2 diamond dist | Max TOP  | Unmodeled error |
             |---------|-----------------|----------------|------------------|----------|-----------------|
-            | []      | 0.000001        | 0.000522       | 0.000729         | 0.000384 | 0.000001        |
-            | Gxpi2:0 | 0.00207         | 0.045378       | 0.062144         | 0.048625 | 0.003824        |
-            | Gypi2:0 | 0.000188        | 0.013716       | 0.016257         | 0.010192 | 0.000152        |
+            | []      | 0.000003        | 0.001533       | 0.002159         | 0.001986 | 0.000005        |
+            | Gxpi2:0 | 0.00094         | 0.030536       | 0.040153         | 0.031146 | 0.001579        |
+            | Gypi2:0 | 0.00038         | 0.019496       | 0.025513         | 0.017248 | 0.000542        |
         
         Standard gauge optimization
 
@@ -80,8 +80,8 @@ class TestLeakageGSTPipeline(unittest.TestCase):
 
         We'll run tests with subspace entanglement infidelity.
 
-            * For LAGO, infidelity of Gxpi2 is 10x larger than that of Gypi2;
-              we'll test for a 5x difference.
+            * For LAGO, infidelity of Gxpi2 is 2.47x larger than that of Gypi2;
+              we'll test for a 2x difference.
             
             * For standard gauge optimization, Gxpi2 and Gypi2 have almost identical infidelities;
               we'll test for a factor 1.1x there.
@@ -99,6 +99,10 @@ class TestLeakageGSTPipeline(unittest.TestCase):
         for lbl in ['LAGO', 'stdgaugeopt']:
             infids[lbl] = {g: 1 - fidelity(gates[lbl][g], gates['target'][g], 'l2p1', n_leak=1) for g in ['x', 'y'] } 
 
-        self.assertGreater( infids['LAGO']['x'],        5.0 * infids['LAGO']['y']        )
+        self.assertGreater( infids['LAGO']['x'],        2.0 * infids['LAGO']['y']        )
         self.assertLess(    infids['stdgaugeopt']['x'], 1.1 * infids['stdgaugeopt']['y'] )
         return
+
+if __name__ == '__main__':
+    TestLeakageGSTPipeline().test_pipeline_1Q_XYI()
+    print()


### PR DESCRIPTION
Changes
 * Remove unnecessary model copies in confidenceregionfactory.py.
 * Log a warning if we try to add confidence regions to a model whose number of parameters differs from that of "final iteration estimate".
 * Add a helper to parse the confidence_level argument in construct_standard_report. We now handle fractional values in (0,1) in the natural way.
 * Leakage-aware gauge optimization no longer has a first stage that puts all weight on SPAM. Instead, it puts equal weight on SPAM and gates, and uses Frobenius loss instead of Frobenius-squared. The latter change reduces bias toward gauges that spread error out across gates.
 * Update construct_leakage_report to accept a confidence_level argument. When provided, we automatically add the confidence region factories needed for report generation.