### PR TITLE
MAINT: LindbladCoefficientBlock blocktype branching

### DIFF
--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -28,7 +28,15 @@ from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
 
 
 def _custom_superops_stdbasis_conversion(mx_basis, sparse, superops):
-    # Get basis transfer matrices from 'std' <-> desired mx_basis
+    """ 
+    The input superops is either:
+        (1) a list of CSR matrices, or 
+        (2) an ndarray of shape (n, d, d) for some d,
+    where superops[i] is a superoperator in the mx_basis representation.
+
+    The output superops has the same datatype as the input, although
+    the superoperators are now in the standard (matrix-unit) basis.
+    """
     mxBasisToStd = mx_basis.create_transform_matrix(_BuiltinBasis("std", mx_basis.dim, sparse))
     # use BuiltinBasis("std") instead of just "std" in case mx_basis is a TensorProdBasis
 
@@ -37,12 +45,13 @@ def _custom_superops_stdbasis_conversion(mx_basis, sparse, superops):
         else _np.linalg.inv(mxBasisToStd)
 
     if sparse:
-        #Note: complex OK here sometimes, as only linear combos of "other" gens
+        # Note: complex OK here sometimes, as only linear combos of "other" gens
         # (like (i,j) + (j,i) terms) need to be real.
         superops = [leftTrans @ (mx @ rightTrans) for mx in superops]
-        for mx in superops: mx.sort_indices()
+        for mx in superops:
+            mx.sort_indices()
     else:
-        #superops = _np.einsum("ik,akl,lj->aij", leftTrans, superops, rightTrans)
+        # superops = _np.einsum("ik,akl,lj->aij", leftTrans, superops, rightTrans)
         superops = _np.transpose(_np.tensordot(
             _np.tensordot(leftTrans, superops, (1, 1)), rightTrans, (2, 0)), (1, 0, 2))
     return superops

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -71,12 +71,12 @@ class InvalidBlockTypeError(ValueError):
         super().__init__(msg)
 
 
-class InvalidParamMode(ValueError):
+class InvalidParamModeError(ValueError):
 
     msg_template = "Internal error: invalid parameter mode (%s) for block type %s!"
 
     def __init__(self, *args: object) -> None:
-        msg = InvalidParamMode.msg_template % (args[0], args[1])
+        msg = InvalidParamModeError.msg_template % (args[0], args[1])
         super().__init__(msg)
 
 
@@ -200,7 +200,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
         elif self._param_mode ==  'elements':
             return len(self._bel_labels)
         else:
-            raise InvalidParamMode(self._param_mode, self._block_type)
+            raise InvalidParamModeError(self._param_mode, self._block_type)
     
     def _num_params_otherdiag(self):
         if self._param_mode == 'static':
@@ -210,7 +210,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
         elif self._param_mode in ('elements', 'cholesky'):
             return len(self._bel_labels)
         else:
-            raise InvalidParamMode(self._param_mode, self._block_type)
+            raise InvalidParamModeError(self._param_mode, self._block_type)
 
     def _num_params_other(self):
         if self._param_mode == 'static':
@@ -218,7 +218,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
         elif self._param_mode in ('elements', 'cholesky'):
             return len(self._bel_labels)**2
         else:
-            raise InvalidParamMode(self._param_mode, self._block_type)
+            raise InvalidParamModeError(self._param_mode, self._block_type)
 
     def _update_superops_cache(self, mxs, mx_basis, cache_key):
         d2 = mx_basis.dim

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -617,16 +617,25 @@ class LindbladCoefficientBlock(_NicelySerializable):
     def coefficient_labels(self):
         """Labels for the elements of `self.block_data` (flattened if relevant)"""
         if self._block_type == 'ham':
-            labels = ["%s Hamiltonian error coefficient" % lbl for lbl in self._bel_labels]
+            return self._coefficient_labels_ham()
         elif self._block_type == 'other_diagonal':
-            labels = ["(%s,%s) other error coefficient" % (lbl, lbl) for lbl in self._bel_labels]
+            return self._coefficient_labels_otherdiag()
         elif self._block_type == 'other':
-            labels = []
-            for i, ilbl in enumerate(self._bel_labels):
-                for j, jlbl in enumerate(self._bel_labels):
-                    labels.append("(%s,%s) other error coefficient" % (ilbl, jlbl))
+            return self._coefficient_labels_other()
         else:
-            raise ValueError("Internal error: invalid block type!")
+            raise InvalidBlockTypeError()
+    
+    def _coefficient_labels_ham(self):
+        return ["%s Hamiltonian error coefficient" % lbl for lbl in self._bel_labels]
+    
+    def _coefficient_labels_otherdiag(self):
+        return ["(%s,%s) other error coefficient" % (lbl, lbl) for lbl in self._bel_labels]
+    
+    def _coefficient_labels_other(self):
+        labels = []
+        for i, ilbl in enumerate(self._bel_labels):
+            for j, jlbl in enumerate(self._bel_labels):
+                labels.append("(%s,%s) other error coefficient" % (ilbl, jlbl))
         return labels
 
     @property

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -1056,8 +1056,8 @@ class LindbladCoefficientBlock(_NicelySerializable):
         eeg_indices = self.elementary_errorgen_indices
         blkdata_deriv = self.deriv_wrt_params(v)
         if blkdata_deriv.ndim == 3:  # (coeff_dim_1, coeff_dim_2, param_dim) => (coeff_dim, param_dim)
-            blkdata_deriv = blkdata_deriv.reshape((blkdata_deriv.shape[0] * blkdata_deriv.shape[1],
-                                                   blkdata_deriv.shape[2]))  # blkdata_deriv rows <=> flat_data indices
+            cd1, cd2, pd = blkdata_deriv.shape  # type: ignore
+            blkdata_deriv = blkdata_deriv.reshape((cd1 * cd2, pd), order='C')  # blkdata_deriv rows <=> flat_data indices
 
         eeg_deriv = _np.zeros((len(eeg_indices), self.num_params), 'd')  # may need to be complex?
 

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -457,21 +457,18 @@ class LindbladCoefficientBlock(_NicelySerializable):
         return idx
 
     def _elementary_errorgen_indices_ham(self):
-        from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
         elem_errgen_indices = _collections.OrderedDict()
         for i, lbl in enumerate(self._bel_labels):
             elem_errgen_indices[_LEEL('H', (lbl,))] = [(1.0, i)]
         return elem_errgen_indices
 
     def _elementary_errorgen_indices_otherdiag(self):
-        from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
         elem_errgen_indices = _collections.OrderedDict()
         for i, lbl in enumerate(self._bel_labels):
             elem_errgen_indices[_LEEL('S', (lbl,))] = [(1.0, i)]
         return elem_errgen_indices
 
     def _elementary_errorgen_indices_other(self):
-        from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
         elem_errgen_indices = _collections.OrderedDict()
         # Difficult case, as coefficients do not correspond to elementary errorgens, so
         # there's no single index for, e.g. ('C', lbl1, lbl2) - rather this elementary

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -1137,31 +1137,28 @@ class LindbladCoefficientBlock(_NicelySerializable):
     def _superop_deriv_wrt_params_ham(self, superops):
         if self._param_mode == 'elements':
             # d/dp_k of H‐term superop = the k’th superop itself
