### PR TITLE
Use np.einsum instead of np.linalg.multi_dot

### DIFF
--- a/test/unit/modelmembers/test_operation.py
+++ b/test/unit/modelmembers/test_operation.py
@@ -815,8 +815,8 @@ class StochasticNoiseOpTester(BaseCase):
         self.assertArraysAlmostEqual(sop.to_dense(), expected_mx)
 
         rho = create_spam_vector("0", "Q0", Basis.cast("pp", [4]))
-        self.assertAlmostEqual(float(np.dot(rho.T, np.dot(sop.to_dense(), rho))),
-                               0.99)  # b/c X dephasing w/rate is 0.1^2 = 0.01
+        self.assertAlmostEqual(np.einsum("ab,bc,cd->",rho.T, sop.to_dense(), rho), 0.99)
+        # b/c X dephasing w/rate is 0.1^2 = 0.01
 
 
 class DepolarizeOpTester(BaseCase):
@@ -832,4 +832,4 @@ class DepolarizeOpTester(BaseCase):
 
         rho = create_spam_vector("0", "Q0", Basis.cast("pp", [4]))
         # b/c both X and Y dephasing rates => 0.01 reduction
-        self.assertAlmostEqual(float(np.dot(rho.T, np.dot(dop.to_dense(), rho))), 0.98)
+        self.assertAlmostEqual(np.einsum("ab,bc,cd->",rho.T, dop.to_dense(), rho), 0.98)

--- a/test/unit/objects/test_errorgenpropagation.py
+++ b/test/unit/objects/test_errorgenpropagation.py
@@ -209,7 +209,7 @@ def probabilities_errorgen_prop(error_propagator, target_model, circuit, use_bch
     for i, effect in enumerate(ideal_meas.values()):
         dense_effect = effect.to_dense().copy()
         dense_prep = ideal_prep.to_dense().copy()
-        prob_vec[i] = np.linalg.multi_dot([dense_effect.reshape((1,len(dense_effect))), eoc_channel, ideal_channel, dense_prep.reshape((len(dense_prep),1))])
+        prob_vec[i] = np.einsum("a,ab,bc,c->",dense_effect, eoc_channel, ideal_channel, dense_prep)
     return prob_vec
 
 def probabilities_fwdsim(noise_model, circuit):

--- a/test/unit/tools/test_errgenproptools.py
+++ b/test/unit/tools/test_errgenproptools.py
@@ -590,7 +590,7 @@ def probabilities_errorgen_prop(error_propagator, target_model, circuit, use_bch
     for i, effect in enumerate(ideal_meas.values()):
         dense_effect = effect.to_dense().copy()
         dense_prep = ideal_prep.to_dense().copy()
-        prob_vec[i] = np.linalg.multi_dot([dense_effect.reshape((1,len(dense_effect))), eoc_channel, ideal_channel, dense_prep.reshape((len(dense_prep),1))])
+        prob_vec[i] = np.einsum("a,ab,bc,c->",dense_effect, eoc_channel, ideal_channel, dense_prep)
     return prob_vec
 
 def pauli_expectation_errorgen_prop(error_propagator, target_model, circuit, pauli, use_bch=False, bch_order=1, truncation_threshold=1e-14):


### PR DESCRIPTION
In python 3.12 it appears as though `np.linalg.multi_dot(x.T, A, y)` will retain the output as a 1x1 array which is not convertible directly to a scalar value. If we instead use `np.einsum` ensuring that the output has no indices remaining then the output will be a scalar value as intended.