-            return superops.transpose((1, 2, 0))
+            return superops.transpose((1, 2, 0)) # PRETRANS, this was:
+            # _np.einsum("ik,akl,lj->ija", self.leftTrans, self.hamGens, self.rightTrans)
         else:
             raise InvalidParamModeError(self._param_mode, self._block_type)
 
     def _superop_deriv_wrt_params_otherdiag(self, superops, v):
         transposed = _np.transpose(superops, (1, 2, 0))  # shape = (d, d, nBEL)
 
-        if self._param_mode == 'depol':
-            # all coeffs = p^2, so d/dp = 2 p * sum_m superops[m]
-            base = _np.sum(transposed, axis=2)  # shape (d,d)
-            return base[:, :, None] * 2.0 * v[0]
-
-        elif self._param_mode == 'reldepol':
-            # all coeffs = p, so d/dp = sum_m superops[m]
-            base = _np.sum(transposed, axis=2)
-            return base[:, :, None] * 1.0
-
-        elif self._param_mode == 'cholesky':
-            # coeffs = p_i^2, so d/dp_i = 2 p_i * superops[i]
-            return transposed * (2.0 * v)[None, None, :]
-
-        elif self._param_mode == 'elements':
-            # coeffs = p_i, so d/dp_i = superops[i]
+        # Derivative of exponent wrt other param; shape == [dim,dim,bs-1]
+        #  except "depol" & "reldepol" cases, when shape == [dim,dim,1]
+        if self._param_mode == "depol":  # all coeffs same & == param^2
+            # dOdp  = _np.einsum('alj->lj', self.otherGens)[:,:,None] * 2*otherParams[0]
+            return _np.sum(transposed, axis=2)[:, :, None] * 2 * v[0]
+        elif self._param_mode == "reldepol":  # all coeffs same & == param
+            # dOdp  = _np.einsum('alj->lj', self.otherGens)[:,:,None]
+            return _np.sum(transposed, axis=2)[:, :, None]
+        elif self._param_mode == "cholesky":  # (coeffs = params^2)
+            # dOdp  = _np.einsum('alj,a->lja', self.otherGens, 2*otherParams)
+            return transposed * 2 * v  # just a broadcast
+        elif self._param_mode == "elements":  # "unconstrained" (coeff == params)
+            # dOdp  = _np.einsum('alj->lja', self.otherGens)
             return transposed
-
         else:
             raise InvalidParamModeError(self._param_mode, self._block_type)
 
@@ -1179,11 +1176,12 @@ class LindbladCoefficientBlock(_NicelySerializable):
             F1 = _np.tril(_np.ones((num_bels, num_bels), 'd'))
             F2 = _np.triu(_np.ones((num_bels, num_bels), 'd'), 1) * 1j
 
-            # using Einstein sums to build ∂O/∂p_{ab}
-            dOdp  = _np.einsum('amlj,mb,ab->ljab', superops, Lbar, F1)
-            dOdp += _np.einsum('malj,mb,ab->ljab', superops,   L, F1)
-            dOdp += _np.einsum('bmlj,ma,ab->ljab', superops, Lbar, F2)
-            dOdp += _np.einsum('mblj,ma,ab->ljab', superops,   L, F2.conjugate())
+            # Derivative of exponent wrt other param; shape == [dim,dim,bel_index,bel_index]
+            # Note: replacing einsums here results in at least 3 numpy calls (probably slower?)
+            dOdp  = _np.einsum('amlj,mb,ab->ljab', superops, Lbar, F1)        # only a >= b nonzero (F1)
+            dOdp += _np.einsum('malj,mb,ab->ljab', superops,    L, F1)        # ditto
+            dOdp += _np.einsum('bmlj,ma,ab->ljab', superops, Lbar, F2)        # only b > a nonzero (F2)
+            dOdp += _np.einsum('mblj,ma,ab->ljab', superops,    L, F2.conj()) # ditto 
             return dOdp
 
         elif self._param_mode == 'elements':
@@ -1192,13 +1190,19 @@ class LindbladCoefficientBlock(_NicelySerializable):
             F1 = _np.tril(_np.ones((num_bels, num_bels), 'd'), -1)
             F2 = _np.triu(_np.ones((num_bels, num_bels), 'd'),  1) * 1j
 
-            # reorder superops so indices = (l,j,a,b)
-            AB_LJ = _np.transpose(superops, (2, 3, 0, 1))
-            BA_LJ = _np.transpose(superops, (2, 3, 1, 0))
+            # Derivative of exponent wrt other param; shape == [dim,dim,bs-1,bs-1]
+            # dOdp  = _np.einsum('ablj,ab->ljab', self.otherGens, F0) # a == b case
+            # dOdp += _np.einsum('ablj,ab->ljab', self.otherGens, F1)
+            #      += _np.einsum('balj,ab->ljab', self.otherGens, F1) # a > b (F1)
+            # dOdp += _np.einsum('balj,ab->ljab', self.otherGens, F2) 
+            #      -= _np.einsum('ablj,ab->ljab', self.otherGens, F2) # a < b (F2)
 
-            dOdp  = AB_LJ * F0[None, None, :, :]
-            dOdp += AB_LJ * F1[None, None, :, :] + BA_LJ * F1[None, None, :, :]
-            dOdp += BA_LJ * F2[None, None, :, :] - AB_LJ * F2[None, None, :, :]
+            # reorder superops so indices = (l,j,a,b)
+            AB_LJ = _np.transpose(superops, (2, 3, 0, 1))  # ablj -> ljab
+            BA_LJ = _np.transpose(superops, (2, 3, 1, 0))  # balj -> ljab
+            dOdp  = AB_LJ * F0[None, None, :, :]                                 # a == b case
+            dOdp += AB_LJ * F1[None, None, :, :] + BA_LJ * F1[None, None, :, :]  # a > b (F1)
+            dOdp += BA_LJ * F2[None, None, :, :] - AB_LJ * F2[None, None, :, :]  # a < b (F2)
             return dOdp
 
         else:

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -530,9 +530,9 @@ class LindbladCoefficientBlock(_NicelySerializable):
             for j, lbl2 in enumerate(self._bel_labels[i + 1:], start=i + 1):
                 ij = i * stride + j
                 ji = j * stride + i
-                #Contributions from NH_PQ and NH_QP coeffs to C_PQ and A_PQ coeffs:
-                # C_PQ = NH_PQ + NH_QP
-                # A_PQ = i(NH_QP - NH_PQ)
+                # Contributions from NH_PQ and NH_QP coeffs to C_PQ and A_PQ coeffs:
+                #  C_PQ = NH_PQ + NH_QP
+                #  A_PQ = i(NH_QP - NH_PQ)
                 block_data_indices[ij] = [(1.0, _LEEL('C', (lbl1, lbl2))), (-1.0j, _LEEL('A', (lbl1, lbl2)))]
                 # NH_PQ = (C_PQ + i A_PQ)/2, but here we care that NH_PQ appears w/1.0 in C_PQ and -1j in A_QP
                 block_data_indices[ji] = [(1.0, _LEEL('C', (lbl1, lbl2))), (+1.0j, _LEEL('A', (lbl1, lbl2)))]

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -229,6 +229,32 @@ class LindbladCoefficientBlock(_NicelySerializable):
         else:
             raise InvalidParamModeError(self._param_mode, self._block_type)
 
+    def create_lindblad_term_superoperators(self, mx_basis='pp', sparse: Union[Literal['auto'], bool]="auto", include_1norms=False, flat=False):
+        assert(self._basis is not None), "Cannot create lindblad superoperators without a basis!"
+        basis = self._basis
+        sparse = basis.sparse if (sparse == "auto") else sparse
+        mxs = [basis[lbl] for lbl in self._bel_labels]
+        if len(mxs) == 0:
+            return ([], []) if include_1norms else []  # short circuit - no superops to return
+
+        d = mxs[0].shape[0]
+        d2 = d**2  # if mxs[0] is sparse, then d2 != mxs[0].size.
+        mx_basis = _Basis.cast(mx_basis, d2, sparse=sparse)
+
+        cache_key = (self._block_type, tuple(self._bel_labels), mx_basis, basis)
+        if cache_key not in self._superops_cache:
+            self._update_superops_cache(mxs, mx_basis, cache_key)
+        cached_superops, cached_superops_1norms = self._superops_cache[cache_key]
+
+        if flat or self._block_type in ('ham', 'other_diagonal'):
+            if include_1norms:
+                return _copy.deepcopy(cached_superops), cached_superops_1norms.copy()
+            else:
+                return _copy.deepcopy(cached_superops)
+
+        out = _unflatten_cached_other_lindblad_term_superoperators(cached_superops, cached_superops_1norms, include_1norms)
+        return out
+
     def _update_superops_cache(self, mxs, mx_basis, cache_key):
         d2 = mx_basis.dim
         sparse = mx_basis.sparse
@@ -255,32 +281,6 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
         self._superops_cache[cache_key] = (superops, superop_1norms)
         return 
-
-    def create_lindblad_term_superoperators(self, mx_basis='pp', sparse: Union[Literal['auto'], bool]="auto", include_1norms=False, flat=False):
-        assert(self._basis is not None), "Cannot create lindblad superoperators without a basis!"
-        basis = self._basis
-        sparse = basis.sparse if (sparse == "auto") else sparse
-        mxs = [basis[lbl] for lbl in self._bel_labels]
-        if len(mxs) == 0:
-            return ([], []) if include_1norms else []  # short circuit - no superops to return
-
-        d = mxs[0].shape[0]
-        d2 = d**2  # if mxs[0] is sparse, then d2 != mxs[0].size.
-        mx_basis = _Basis.cast(mx_basis, d2, sparse=sparse)
-
-        cache_key = (self._block_type, tuple(self._bel_labels), mx_basis, basis)
-        if cache_key not in self._superops_cache:
-            self._update_superops_cache(mxs, mx_basis, cache_key)
-        cached_superops, cached_superops_1norms = self._superops_cache[cache_key]
-
-        if flat or self._block_type in ('ham', 'other_diagonal'):
-            if include_1norms:
-                return _copy.deepcopy(cached_superops), cached_superops_1norms.copy()
-            else:
-                return _copy.deepcopy(cached_superops)
-
-        out = _unflatten_cached_other_lindblad_term_superoperators(cached_superops, cached_superops_1norms, include_1norms)
-        return out
 
     def create_lindblad_term_objects(self, parameter_index_offset, max_polynomial_vars, evotype, state_space):
         mpv = max_polynomial_vars
@@ -1357,6 +1357,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
         if len(self._bel_labels) < 10:
             s += " Coefficients are:\n" + str(_np.round(self.block_data, 4))
         return s
+
 
 @lru_cache(maxsize=16)
 def cached_diag_indices(n):

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -1209,19 +1209,8 @@ class LindbladCoefficientBlock(_NicelySerializable):
             raise InvalidParamModeError(self._param_mode, self._block_type)
 
     def superop_hessian_wrt_params(self, superops, v=None, superops_are_flat=False):
-        """
-        Second derivative (Hessian) of the Lindblad-term superoperators w.r.t. the real parameters.
+        # NOTE: `v` is here for consistency with superop_deriv_wrt_params.
 
-        v: ignored. Here for consistency with superop_deriv_wrt_params.
-
-        Returns
-        -------
-        ndarray
-            Tensor of shape (d, d, …) with either 2 or 4 derivative dimensions:
-            - For 'ham' and 'other_diagonal' blocks: shape (d, d, nP, nP)
-            - For 'other' blocks: shape (d, d, snP, snP, snP, snP)
-              where snP = sqrt(self.num_params)
-        """
         # static blocks always have zero Hessian
         if self._param_mode == 'static':
             if superops_are_flat or self._block_type != 'other':
@@ -1241,8 +1230,7 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
         # sanity checks & real‐cast
         tr = d2.ndim
-        assert (tr - 2) in (2, 4), \
-            "Currently, d2Odp2 can only have 2 or 4 derivative dimensions"
+        assert (tr - 2) in (2, 4), "Currently, d2Odp2 can only have 2 or 4 derivative dimensions"
         assert _np.linalg.norm(_np.imag(d2)) < IMAG_TOL
         return _np.real(d2)
 

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -751,29 +751,29 @@ class LindbladCoefficientBlock(_NicelySerializable):
         if self._param_mode in ("depol", "reldepol"):
             if self._param_mode == "depol":
                 nonneg = [v >= ttol for v in self.block_data]
-                assert all(nonneg), "Lindblad stochastic coefficients are not positive!"
+                assert all(nonneg), f"Lindblad stochastic coefficients are not positive! (tol={ttol})"
             # check all diagonal entries are equal
             first = self.block_data[0]
             all_equal = [_np.isclose(v, first, atol=1e-6) for v in self.block_data]
-            assert all(all_equal), "Diagonal lindblad coefficients are not equal!"
+            assert all(all_equal), f"Diagonal lindblad coefficients are not equal! (tol={ttol})"
             # build the single parameter
             if self._param_mode == "depol":
-                avg = _np.mean(self.block_data.clip(0, 1e100))
-                return _np.array([_np.sqrt(_np.real(avg))], 'd')
+                avg = _np.mean(self.block_data.clip(0, 1e100))  # was 1e-16
+                return _np.array([_np.sqrt(_np.real(avg))], 'd') # shape (1,)
             else:  # 'reldepol'
                 avg = _np.mean(self.block_data)
-                return _np.array([_np.real(avg)], 'd')
+                return _np.array([_np.real(avg)], 'd') # shape (1,)
 
         # cholesky: each block_data[i] = param[i]**2
         elif self._param_mode == "cholesky":
             nonneg = [v >= ttol for v in self.block_data]
             assert all(nonneg), "Lindblad stochastic coefficients are not positive!"
-            clipped = self.block_data.clip(0, 1e100)
-            return _np.sqrt(clipped.real)
+            clipped = self.block_data.clip(0, 1e100)  # was 1e-16
+            return _np.sqrt(clipped.real)  # shape (len(self._bel_labels),)
 
         # elements: unconstrained real diag
         elif self._param_mode == "elements":
-            return self.block_data.real
+            return self.block_data.real  # shape (len(self._bel_labels),)
 
         else:
             raise InvalidParamModeError(self._param_mode, self._block_type)
@@ -796,14 +796,14 @@ class LindbladCoefficientBlock(_NicelySerializable):
             num_nonzero = num_bels - len(zero_inds)
 
             # permute zero rows/cols to end
+            next_nonzero = 0; next_zero = num_nonzero
             perm = _np.zeros((num_bels, num_bels), 'd')
-            ni = nz = 0
             for i in range(num_bels):
                 if i in zero_inds:
-                    perm[num_nonzero + nz, i] = 1.0; nz += 1
+                    perm[next_zero, i] = 1.0; next_zero += 1
                 else:
-                    perm[ni, i] = 1.0; ni += 1
-
+                    perm[next_nonzero, i] = 1.0; next_nonzero += 1
+                
             # extract nonzero block, compute eigen‐decomp & cholesky
             pdata = perm @ self.block_data @ perm.T
             small = pdata[0:num_nonzero, 0:num_nonzero]
@@ -824,9 +824,12 @@ class LindbladCoefficientBlock(_NicelySerializable):
                 Lsmall = _np.linalg.cholesky(small)
 
             # re‐embed into full L
-            Lfull = _np.zeros((num_bels, num_bels), 'complex')
-            Lfull[:num_nonzero, :num_nonzero] = Lsmall
-            Lmx = perm.T @ Lfull @ perm
+            perm_Lmx = _np.zeros((num_bels, num_bels), 'complex')
+            perm_Lmx[:num_nonzero, :num_nonzero] = Lsmall
+            Lmx = perm.T @ perm_Lmx @ perm
+            # ^ That's a little weird (one might expect to just set `Lmx = perm.T @ perm_Lmx`),
+            #   but the result still satisfies self.block_data \approx Lmx @ Lmx.T.conj().
+            #   I.e., the permutation of perm_Lmx's columns doesn't make things *wrong.*
 
             # now extract the real diag & real/imag lower‐triangle
             for i in range(num_bels):

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -1212,6 +1212,8 @@ class LindbladCoefficientBlock(_NicelySerializable):
         """
         Second derivative (Hessian) of the Lindblad-term superoperators w.r.t. the real parameters.
 
+        v: ignored. Here for consistency with superop_deriv_wrt_params.
+
         Returns
         -------
         ndarray
@@ -1227,16 +1229,11 @@ class LindbladCoefficientBlock(_NicelySerializable):
             else:
                 return _np.zeros((superops.shape[2], superops.shape[3], 0, 0), 'd')
 
-        # pull in v for other_diagonal (even though not needed numerically here, for consistency/checks)
-        if self._block_type == 'other_diagonal' and v is None:
-            v = self.to_vector()
-            assert len(v) == self.num_params
-
         # dispatch to block‐type helper
         if   self._block_type == 'ham':
             d2 = self._superop_hessian_wrt_params_ham(superops)
         elif self._block_type == 'other_diagonal':
-            d2 = self._superop_hessian_wrt_params_otherdiag(superops, v)
+            d2 = self._superop_hessian_wrt_params_otherdiag(superops)
         elif self._block_type == 'other':
             d2 = self._superop_hessian_wrt_params_other(superops, superops_are_flat)
         else:
@@ -1253,22 +1250,24 @@ class LindbladCoefficientBlock(_NicelySerializable):
         """Hessian for the 'ham' block: always zero (linear in parameters)."""
         if self._param_mode != 'elements':
             raise InvalidParamModeError(self._param_mode, self._block_type)
-        # shape = (d, d, nP, nP)
-        d = superops.shape[1]
+        d1, d2 = superops.shape[1:3]
         nP = self.num_params
-        return _np.zeros((d, d, nP, nP), 'd')
+        return _np.zeros((d1, d2, nP, nP), 'd')
 
-    def _superop_hessian_wrt_params_otherdiag(self, superops, v):
+    def _superop_hessian_wrt_params_otherdiag(self, superops):
         """Hessian for the 'other_diagonal' block."""
-        d = superops.shape[1]
         nP = self.num_params
 
+        # Derivative of exponent wrt other param; shape == [dim,dim,nP,nP]
         if self._param_mode == 'depol':
-            # d²O/dp² = 2 * sum_i superops[i]
+            # d2Odp2  = _np.einsum('alj->lj', self.otherGens)[:,:,None,None] * 2
             base = _np.sum(superops, axis=0)   # shape (d,d)
             return base[:, :, None, None] * 2.0
 
         elif self._param_mode == 'cholesky':
+            # d2Odp2  = _np.einsum('alj,aq->ljaq', self.otherGens, 2*_np.identity(nP,'d'))
+            # ^ old implementation 
+
             # d²O/dp_i dp_j = 0 if i≠j;  = 2 superops[i] if i==j
             # build (d,d,nP,1) then broadcast with I_{nP}
             trans = _np.transpose(superops, (1, 2, 0))      # shape (d,d,nP)
@@ -1277,7 +1276,8 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
         elif self._param_mode in ('elements', 'reldepol'):
             # second derivative is zero for direct or relative‐depol modes
-            return _np.zeros((d, d, nP, nP), 'd')
+            d1, d2 = superops.shape[1:3]
+            return _np.zeros((d1, d2, nP, nP), 'd')
 
         else:
             raise InvalidParamModeError(self._param_mode, self._block_type)
@@ -1285,19 +1285,19 @@ class LindbladCoefficientBlock(_NicelySerializable):
     def _superop_hessian_wrt_params_other(self, superops, superops_are_flat):
         """Hessian for the full 'other' block (Pauli correlation / active errors)."""
         num_bels = len(self._bel_labels)
-        nP = self.num_params
 
         if superops_are_flat:
             superops = superops.reshape((num_bels, num_bels, superops.shape[1], superops.shape[2]))
 
+        sqrt_nP = _np.sqrt(self.num_params)
+        snP = int(sqrt_nP)
+        assert snP == sqrt_nP == num_bels
+
         if self._param_mode == 'cholesky':
-            sqrt_nP = _np.sqrt(nP)
-            snP = int(sqrt_nP)
-            assert snP == sqrt_nP == num_bels
             d2Odp2 = _np.zeros([superops.shape[2], superops.shape[3], snP, snP, snP, snP], 'complex')
             # yikes! maybe make this SPARSE in future?
 
-            #Note: correspondence w/Erik's notes: a=alpha, b=beta, q=gamma, r=delta
+            # Note: correspondence w/Erik's notes: a=alpha, b=beta, q=gamma, r=delta
             # indices of d2Odp2 are [i,j,a,b,q,r]
 
             def iter_base_ab_qr(ab_inc_eq, qr_inc_eq):
@@ -1326,9 +1326,6 @@ class LindbladCoefficientBlock(_NicelySerializable):
 
         elif self._param_mode == 'elements':
             # unconstrained Hermitian: Hessian is identically zero
-            sqrt_nP = _np.sqrt(nP)
-            snP = int(sqrt_nP)
-            assert snP == sqrt_nP == num_bels
             d2Odp2 = _np.zeros([superops.shape[2], superops.shape[3], snP, snP, snP, snP], 'd')  # all params linear
             return d2Odp2
 

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -32,28 +32,31 @@ def _custom_superops_stdbasis_conversion(mx_basis, sparse, superops):
     The input superops is either:
         (1) a list of CSR matrices, or 
         (2) an ndarray of shape (n, d, d) for some d,
-    where superops[i] is a superoperator in the mx_basis representation.
+    where superops[i] is a superoperator in the standard (matrix-unit) basis.
 
     The output superops has the same datatype as the input, although
-    the superoperators are now in the standard (matrix-unit) basis.
+    the superoperators are now in mx_basis.
     """
-    mxBasisToStd = mx_basis.create_transform_matrix(_BuiltinBasis("std", mx_basis.dim, sparse))
-    # use BuiltinBasis("std") instead of just "std" in case mx_basis is a TensorProdBasis
-
-    rightTrans = mxBasisToStd
-    leftTrans = _spsl.inv(mxBasisToStd.tocsc()).tocsr() if _sps.issparse(mxBasisToStd) \
-        else _np.linalg.inv(mxBasisToStd)
+    builtin_std = _BuiltinBasis("std", mx_basis.dim, sparse)
+    # ^ use instead of just "std" in case mx_basis is a TensorProdBasis
+    mxbasis_to_std = mx_basis.create_transform_matrix(builtin_std)
 
     if sparse:
         # Note: complex OK here sometimes, as only linear combos of "other" gens
         # (like (i,j) + (j,i) terms) need to be real.
-        superops = [leftTrans @ (mx @ rightTrans) for mx in superops]
+        if _sps.issparse(mxbasis_to_std):
+            std_to_mxbasis = _spsl.inv(mxbasis_to_std.tocsc()).tocsr()
+        else:
+            std_to_mxbasis = mx_basis.inverse_transform_matrix(builtin_std)
+        superops = [std_to_mxbasis @ (mx @ mxbasis_to_std) for mx in superops]
         for mx in superops:
             mx.sort_indices()
     else:
-        # superops = _np.einsum("ik,akl,lj->aij", leftTrans, superops, rightTrans)
-        superops = _np.transpose(_np.tensordot(
-            _np.tensordot(leftTrans, superops, (1, 1)), rightTrans, (2, 0)), (1, 0, 2))
+        std_to_mxbasis = mx_basis.inverse_transform_matrix(builtin_std)
+        # superops = _np.einsum("ik,akl,lj->aij", std_to_mxbasis, superops, mxbasis_to_std)
+        temp     = _np.tensordot(std_to_mxbasis, superops, (1, 1)) # type: ignore
+        temp     = _np.tensordot(temp,     mxbasis_to_std, (2, 0))
+        superops = _np.transpose(temp, (1, 0, 2))
     return superops
 
 

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -457,32 +457,39 @@ class LindbladCoefficientBlock(_NicelySerializable):
         return idx
 
     def _elementary_errorgen_indices_ham(self):
+        from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
         elem_errgen_indices = _collections.OrderedDict()
         for i, lbl in enumerate(self._bel_labels):
             elem_errgen_indices[_LEEL('H', (lbl,))] = [(1.0, i)]
         return elem_errgen_indices
 
     def _elementary_errorgen_indices_otherdiag(self):
+        from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
         elem_errgen_indices = _collections.OrderedDict()
         for i, lbl in enumerate(self._bel_labels):
             elem_errgen_indices[_LEEL('S', (lbl,))] = [(1.0, i)]
         return elem_errgen_indices
 
     def _elementary_errorgen_indices_other(self):
+        from pygsti.baseobjs.errorgenlabel import LocalElementaryErrorgenLabel as _LEEL
         elem_errgen_indices = _collections.OrderedDict()
+        # Difficult case, as coefficients do not correspond to elementary errorgens, so
+        # there's no single index for, e.g. ('C', lbl1, lbl2) - rather this elementary
+        # errorgen is a linear combination of two coefficients.
         stride = len(self._bel_labels)
         for i, lbl1 in enumerate(self._bel_labels):
             ii = i * stride + i
-            # the diagonal (stochastic) term
             elem_errgen_indices[_LEEL('S', (lbl1,))] = [(1.0, ii)]
-            # the off-diagonal C and A combinations
-            for j, lbl2 in enumerate(self._bel_labels[i+1:], start=i+1):
+
+            for j, lbl2 in enumerate(self._bel_labels[i + 1:], start=i + 1):
                 ij = i * stride + j
                 ji = j * stride + i
-                # C_{P,Q} = ( NH_{P,Q} + NH_{Q,P} )
-                elem_errgen_indices[_LEEL('C', (lbl1, lbl2))] = [(0.5, ij), (0.5, ji)]
-                # A_{P,Q} = i ( NH_{Q,P} – NH_{P,Q} )
-                elem_errgen_indices[_LEEL('A', (lbl1, lbl2))] = [(0.5j, ij), (-0.5j, ji)]
+
+                #Contributions from C_PQ and A_PQ coeffs NH_PQ and NH_QP coeffs:
+                # NH_PQ = (C_PQ + i A_PQ)/2
+                # NH_QP = (C_PQ - i A_PQ)/2
+                elem_errgen_indices[_LEEL('C', (lbl1, lbl2))] = [(0.5, ij), (0.5, ji)]  # C_PQ contributions
+                elem_errgen_indices[_LEEL('A', (lbl1, lbl2))] = [(0.5j, ij), (-0.5j, ji)]  # A_PQ contributions
         return elem_errgen_indices
 
     @property

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -283,51 +283,73 @@ class LindbladCoefficientBlock(_NicelySerializable):
         return out
 
     def create_lindblad_term_objects(self, parameter_index_offset, max_polynomial_vars, evotype, state_space):
-        # needed b/c operators produced by lindblad_error_generators have an extra 'd' scaling
         mpv = max_polynomial_vars
         pio = parameter_index_offset
 
         if self._block_type == 'ham':
-            return self._create_lindblad_term_objects_ham(pio, mpv, evotype, state_space)
+            Lterms = self._create_lindblad_term_objects_ham(evotype, state_space, mpv, pio)
 
-        if self._block_type == 'other_diagonal':
-            return self._create_lindblad_term_objects_otherdiag(pio, mpv, evotype, state_space)
-        
-        if self._block_type == 'other':
-            return self._create_lindblad_term_objects_other(pio, mpv, evotype, state_space)
-        
-        raise ValueError("Invalid block_type '%s'" % str(self._block_type))
+        elif self._block_type == 'other_diagonal':
+            Lterms = self._create_lindblad_term_objects_otherdiag(evotype, state_space, mpv, pio)
 
-    def _create_lindblad_term_objects_ham(self, parameter_index_offset, max_polynomial_vars, evotype, state_space):
-        assert self._block_type == 'ham'
-        mpv = max_polynomial_vars
-        pio = parameter_index_offset
-        Lterms = []
-        for k, bel_label in enumerate(self._bel_labels):  # k == index of local parameter that is coefficient
-            # ensure all Rank1Term operators are *unitary*, so we don't need to track their "magnitude"
-            scale, U = _mt.to_unitary(self._basis[bel_label])
-
-            if self._param_mode == 'elements':
-                cpi = (pio + k,)  # coefficient's parameter indices (with offset)
-            elif self._param_mode == 'static':
-                cpi = ()  # not multiplied by any parameters
-                scale *= self.block_data[k]  # but scale factor gets multiplied by (static) coefficient
-            else: raise ValueError("Internal error: invalid param mode!!")
-
-            #Note: 2nd op to create_from must be the *adjoint* of the op you'd normally write down
-            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                _Polynomial({cpi: -1j * scale}, mpv), U, None, evotype, state_space))
-            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                _Polynomial({cpi: +1j * scale}, mpv), None, U.conjugate().T, evotype, state_space))
-        return Lterms
+        elif self._block_type == 'other':
+            Lterms = self._create_lindblad_term_objects_other(evotype, state_space, mpv, pio)
     
-    def _create_lindblad_term_objects_otherdiag(self, parameter_index_offset, max_polynomial_vars, evotype, state_space):
-        assert self._block_type == 'other_diagonal'
-        mpv = max_polynomial_vars
-        pio = parameter_index_offset
+        else:
+            raise ValueError("Invalid block_type '%s'" % str(self._block_type))
+
+        return Lterms
+
+    def _create_lindblad_term_objects_other(self, evotype, state_space, mpv, pio):
+        Lterms = []
+        num_bels = len(self._bel_labels)
+        for i, bel_labeli in enumerate(self._bel_labels):
+            for j, bel_labelj in enumerate(self._bel_labels):
+                scalem, Um = _mt.to_unitary(self._basis[bel_labeli])  # ensure all Rank1Term operators are *unitary*
+                scalen, Un = _mt.to_unitary(self._basis[bel_labelj])  # ensure all Rank1Term operators are *unitary*
+                Lm, Ln = Um, Un
+                Lm_dag = Lm.conjugate().T; Ln_dag = Ln.conjugate().T
+                scale = scalem * scalen
+
+                polyTerms = {}
+                if self._param_mode == 'cholesky':
+                        # coeffs = _np.dot(self.Lmx,self.Lmx.T.conjugate())
+                        # coeffs_ij = sum_k Lik * Ladj_kj = sum_k Lik * conjugate(L_jk)
+                        #           = sum_k (Re(Lik) + 1j*Im(Lik)) * (Re(L_jk) - 1j*Im(Ljk))
+                    def i_re(a, b): return pio + (a * num_bels + b)
+                    def i_im(a, b): return pio + (b * num_bels + a)
+                    for k in range(0, min(i, j) + 1):
+                        if k <= i and k <= j:
+                            polyTerms[(i_re(i, k), i_re(j, k))] = 1.0
+                        if k <= i and k < j:
+                            polyTerms[(i_re(i, k), i_im(j, k))] = -1.0j
+                        if k < i and k <= j:
+                            polyTerms[(i_im(i, k), i_re(j, k))] = 1.0j
+                        if k < i and k < j:
+                            polyTerms[(i_im(i, k), i_im(j, k))] = 1.0
+                elif self._param_mode == 'elements':  # unconstrained
+                        # coeffs_ij = param[i,j] + 1j*param[j,i] (coeffs == block_data is Hermitian)
+                    ijIndx = pio + (i * num_bels + j)
+                    jiIndx = pio + (j * num_bels + i)
+                    polyTerms = {(ijIndx,): 1.0, (jiIndx,): 1.0j}
+                elif self._param_mode == 'static':
+                    polyTerms = {(): self.block_data[i, j]}
+                else: raise ValueError("Internal error: invalid param mode!!")
+
+                    #Note: 2nd op to create_from must be the *adjoint* of the op you'd normally write down
+                base_poly = _Polynomial(polyTerms, mpv) * scale
+                Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                        1.0 * base_poly, Ln, Lm, evotype, state_space))
+                Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                        -0.5 * base_poly, None, _np.dot(Ln_dag, Lm), evotype, state_space))  # adjoint(dot(Lm_dag,Ln))
+                Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                        -0.5 * base_poly, _np.dot(Lm_dag, Ln), None, evotype, state_space))
+        return Lterms
+
+    def _create_lindblad_term_objects_otherdiag(self, evotype, state_space, mpv, pio):
         Lterms = []
         for k, bel_label in enumerate(self._bel_labels):  # k == index of local parameter that is coefficient
-            # ensure all Rank1Term operators are *unitary*, so we don't need to track their "magnitude"
+                # ensure all Rank1Term operators are *unitary*, so we don't need to track their "magnitude"
             scale, U = _mt.to_unitary(self._basis[bel_label])
             scale = scale**2  # because there are two "U"s in each overall term below
 
@@ -343,66 +365,37 @@ class LindbladCoefficientBlock(_NicelySerializable):
             pw = 2 if self._param_mode in ("cholesky", "depol") else 1
             Lm = Ln = U
             Lm_dag = Lm.conjugate().T  # assumes basis is dense (TODO: make sure works
-            Ln_dag = Ln.conjugate().T  # for sparse case too - and _np.dots below!)
-
-            #Note: 2nd op to create_from must be the *adjoint* of the op you'd normally write down
-            # e.g. in 2nd term, _np.dot(Ln_dag, Lm) == adjoint(_np.dot(Lm_dag,Ln))
-            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                _Polynomial({cpi * pw: 1.0 * scale}, mpv), Ln, Lm, evotype, state_space))
-            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                _Polynomial({cpi * pw: -0.5 * scale}, mpv), None, _np.dot(Ln_dag, Lm), evotype, state_space))
-            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                _Polynomial({cpi * pw: -0.5 * scale}, mpv), _np.dot(Lm_dag, Ln), None, evotype, state_space))
-        return Lterms
-    
-    def _create_lindblad_term_objects_other(self, parameter_index_offset, max_polynomial_vars, evotype, state_space):
-        assert self._block_type == 'other'
-        num_bels = len(self._bel_labels)
-        mpv = max_polynomial_vars
-        pio = parameter_index_offset
-        Lterms = []
-        for i, bel_labeli in enumerate(self._bel_labels):
-            for j, bel_labelj in enumerate(self._bel_labels):
-
-                scalem, Um = _mt.to_unitary(self._basis[bel_labeli])  # ensure all Rank1Term operators are *unitary*
-                scalen, Un = _mt.to_unitary(self._basis[bel_labelj])  # ensure all Rank1Term operators are *unitary*
-                Lm, Ln = Um, Un
-                Lm_dag = Lm.conjugate().T; Ln_dag = Ln.conjugate().T
-                scale = scalem * scalen
-
-                polyTerms = {}
-                if self._param_mode == 'cholesky':
-                    # coeffs = _np.dot(self.Lmx,self.Lmx.T.conjugate())
-                    # coeffs_ij = sum_k Lik * Ladj_kj = sum_k Lik * conjugate(L_jk)
-                    #           = sum_k (Re(Lik) + 1j*Im(Lik)) * (Re(L_jk) - 1j*Im(Ljk))
-                    def i_re(a, b): return pio + (a * num_bels + b)
-                    def i_im(a, b): return pio + (b * num_bels + a)
-                    for k in range(0, min(i, j) + 1):
-                        if k <= i and k <= j:
-                            polyTerms[(i_re(i, k), i_re(j, k))] = 1.0
-                        if k <= i and k < j:
-                            polyTerms[(i_re(i, k), i_im(j, k))] = -1.0j
-                        if k < i and k <= j:
-                            polyTerms[(i_im(i, k), i_re(j, k))] = 1.0j
-                        if k < i and k < j:
-                            polyTerms[(i_im(i, k), i_im(j, k))] = 1.0
-                elif self._param_mode == 'elements':  # unconstrained
-                    # coeffs_ij = param[i,j] + 1j*param[j,i] (coeffs == block_data is Hermitian)
-                    ijIndx = pio + (i * num_bels + j)
-                    jiIndx = pio + (j * num_bels + i)
-                    polyTerms = {(ijIndx,): 1.0, (jiIndx,): 1.0j}
-                elif self._param_mode == 'static':
-                    polyTerms = {(): self.block_data[i, j]}
-                else: raise ValueError("Internal error: invalid param mode!!")
+            Ln_dag = Ln.conjugate().T  # for sparse case too - and np.dots below!)
 
                 #Note: 2nd op to create_from must be the *adjoint* of the op you'd normally write down
-                base_poly = _Polynomial(polyTerms, mpv) * scale
-                Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                    1.0 * base_poly, Ln, Lm, evotype, state_space))
-                Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                    -0.5 * base_poly, None, _np.dot(Ln_dag, Lm), evotype, state_space))  # adjoint(dot(Lm_dag,Ln))
-                Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
-                    -0.5 * base_poly, _np.dot(Lm_dag, Ln), None, evotype, state_space))
+                # e.g. in 2nd term, _np.dot(Ln_dag, Lm) == adjoint(_np.dot(Lm_dag,Ln))
+            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                    _Polynomial({cpi * pw: 1.0 * scale}, mpv), Ln, Lm, evotype, state_space))
+            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                    _Polynomial({cpi * pw: -0.5 * scale}, mpv), None, _np.dot(Ln_dag, Lm), evotype, state_space))
+            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                    _Polynomial({cpi * pw: -0.5 * scale}, mpv), _np.dot(Lm_dag, Ln), None, evotype, state_space))
+        return Lterms
+
+    def _create_lindblad_term_objects_ham(self, evotype, state_space, mpv, pio):
+        Lterms = []
+        for k, bel_label in enumerate(self._bel_labels):  # k == index of local parameter that is coefficient
+                # ensure all Rank1Term operators are *unitary*, so we don't need to track their "magnitude"
+            scale, U = _mt.to_unitary(self._basis[bel_label])
+                #scale /= 2  # DEBUG REMOVE - this makes ham terms w/PP the same as earlier versions of pyGSTi
+
+            if self._param_mode == 'elements':
+                cpi = (pio + k,)  # coefficient's parameter indices (with offset)
+            elif self._param_mode == 'static':
+                cpi = ()  # not multiplied by any parameters
+                scale *= self.block_data[k]  # but scale factor gets multiplied by (static) coefficient
+            else: raise ValueError("Internal error: invalid param mode!!")
+
+                #Note: 2nd op to create_from must be the *adjoint* of the op you'd normally write down
+            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                    _Polynomial({cpi: -1j * scale}, mpv), U, None, evotype, state_space))
+            Lterms.append(_term.RankOnePolynomialOpTerm.create_from(
+                    _Polynomial({cpi: +1j * scale}, mpv), None, U.conjugate().T, evotype, state_space))
         return Lterms
 
     @property

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -993,7 +993,6 @@ class LindbladCoefficientBlock(_NicelySerializable):
             raise InvalidBlockTypeError()
 
     def _deriv_wrt_params_ham(self) -> _np.ndarray:
-        """deriv_wrt_params for the 'ham' block."""
         num_bels = len(self._bel_labels)
         if self._param_mode == 'elements':
             # d(block_data[i])/d v[j] = δ_{i,j}
@@ -1002,7 +1001,6 @@ class LindbladCoefficientBlock(_NicelySerializable):
             raise InvalidParamModeError(self._param_mode, self._block_type)
 
     def _deriv_wrt_params_otherdiag(self, v: _np.ndarray) -> _np.ndarray:
-        """deriv_wrt_params for the 'other_diagonal' block."""
         num_bels = len(self._bel_labels)
         nP = len(v)
         mat = _np.zeros((num_bels, nP), 'd')
@@ -1030,39 +1028,41 @@ class LindbladCoefficientBlock(_NicelySerializable):
         return mat
 
     def _deriv_wrt_params_other(self, v: _np.ndarray) -> _np.ndarray:
-        """deriv_wrt_params for the 'other' block (full Hermitian matrix)."""
         num_bels = len(self._bel_labels)
         nP = len(v)
         params = v.reshape((num_bels, num_bels))
+        stride = num_bels
 
         if self._param_mode == 'cholesky':
-            # We have block_data = C C†, where C = cache_mx depends on params.
-            # Build C and dC/dp, then d(block_data)/dp = dC·C† + C·(dC)†
-            cache_mx : _np.ndarray = self._cache_mx  # type: ignore
+            # We have block_data = C C†, where C is the matrix
+            #   C[i,i] = params[i,i]
+            #   C[i,j] = params[i,j] + 1j * params[j,i] (i > j).
+            #
+            # We need to compute d(block_data)/dp.
+            #   --> We'll build C and dC/dp, then d(block_data)/dp = dC·C† + C·(dC)†.
+            #
             dC = _np.zeros((nP, num_bels, num_bels), 'complex')
-            stride = num_bels
+            C : _np.ndarray = self._cache_mx  # type: ignore
 
-            # fill C and dC
             for i in range(num_bels):
-                cache_mx[i, i] = params[i, i]
+                C[i, i] = params[i, i]
                 dC[i*stride + i, i, i] = 1.0
                 for j in range(i):
-                    cache_mx[i, j] = params[i, j] + 1j * params[j, i]
+                    C[i, j] = params[i, j] + 1j * params[j, i]
                     dC[i*stride + j, i, j] = 1.0
                     dC[j*stride + i, i, j] = 1.0j
 
-            # form the Jacobian: shape = (num_bels, num_bels, nP)
-            term1 = _np.tensordot(dC, cache_mx.T.conj(), (1, 0))  # (nP,i,j)
-            term2 = _np.tensordot(cache_mx, dC.conjugate().transpose((0,2,1)), (1,0))  # (i,j,nP)
-            # combine and roll axis 0 → last
-            dB = term1 + term2.transpose((2,0,1))
-            return _np.rollaxis(dB, 0, 3)
+            dBdp  = _np.dot(dC, C.T.conjugate())
+            dBdp += _np.dot(C, dC.conjugate().transpose((0, 2, 1))).transpose((1, 0, 2))
+            # deriv = dC * C^T + C * dC^T
+
+            dBdp = _np.rollaxis(dBdp, 0, 3)  # => shape = (num_bels, num_bels, nP)
+            return dBdp
 
         elif self._param_mode == 'elements':
             # direct Hermitian: block_data[i,j] = v[i,j]_real + i v[j,i]_real
             # so we only get linear contributions
             mat = _np.zeros((num_bels, num_bels, nP), 'complex')
-            stride = num_bels
             for i in range(num_bels):
                 # diag
                 mat[i, i, i*stride + i] = 1.0

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -47,12 +47,12 @@ def _custom_superops_stdbasis_conversion(mx_basis, sparse, superops):
         if _sps.issparse(mxbasis_to_std):
             std_to_mxbasis = _spsl.inv(mxbasis_to_std.tocsc()).tocsr()
         else:
-            std_to_mxbasis = mx_basis.inverse_transform_matrix(builtin_std)
+            std_to_mxbasis = mx_basis.reverse_transform_matrix(builtin_std)
         superops = [std_to_mxbasis @ (mx @ mxbasis_to_std) for mx in superops]
         for mx in superops:
             mx.sort_indices()
     else:
-        std_to_mxbasis = mx_basis.inverse_transform_matrix(builtin_std)
+        std_to_mxbasis = mx_basis.reverse_transform_matrix(builtin_std)
         # superops = _np.einsum("ik,akl,lj->aij", std_to_mxbasis, superops, mxbasis_to_std)
         temp     = _np.tensordot(std_to_mxbasis, superops, (1, 1)) # type: ignore
         temp     = _np.tensordot(temp,     mxbasis_to_std, (2, 0))

--- a/pygsti/modelmembers/operations/lindbladcoefficients.py
+++ b/pygsti/modelmembers/operations/lindbladcoefficients.py
@@ -924,23 +924,33 @@ class LindbladCoefficientBlock(_NicelySerializable):
         num_bels = len(self._bel_labels)
         params = v.reshape((num_bels, num_bels))
 
+        params_upper_indices = triu_indices(num_bels)
         if self._param_mode == 'cholesky':
-            # rebuild the Hermitian block_data = L · L† from the Cholesky‐style params
+            # params is an array of length num_bels*num_bels that
+            # encodes a lower-triangular matrix "cache_mx" via:
+            #  cache_mx[i,i] = params[i,i]
+            #  cache_mx[i,j] = params[i,j] + 1j*params[j,i] (i > j)
             cache_mx : _np.ndarray = self._cache_mx # type: ignore
-            # fill cache_mx from params:
-            #   diag entries:
-            diag_idxs = cached_diag_indices(num_bels)
-            cache_mx[diag_idxs] = params[diag_idxs]
-            # lower‐triangle real, upper‐triangle imaginary
-            upper = triu_indices(num_bels)
-            cache_mx_T = cache_mx.T
-            cache_mx_T[upper] = params.T[upper] + 1j * params[upper]
-            cache_mx[:] = cache_mx_T.T
-            # now form block_data = L L†
-            self.block_data[:, :] = cache_mx @ cache_mx.conjugate().T
+
+            params_upper = 1j * params[params_upper_indices]
+            params_lower = (params.T)[params_upper_indices]
+
+            cache_mx_trans = cache_mx.T
+            cache_mx_trans[params_upper_indices] = params_lower + params_upper
+            diag_indices = cached_diag_indices(num_bels)
+            cache_mx[diag_indices] = params[diag_indices]
+
+            # The matrix of (complex) "other"-coefficients is build by assuming
+            # cache_mx is its Cholesky decomp; means otherCoeffs is pos-def.
+
+            # NOTE that the Cholesky decomp with all positive real diagonal
+            # elements is *unique* for a given positive-definite block_data
+            # matrix, but we don't care about this uniqueness criteria and so
+            # the diagonal els of cache_mx can be negative and that's fine -
+            # block_data will still be posdef.
+            self.block_data[:, :] = cache_mx @ cache_mx.T.conj()
 
         elif self._param_mode == 'elements':
-            params_upper_indices = triu_indices(num_bels) 
             params_upper = -1j*params[params_upper_indices]
             params_lower = (params.T)[params_upper_indices]
 

--- a/pygsti/modelmembers/operations/lindbladerrorgen.py
+++ b/pygsti/modelmembers/operations/lindbladerrorgen.py
@@ -1359,6 +1359,8 @@ class LindbladErrorgen(_LinearOperator):
         dim = self.dim
         blk_superop_derivs = []; off = 0
         for blk, (superops, _) in zip(self.coefficient_blocks, self.lindblad_term_superops_and_1norms):
+            if isinstance(superops, list):
+                raise ValueError()
             superop_deriv = blk.superop_deriv_wrt_params(superops, self.paramvals[off: off + blk.num_params], True)
             superop_deriv = superop_deriv.reshape((dim**2, -1))  # [iFlattenedOp, iParam]
             blk_superop_derivs.append(superop_deriv)

--- a/test/unit/util.py
+++ b/test/unit/util.py
@@ -12,17 +12,29 @@ import numpy as np
 
 def needs_cvxpy(fn):
     """Shortcut decorator for skipping tests that require CVXPY"""
-    return unittest.skipIf('SKIP_CVXPY' in os.environ, "skipping cvxpy tests")(fn)
+    try:
+        import cvxpy
+        return unittest.skipIf('SKIP_CVXPY' in os.environ, "skipping cvxpy tests")(fn)
+    except ImportError:
+        return unittest.skip('cvxpy is not installed')
 
 
 def needs_deap(fn):
     """Shortcut decorator for skipping tests that require deap"""
-    return unittest.skipIf('SKIP_DEAP' in os.environ, "skipping deap tests")(fn)
+    try:
+        import deap
+        return unittest.skipIf('SKIP_DEAP' in os.environ, "skipping deap tests")(fn)
+    except ImportError:
+        return unittest.skip('deap is not installed')
 
 
 def needs_matplotlib(fn):
     """Shortcut decorator for skipping tests that require matplotlib"""
-    return unittest.skipIf('SKIP_MATPLOTLIB' in os.environ, "skipping matplotlib tests")(fn)
+    try:
+        import matplotlib
+        return unittest.skipIf('SKIP_MATPLOTLIB' in os.environ, "skipping matplotlib tests")(fn)
+    except ImportError:
+        return unittest.skip('matplotlib is not installed')
 
 
 def with_temp_path(fn):


### PR DESCRIPTION
This PR has major changes to LindbladCoefficientBlock. I've taken care to produce code that is equivalent to the old code from an input-output perspective.

After this PR we'll be well-positioned to make a base class for LindbladCoefficientBlock (or just make LindbladCoefficientBlock a base class) from which new classes can inherit. I want to do this because I have an idea for a sparse Cholesky approach to reduced-order CPTP models.

The diff for this PR is kind of awful. Honestly, it's a little hopeless to track what happened. My ask is that we merge anyway once all tests pass. The approach I took to the refactor was to go function by function, preserving as much of the original implementation as possible. My first pass used an LLM for applying the refactoring pattern below. Once some tests failed after this, I did another pass that manually copy-pasted relevant codeblocks from the old ``perform_operation`` functions into the new ``_perform_operation_<blocktype>`` helper functions.

### general approach
I took functions like
```python
def perform_operation(self, *args, **kwargs):
    # some pre-branching work ...
    if self._blocktype == 'ham':
        # insert 3 to 5 lines here; call this codeblock "X"
        pass
    elif self._blocktype == 'other_diagonal':
        # insert 10 to 20 lines of code here; call this codeblock "Y"
        pass
    elif self._blocktype == 'other':
        # insert 20 to 80 lines of code here; call this codeblock "Z"
        pass
    else:
        raise ValueError('unsupported block type')
     # some post-branching work ...
     return
```
and refactored them to
```python
def perform_operation(self, *args, **kwargs):
    # some pre-branching work ...
    if self._blocktype == 'ham':
        self._perform_operation_ham(*args, **kwargs)
    elif self._blocktype == 'other_diagonal':
        self._perform_operation_otherdiag(*args, **kwargs)
    elif self._blocktype == 'other':
        self._perform_operation_other(*args, **kwargs)
    else:
        raise InvalidBlockTypeError()
     # some post-branching work ...
    return

def _perform_operation_ham(self, *args, **kwargs):
    # insert codeblock "X" here
    return

def _perform_operation_otherdiag(self, *args, **kwargs):
    # insert codeblock "Y" here
    return
    
def _perform_operation_other(self, *args, **kwargs):
    # insert codeblock "Z" here
    return
    
    