### PR TITLE
NumPy 2 fixes and new warning infrastructure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,7 +21,7 @@
 # F403: 'from module import *' used; unable to detect undefined names
 # F405: name may be undefined, or defined from star imports: module
 # N806: variable in function should be lowercase 
-ignore=E265,E266,E402,E701,E702,E704,E722,E741,W503,W605,F401,F403,F405,N806
+ignore=E265,E266,E402,E701,E702,E704,E722,E741,W503,F401,F403,F405,N806
 
 exclude=
     # automatically generated

--- a/.github/workflows/reuseable-main.yml
+++ b/.github/workflows/reuseable-main.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   SKIP_DEAP: 1
+  PYGSTI_NO_CUSTOMLM_SIGINT: 1
 
 jobs:
   build-and-test:

--- a/pygsti/algorithms/gaugeopt.py
+++ b/pygsti/algorithms/gaugeopt.py
@@ -222,7 +222,8 @@ class GaugeoptToTargetArgs:
             of pyGSTi will infer intended keyword arguments based on the legacy argument 
             positions. Future versions of pyGSTi will raise an error.
             """
-            _warnings.warn(msg)
+            from pygsti.tools.exceptions import DeprecatedPositionalArgumentsWarning
+            _warnings.warn(msg, DeprecatedPositionalArgumentsWarning)
             for k,v in zip(GaugeoptToTargetArgs.old_trailing_positional_args, args):
                 full_kwargs[k] = v
 

--- a/pygsti/baseobjs/_compatibility.py
+++ b/pygsti/baseobjs/_compatibility.py
@@ -11,8 +11,6 @@ Tools for general compatibility.
 #***************************************************************************************************
 
 import numbers as _numbers
-import uuid as _uuid
-from contextlib import contextmanager as _contextmanager
 
 
 def isint(x):
@@ -44,26 +42,3 @@ def _numpy14einsumfix():
             return _np.orig_einsum(str(s), *args, **kwargs)
         _np.orig_einsum = _np.einsum
         _np.einsum = fixed_einsum
-
-
-@_contextmanager
-def patched_uuid():
-    """
-    Monkeypatch the uuid module with a fake SafeUUID
-
-    `uuid.SafeUUID` is new in Python 3.7. This is a workaround to
-    allow unpickling objects from >= 3.7 in < 3.7.
-
-    TODO: objects should be serialized correctly and this should be deprecated.
-    """
-    if 'SafeUUID' not in dir(_uuid):
-        class dummy_SafeUUID(object):  # noqa N803
-            def __new__(cls, *args):
-                return _uuid.UUID.__new__(_uuid.UUID, *args)
-        _uuid.SafeUUID = dummy_SafeUUID
-
-        yield  # context block
-
-        _uuid.__delattr__('SafeUUID')
-    else:
-        yield

--- a/pygsti/circuits/subcircuit_selection.py
+++ b/pygsti/circuits/subcircuit_selection.py
@@ -16,23 +16,36 @@ from typing import Dict, List, Tuple, Callable, Union, Optional, Any, Protocol, 
 if TYPE_CHECKING:
     try:
         import qiskit
-    except:
+    except ImportError:
         pass
 
 import warnings as _warnings
-from collections import Counter as _Counter, defaultdict as _defaultdict
-import itertools as _itertools
+from collections import defaultdict as _defaultdict
 import networkx as _nx
 
 import tqdm as _tqdm
 
 import numpy as _np
-import json as _json
 
 from pygsti.circuits.circuit import Circuit as _Circuit
 from pygsti.baseobjs.label import Label as _Label
 from pygsti.protocols.protocol import FreeformDesign as _FreeformDesign
 from pygsti.tools import internalgates as _itgs
+from pygsti.tools.exceptions import MissingDependencyWarning
+
+
+QISKIT_VERSION_MISMATCH_MESSAGE_TEMPLATE = \
+f"""
+Simple subcircuit selection with a qiskit CouplingMap and/or InstructionDurations object
+is designed for qiskit version 2.1.1, and may not function properly for your qiskit version,
+which is %s.
+"""
+
+QISKIT_MISSING_MESSAGE = \
+"""
+Qiskit is required if using a CouplingMap or InstructionDurations object
+for subcircuit selection, and does not appear to be installed.
+"""
 
 MAX_STARTING_LAYER_ATTEMPTS = 1000
 
@@ -116,12 +129,9 @@ def sample_subcircuits(full_circs: Union[_Circuit, List[_Circuit]],
     try:
         import qiskit
         if qiskit.__version__ != '2.1.1':
-            _warnings.warn("Subcircuit selection with a qiskit CouplingMap and/or InstructionDurations object "
-            "is designed for qiskit version 2.1.1 "
-            "and may not function properly for your qiskit version, which is " + qiskit.__version__)
+            _warnings.warn(QISKIT_VERSION_MISMATCH_MESSAGE_TEMPLATE % qiskit.__version__, MissingDependencyWarning)
     except:
-        _warnings.warn('Qiskit is required if using a CouplingMap or InstructionDurations object '
-        'for subcircuit selection, and does not appear to be installed.')
+        _warnings.warn(QISKIT_MISSING_MESSAGE, MissingDependencyWarning)
     
     if rand_state is None:
         rand_state = _np.random.RandomState()
@@ -252,12 +262,9 @@ def simple_weighted_subcirc_selection(full_circ: _Circuit,
     try:
         import qiskit
         if qiskit.__version__ != '2.1.1':
-            _warnings.warn("Simple subcircuit selection with a qiskit CouplingMap and/or InstructionDurations object "
-            "is designed for qiskit version 2.1.1 "
-            "and may not function properly for your qiskit version, which is " + qiskit.__version__)
+            _warnings.warn(QISKIT_VERSION_MISMATCH_MESSAGE_TEMPLATE % qiskit.__version__, MissingDependencyWarning)
     except:
-        _warnings.warn('Qiskit is required if using a CouplingMap or InstructionDurations object '
-        'for simple subcircuit selection, and does not appear to be installed.')
+        _warnings.warn(QISKIT_MISSING_MESSAGE, MissingDependencyWarning)
 
     full_width = len(full_circ.line_labels)
     full_depth = len(full_circ)

--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -2972,7 +2972,6 @@ class DataSet(_MongoSerializable):
         else:
             f = file_or_filename
 
-        # with _compat.patched_uuid():
         state_dict = _pickle.load(f)
 
         if "gsIndexKeys" in state_dict:

--- a/pygsti/data/dataset.py
+++ b/pygsti/data/dataset.py
@@ -30,6 +30,7 @@ from pygsti.baseobjs.label import Label as _Label
 from pygsti.tools import NamedDict as _NamedDict
 from pygsti.tools import listtools as _lt
 from pygsti.tools.legacytools import deprecate as _deprecated_fn
+from pygsti.tools.exceptions import HashingEditableCircuitWarning as _HashingEditableCircuitWarning
 
 # import scipy.special as _sps
 # import scipy.fftpack as _fft
@@ -1412,9 +1413,13 @@ class DataSet(_MongoSerializable):
         if self.collisionAction == "keepseparate":
             if circuit in self.cirIndex:
                 tagged_circuit = circuit.copy(editable=True)
-                i = 1; tagged_circuit.occurrence = i
-                while tagged_circuit in self.cirIndex:
-                    i += 1; tagged_circuit.occurrence = i
+                with _warnings.catch_warnings():
+                    i = 1; tagged_circuit.occurrence = i
+                    _warnings.simplefilter('ignore', _HashingEditableCircuitWarning)
+                    # ^ We need that to suppress the warning in triggered from
+                    #   evaluation of `tagged_circuit in self.cirIndex`.
+                    while tagged_circuit in self.cirIndex:
+                        i += 1; tagged_circuit.occurrence = i
                 tagged_circuit.done_editing()
                 #add data for a new (duplicate) circuit
                 circuit = tagged_circuit
@@ -2967,8 +2972,8 @@ class DataSet(_MongoSerializable):
         else:
             f = file_or_filename
 
-        with _compat.patched_uuid():
-            state_dict = _pickle.load(f)
+        # with _compat.patched_uuid():
+        state_dict = _pickle.load(f)
 
         if "gsIndexKeys" in state_dict:
             _warnings.warn("Loading a deprecated-format DataSet.  Please re-save asap.")

--- a/pygsti/extras/devices/__init__.py
+++ b/pygsti/extras/devices/__init__.py
@@ -8,5 +8,4 @@
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
-from .devcore import *
 from .experimentaldevice import ExperimentalDevice

--- a/pygsti/extras/idletomography/idtreport.py
+++ b/pygsti/extras/idletomography/idtreport.py
@@ -778,12 +778,8 @@ def create_idletomography_report(results, filename, title="auto",
 
     if title is None or title == "auto":
         if filename is not None:
-            autoname = _autotitle.generate_name()
+            autoname = _autotitle.generate_name(log_warning=True)
             title = "Idle Tomography Report for " + autoname
-            _warnings.warn(("You should really specify `title=` when generating reports,"
-                            " as this makes it much easier to identify them later on.  "
-                            "Since you didn't, pyGSTi has generated a random one"
-                            " for you: '{}'.").format(autoname))
         else:
             title = "N/A"  # No title - but it doesn't matter since filename is None
 

--- a/pygsti/extras/interpygate/core.py
+++ b/pygsti/extras/interpygate/core.py
@@ -655,7 +655,9 @@ class InterpolatedQuantity(object):
 
         value = _np.zeros(self.qty_shape, dtype='d')
         for i, interpolator in enumerate(self.interpolators.flat):
-            value.flat[i] = interpolator(*v)
+            u = interpolator(*v)
+            w = u.item() if isinstance(u, _np.ndarray) else u
+            value.flat[i] = w
         return value
 
     def write(self, filename):

--- a/pygsti/extras/interpygate/core.py
+++ b/pygsti/extras/interpygate/core.py
@@ -27,8 +27,10 @@ try:
 except ImportError:
     use_csaps = False
     import warnings
-    warnings.warn(("Warning - Cannot import csaps module for spline interpolation. "
-                   "Interpolated gates will default to linear interpolation."))
+    from pygsti.tools.exceptions import MissingDependencyWarning
+    msg = "Warning - Cannot import csaps module for spline interpolation. " \
+          "Interpolated gates will default to linear interpolation."
+    warnings.warn(msg, MissingDependencyWarning)
 
 if use_csaps:
     class custom_interpolator():

--- a/pygsti/extras/paritybenchmarking/disturbancecalc.py
+++ b/pygsti/extras/paritybenchmarking/disturbancecalc.py
@@ -87,7 +87,7 @@ def multikron(a):
 
 # These are useful for making arbitrary matrices and then sticking in the right number of identities:
 def interior_tensor_product(mx, dim_a, dim_b, e=None):
-    """
+    r"""
     `mx` is an operator on two subsystems of dimension dim_a and dim_b
     `mx = sum_i A_i \otimes B_i` where A_i is an operator on subsystem a and B_i is an operator on subsystem b
     Return: sum_i A_i \otimes e \otimes B_i

--- a/pygsti/forwardsims/mapforwardsim.py
+++ b/pygsti/forwardsims/mapforwardsim.py
@@ -729,19 +729,26 @@ class MapForwardSimulator(_DistributableForwardSimulator, SimpleMapForwardSimula
             is to allow a trace or other linear operation to be done
             prior to the scaling.
         """
-        _warnings.warn('Generating dense process matrix representations of circuits or gates \n'
-                       'can be inefficient and should be avoided for the purposes of forward \n'
-                       'simulation/calculation of circuit outcome probability distributions \n' 
-                       'when using the MapForwardSimulator.')
-        
+        superop_dim = self.model.evotype.minimal_dim(self.model.state_space)
+        if superop_dim <= 16:
+            msg = \
+            """
+            Generating dense process matrix representations of circuits or gates
+            can be inefficient and should be avoided for the purposes of forward
+            simulation/calculation of circuit outcome probability distributions
+            when using the MapForwardSimulator. This operator is small enough
+            that it could be computed with MatrixForwardSimulator instead.
+            """
+            from pygsti.tools.exceptions import ForwardSimulatorSuitabilityWarning
+            _warnings.warn(msg, ForwardSimulatorSuitabilityWarning)
+
         # Smallness tolerances, used internally for conditional scaling required
         # to control bulk products, their gradients, and their Hessians.
         _PSMALL = 1e-100
-        
+        G = _np.identity(superop_dim)
         if scale:
             scaledGatesAndExps = {}
             scale_exp = 0
-            G = _np.identity(self.model.evotype.minimal_dim(self.model.state_space))
             for lOp in circuit:
                 if lOp not in scaledGatesAndExps:
                     opmx = self.model.circuit_layer_operator(lOp, 'op').to_dense("minimal")
@@ -763,7 +770,6 @@ class MapForwardSimulator(_DistributableForwardSimulator, SimpleMapForwardSimula
             return G, scale
 
         else:
-            G = _np.identity(self.model.evotype.minimal_dim(self.model.state_space))
             for lOp in circuit:
                 G = _np.dot(self.model.circuit_layer_operator(lOp, 'op').to_dense("minimal"), G)
                 # above line: LEXICOGRAPHICAL VS MATRIX ORDER

--- a/pygsti/io/readers.py
+++ b/pygsti/io/readers.py
@@ -126,7 +126,7 @@ def read_dataset(filename, cache=False, collision_action="aggregate",
 
             printer.log("Writing cache file (to speed future loads): %s"
                         % cache_filename)
-            ds.save(cache_filename)
+            ds.write_binary(cache_filename)
         else:
             # otherwise must use standard dataset file format
             parser = _stdinput.StdInputParser()

--- a/pygsti/io/writers.py
+++ b/pygsti/io/writers.py
@@ -33,6 +33,7 @@ from pygsti.modelmembers import states as _state
 from pygsti.processors import QubitProcessorSpec, QuditProcessorSpec
 from itertools import product
 
+
 def write_empty_dataset(filename, circuits,
                         header_string='## Columns = 1 frequency, count total', num_zero_cols=None,
                         append_weights_column=False):
@@ -321,7 +322,10 @@ def write_model(model, filename, title=None):
     -------
     None
     """
-    _warnings.warn("write_model(...) is unable to write all types of pyGSTi models, and really should NOT be used!")
+    _warnings.warn(
+        "write_model(...) is unable to write all types of pyGSTi models, and really should NOT be used!",
+        _tools.exceptions.pyGSTiDeprecationWarning
+    )
 
     def writeprop(f, lbl, val):
         """ Write (label,val) property to output file """

--- a/pygsti/modelmembers/operations/fullarbitraryop.py
+++ b/pygsti/modelmembers/operations/fullarbitraryop.py
@@ -15,6 +15,12 @@ import numpy as _np
 from pygsti.modelmembers.operations.denseop import DenseOperator as _DenseOperator
 from pygsti.modelmembers.operations.linearop import LinearOperator as _LinearOperator
 
+EPSILON_POWER_FOR_COMPLEX_CAST = 0.875
+# ^ Controls threshold at which we explicitly cast complex data to real data, 
+#   versus letting numpy do the cast (which will lead to a ComplexWarning).
+#   The default value of 0.875 means our threshold in double precision is
+#   about 1e-14.
+
 
 class FullArbitraryOp(_DenseOperator):
     """
@@ -64,11 +70,16 @@ class FullArbitraryOp(_DenseOperator):
         -------
         None
         """
-        mx = _LinearOperator.convert_to_matrix(m)
-        if(mx.shape != (self.dim, self.dim)):
+        mx : _np.ndarray = _LinearOperator.convert_to_matrix(m)
+        if (mx.shape != (self.dim, self.dim)):
             raise ValueError("Argument must be a (%d,%d) matrix!"
                              % (self.dim, self.dim))
-        self._ptr[:, :] = _np.array(mx)
+        if not _np.isrealobj(mx) and _np.isrealobj(self._ptr):
+            tol = _np.finfo(self._ptr.dtype).eps ** EPSILON_POWER_FOR_COMPLEX_CAST
+            if _np.all(_np.abs(mx.imag) <= tol):  # type: ignore
+                mx = mx.real                      # type: ignore
+
+        self._ptr[:, :] = mx
         self._ptr_has_changed()
         self.dirty = True
 

--- a/pygsti/modelmembers/povms/__init__.py
+++ b/pygsti/modelmembers/povms/__init__.py
@@ -37,6 +37,7 @@ from pygsti.baseobjs import statespace as _statespace
 from pygsti.tools import basistools as _bt
 from pygsti.tools import optools as _ot
 from pygsti.tools import sum_of_negative_choi_eigenvalues_gate
+from pygsti.tools.exceptions import PrepareThyself
 from pygsti.baseobjs import Basis
 
 # Avoid circular import
@@ -557,7 +558,12 @@ def convert(povm, to_type, basis, ideal_povm=None, flatten_structure=False, cp_p
                     )
 
                     if degrees_of_freedom > errgen.num_params:
-                        warnings.warn("POVM has more degrees of freedom than the available number of parameters, representation in this parameterization is not guaranteed")
+                        msg = \
+                        """
+                        POVM has more degrees of freedom than the available number of parameters,
+                        representation in this parameterization is not guaranteed.
+                        """
+                        warnings.warn(msg, PrepareThyself)
                     exp_errgen = _ExpErrorgenOp(errgen)
                     
                     num_errgens = errgen.num_params

--- a/pygsti/models/explicitmodel.py
+++ b/pygsti/models/explicitmodel.py
@@ -51,6 +51,8 @@ from pygsti.tools import slicetools as _slct
 from pygsti.tools import listtools as _lt
 from pygsti import SpaceT
 from pygsti.tools.legacytools import deprecate as _deprecated_fn
+from pygsti.tools.exceptions import UnknownGaugeSpaceDimension as _UnknownGaugeSpaceDimension
+
 
 
 class ExplicitOpModel(_mdl.OpModel):
@@ -578,6 +580,42 @@ class ExplicitOpModel(_mdl.OpModel):
         instSize = [i.num_elements for i in self.instruments.values()]
         #Don't count self.factories?
         return sum(rhoSize) + sum(povmSize) + sum(opSize) + sum(instSize)
+
+    @property
+    def num_modeltest_params(self) -> int:
+        """
+        The parameter count to use when testing this model against data.
+
+        Often times, this is the same as :meth:`num_params`, but there are times
+        when it can convenient or necessary to use a parameter count different than
+        the actual number of parameters in this model.
+        """
+        if not hasattr(self, '_num_modeltest_params'):
+            self._num_modeltest_params = None
+
+        if self._num_modeltest_params is not None:
+            return self._num_modeltest_params
+
+        from pygsti.models.model import MEMLIMIT_FOR_NONGAUGE_PARAMS
+        if MEMLIMIT_FOR_NONGAUGE_PARAMS is not None:
+            # We'd like to return self.num_nongauge_params, but accessing that property
+            # performs a memory-intensive computation in ExplicitOpModelCalc._buildup_dpg.
+            # If we have inadequate memory then we skip that computation.
+            buildup_dpg_mem = _np.dtype('d').itemsize * (self.num_params + self.state_space.dim**2)
+            buildup_dpg_mem *= self.num_elements  # type: ignore
+            if buildup_dpg_mem > MEMLIMIT_FOR_NONGAUGE_PARAMS:
+                _warnings.warn(("ExplicitOpModel.num_modeltest_params did not compute number of *non-gauge* parameters - "
+                                "using total (make MEMLIMIT_FOR_NONGAUGE_PARAMS larger if you really want "
+                                "the count of nongauge params)"), _UnknownGaugeSpaceDimension)
+                return self.num_params
+
+        try:
+            return self.num_nongauge_params
+        except:  # numpy can throw a LinAlgError or sparse cases can throw a NotImplementedError
+            _warnings.warn(("ExplicOpModel.num_modeltest_params could not obtain number of *non-gauge* parameters"
+                            " - using total instead"), _UnknownGaugeSpaceDimension)
+            return self.num_params
+
 
     @property
     def num_nongauge_params(self):

--- a/pygsti/models/model.py
+++ b/pygsti/models/model.py
@@ -34,6 +34,7 @@ from pygsti.baseobjs.label import Label as _Label
 from pygsti.baseobjs.resourceallocation import ResourceAllocation as _ResourceAllocation
 from pygsti.tools import slicetools as _slct
 from pygsti.tools import matrixtools as _mt
+from pygsti.tools.exceptions import UnknownGaugeSpaceDimension as _UnknownGaugeSpaceDimension
 from pygsti.circuits import Circuit as _Circuit, SeparatePOVMCircuit as _SeparatePOVMCircuit
 
 MEMLIMIT_FOR_NONGAUGE_PARAMS = None
@@ -127,6 +128,7 @@ class Model(_NicelySerializable):
             return self._num_modeltest_params
         elif 'num_nongauge_params' in dir(self):  # better than hasattr, which *runs* the @property method
             if MEMLIMIT_FOR_NONGAUGE_PARAMS is not None:
+                # QUESTION: what in the heck is happening in this code path?
                 if hasattr(self, 'num_elements'):
                     memForNumGaugeParams = self.num_elements * (self.num_params + self.state_space.dim**2) \
                         * _np.dtype('d').itemsize  # see Model._buildup_dpg (this is mem for dPG)
@@ -136,14 +138,14 @@ class Model(_NicelySerializable):
                 if memForNumGaugeParams > MEMLIMIT_FOR_NONGAUGE_PARAMS:
                     _warnings.warn(("Model.num_modeltest_params did not compute number of *non-gauge* parameters - "
                                     "using total (make MEMLIMIT_FOR_NONGAUGE_PARAMS larger if you really want "
-                                    "the count of nongauge params"))
+                                    "the count of nongauge params"), _UnknownGaugeSpaceDimension)
                     return self.num_params
 
             try:
                 return self.num_nongauge_params  # len(x0)
             except:  # numpy can throw a LinAlgError or sparse cases can throw a NotImplementedError
                 _warnings.warn(("Model.num_modeltest_params could not obtain number of *non-gauge* parameters"
-                                " - using total instead"))
+                                " - using total instead"), _UnknownGaugeSpaceDimension)
                 return self.num_params
         else:
             return self.num_params

--- a/pygsti/models/model.py
+++ b/pygsti/models/model.py
@@ -108,47 +108,23 @@ class Model(_NicelySerializable):
         return len(self._paramvec)
 
     @property
-    def num_modeltest_params(self):
+    def num_modeltest_params(self) -> int:
         """
         The parameter count to use when testing this model against data.
 
         Often times, this is the same as :meth:`num_params`, but there are times
         when it can convenient or necessary to use a parameter count different than
         the actual number of parameters in this model.
-
-        Returns
-        -------
-        int
-            the number of model parameters.
         """
         if not hasattr(self, '_num_modeltest_params'):  # for backward compatibility
             self._num_modeltest_params = None
 
         if self._num_modeltest_params is not None:
             return self._num_modeltest_params
-        elif 'num_nongauge_params' in dir(self):  # better than hasattr, which *runs* the @property method
-            if MEMLIMIT_FOR_NONGAUGE_PARAMS is not None:
-                # QUESTION: what in the heck is happening in this code path?
-                if hasattr(self, 'num_elements'):
-                    memForNumGaugeParams = self.num_elements * (self.num_params + self.state_space.dim**2) \
-                        * _np.dtype('d').itemsize  # see Model._buildup_dpg (this is mem for dPG)
-                else:
-                    return self.num_params
-
-                if memForNumGaugeParams > MEMLIMIT_FOR_NONGAUGE_PARAMS:
-                    _warnings.warn(("Model.num_modeltest_params did not compute number of *non-gauge* parameters - "
-                                    "using total (make MEMLIMIT_FOR_NONGAUGE_PARAMS larger if you really want "
-                                    "the count of nongauge params"), _UnknownGaugeSpaceDimension)
-                    return self.num_params
-
-            try:
-                return self.num_nongauge_params  # len(x0)
-            except:  # numpy can throw a LinAlgError or sparse cases can throw a NotImplementedError
-                _warnings.warn(("Model.num_modeltest_params could not obtain number of *non-gauge* parameters"
-                                " - using total instead"), _UnknownGaugeSpaceDimension)
-                return self.num_params
-        else:
-            return self.num_params
+        
+        _warnings.warn(("Model.num_modeltest_params could not obtain number of *non-gauge* parameters"
+                        " - using total instead"), _UnknownGaugeSpaceDimension)
+        return self.num_params
 
     @num_modeltest_params.setter
     def num_modeltest_params(self, count):

--- a/pygsti/models/modelnoise.py
+++ b/pygsti/models/modelnoise.py
@@ -18,6 +18,7 @@ import numpy as _np
 from pygsti.models.stencillabel import StencilLabel as _StencilLabel
 from pygsti.tools import listtools as _lt
 from pygsti.tools import optools as _ot
+from pygsti.tools.exceptions import UntouchedModelNoiseKey as _UntouchedModelNoiseKey
 from pygsti.modelmembers import operations as _op
 from pygsti.modelmembers.operations.lindbladcoefficients import LindbladCoefficientBlock as _LindbladCoefficientBlock
 from pygsti.baseobjs.basis import Basis as _Basis
@@ -364,8 +365,13 @@ class OpModelNoise(ModelNoise):
         """
         untouched_keys = [k for k, touch_cnt in self._opkey_access_counters.items() if touch_cnt == 0]
         if len(untouched_keys) > 0:
-            _warnings.warn(("The following model-noise entries were unused: %s.  You may want to double check"
-                            " that you've entered a valid noise specification.") % ", ".join(map(str, untouched_keys)))
+            msg = \
+            f"""
+            The following model-noise entries were unused: {', '.join(map(str, untouched_keys))}.
+            You may want to double check that you've entered a valid noise specification.
+            """
+            _warnings.warn(msg, _UntouchedModelNoiseKey)
+        return
 
     def compute_stencil_absolute_sslbls(self, stencil, state_space, target_labels=None, qudit_graph=None):
         """

--- a/pygsti/optimize/optimize.py
+++ b/pygsti/optimize/optimize.py
@@ -178,7 +178,8 @@ def minimize(fn, x0, method='cg', callback=None,
         # with different settings.
         solution = _spo.minimize(fn, x0, method=method, options=opts, tol=tol, callback=callback, jac=jac)
         if not solution.success:
-            tempsol = _spo.minimize(fn, x0, method='COBYLA', options=opts)
+            opts_cobyla = {k: v for (k, v) in opts.items() if (k not in ('gtol', 'ftol'))}
+            tempsol = _spo.minimize(fn, x0, method='COBYLA', options=opts_cobyla)
             # ^ It's wise to pass through `opts` in case it contains bound constraints.
             if not hasattr(jac, '__call__'):
                 jac = '3-point'  # more expensive than the default 2-point finite-difference, but more reliable.

--- a/pygsti/protocols/confidenceregionfactory.py
+++ b/pygsti/protocols/confidenceregionfactory.py
@@ -1179,8 +1179,7 @@ class ConfidenceRegionFactoryView(object):
             delta.shape = f0.shape  # reshape to un-flattened
         else:
             assert(isinstance(f0, float))
-            delta = float(delta)
-
+            delta = delta.item()
         return delta
 
     def _compute_df_from_grad_f_hessian(self, grad_f, f0, verbosity):

--- a/pygsti/protocols/estimate.py
+++ b/pygsti/protocols/estimate.py
@@ -837,8 +837,10 @@ class Estimate(_MongoSerializable):
         mdl_dof = mdl.num_modeltest_params
 
         k = max(ds_dof - mdl_dof, 1)  # expected chi^2 or 2*(logL_ub-logl) mean
-        if ds_dof <= mdl_dof: _warnings.warn("Max-model params (%d) <= model params (%d)!  Using k == 1."
-                                             % (ds_dof, mdl_dof))
+        if ds_dof <= mdl_dof:
+            msg = "Max-model params (%d) <= model params (%d)!  Using k == 1." % (ds_dof, mdl_dof)
+            _warnings.warn( msg, _tools.exceptions.OverparameterizationWarning)
+
         return (fitqty - k) / _np.sqrt(2 * k)
 
     def view(self, gaugeopt_keys, parent=None):

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -1000,6 +1000,7 @@ class GSTGaugeOptSuite(_NicelySerializable):
 
         if self.gaugeopt_target is not None:
             assert(isinstance(self.gaugeopt_target, _Model)), "`gaugeopt_target` must be None or a Model"
+            id_gaugeopt_target = id(self.gaugeopt_target)
             for goparams in gaugeopt_suite_dict.values():
                 if hasattr(goparams, 'keys'):
                     goparams_list = [goparams] 
@@ -1007,13 +1008,14 @@ class GSTGaugeOptSuite(_NicelySerializable):
                     continue
                 else:
                     goparams_list = goparams
-
+                assert isinstance(goparams_list, list)
+                assert len(goparams_list) > 0
                 for goparams_dict in goparams_list:
-                    if 'target_model' in goparams_dict:
-                        _warnings.warn(("`gaugeOptTarget` argument is overriding"
-                                        " user-defined target_model in gauge opt"
-                                        " param dict(s)"))
-                    goparams_dict.update({'target_model': self.gaugeopt_target})
+                    assert isinstance(goparams_dict, dict)
+                    if id_gaugeopt_target != id(goparams_dict.get('target_model', self.gaugeopt_target)):
+                        msg = "`self.gaugeopt_target` member is overriding `target_model` in inner dict of gaugeopt_suite_dict."
+                        _warnings.warn(msg)
+                    goparams_dict['target_model'] = self.gaugeopt_target
 
         return gaugeopt_suite_dict
 
@@ -1082,7 +1084,7 @@ class GSTGaugeOptSuite(_NicelySerializable):
                 'verbosity': printer
             })
 
-            if suite_name == "stdgaugeopt-unreliable2Q" and model.dim == 16:
+            if suite_name == "stdgaugeopt-unreliable2Q" and model.dim == 16 and len(unreliable_ops) > 0:
                 if any([gl in model.operations for gl in unreliable_ops]):
                     stage2_item_weights = {'gates': 1.0, 'spam': 0.0}
                     for gl in unreliable_ops:

--- a/pygsti/report/autotitle.py
+++ b/pygsti/report/autotitle.py
@@ -11,9 +11,11 @@ Automatic report title generation.
 #***************************************************************************************************
 
 import numpy as _np
+import warnings as _warnings
+from pygsti.tools.exceptions import UnnamedReportWarning
 
 
-def generate_name():
+def generate_name(log_warning=True):
     """
     Generate a random adjective + noun name
 
@@ -23,7 +25,13 @@ def generate_name():
     """
     adj = _adjectives[_np.random.randint(0, len(_adjectives))]
     noun = _nouns[_np.random.randint(0, len(_nouns))]
-    return adj + " " + noun
+    autoname = adj + " " + noun
+    if log_warning:
+        _warnings.warn(("You should really specify `title=` when generating reports,"
+                " as this makes it much easier to identify them later on.  "
+                "Since you didn't, pyGSTi has generated a random one"
+                " for you: '{}'.").format(autoname), UnnamedReportWarning)
+    return autoname
 
 
 _nouns = [

--- a/pygsti/report/factory.py
+++ b/pygsti/report/factory.py
@@ -1247,12 +1247,8 @@ def construct_standard_report(results, title="auto",
                           " confidence interval - please note the updated function signature"))
 
     if title is None or title == "auto":
-        autoname = _autotitle.generate_name()
+        autoname = _autotitle.generate_name(log_warning=True)
         title = "GST Report for " + autoname
-        _warnings.warn(("You should really specify `title=` when generating reports,"
-                        " as this makes it much easier to identify them later on.  "
-                        "Since you didn't, pyGSTi has generated a random one"
-                        " for you: '{}'.").format(autoname))
 
     pdfInfo = [('Author', 'pyGSTi'), ('Title', title),
                ('Keywords', 'GST'), ('pyGSTi Version', _pygsti_version)]
@@ -1504,12 +1500,8 @@ def construct_nqnoise_report(results, title="auto",
                           " confidence interval - please note the updated function signature"))
 
     if title is None or title == "auto":
-        autoname = _autotitle.generate_name()
+        autoname = _autotitle.generate_name(log_warning=True)
         title = "GST Report for " + autoname
-        _warnings.warn(("You should really specify `title=` when generating reports,"
-                        " as this makes it much easier to identify them later on.  "
-                        "Since you didn't, pyGSTi has generated a random one"
-                        " for you: '{}'.").format(autoname))
 
     pdfInfo = [('Author', 'pyGSTi'), ('Title', title),
                ('Keywords', 'GST'), ('pyGSTi Version', _pygsti_version)]
@@ -1665,12 +1657,8 @@ def create_drift_report(results, title='auto', ws=None, verbosity=1):
     ws = ws or _ws.Workspace()
 
     if title is None or title == "auto":
-        autoname = _autotitle.generate_name()
+        autoname = _autotitle.generate_name(log_warning=True)
         title = "Drift Report for " + autoname
-        _warnings.warn(("You should really specify `title=` when generating reports,"
-                        " as this makes it much easier to identify them later on.  "
-                        "Since you didn't, pyGSTi has generated a random one"
-                        " for you: '{}'.").format(autoname))
 
     pdfInfo = [('Author', 'pyGSTi'), ('Title', title),
                ('Keywords', 'GST'), ('pyGSTi Version', _pygsti_version)]

--- a/pygsti/report/plothelpers.py
+++ b/pygsti/report/plothelpers.py
@@ -364,7 +364,9 @@ def rated_n_sigma(dataset, model, circuits, objfn_builder, np=None, wildcard=Non
     Ns = dataset.degrees_of_freedom(ds_gstrs)  # number of independent parameters in dataset
     k = max(Ns - np, 1)  # expected chi^2 or 2*(logL_ub-logl) mean
     Nsig = (fitqty - k) / _np.sqrt(2 * k)
-    if Ns <= np: _warnings.warn("Max-model params (%d) <= model params (%d)!  Using k == 1." % (Ns, np))
+    if Ns <= np:
+        msg = "Max-model params (%d) <= model params (%d)!  Using k == 1." % (Ns, np)
+        _warnings.warn(msg, _tools.exceptions.OverparameterizationWarning)
     #pv = 1.0 - _stats.chi2.cdf(chi2,k) # reject GST model if p-value < threshold (~0.05?)
 
     if Nsig <= 2: rating = 5

--- a/pygsti/tools/__init__.py
+++ b/pygsti/tools/__init__.py
@@ -13,6 +13,7 @@ pyGSTi Tools Python Package
 from .basistools import *
 from .chi2fns import *
 from .edesigntools import *
+from .exceptions import *
 from .hypothesis import *
 # Import the most important/useful routines of each module into
 # the package namespace

--- a/pygsti/tools/errgenproptools.py
+++ b/pygsti/tools/errgenproptools.py
@@ -1258,7 +1258,7 @@ def error_generator_commutator(errorgen_1, errorgen_2, flip_weight=False, weight
     return errorgens
 
 def error_generator_composition(errorgen_1, errorgen_2, weight=1.0, identity=None):
-    """
+    r"""
     Returns the composition of two error generators. I.e. errorgen_1[errorgen_2[\cdot]].
     
     Parameters

--- a/pygsti/tools/exceptions.py
+++ b/pygsti/tools/exceptions.py
@@ -74,3 +74,12 @@ class HashingEditableCircuitWarning(UserWarning):
     triggered when performing a check like 
     `if c in dict_of_circuits: ...`.
     """
+    pass
+
+
+class PrepareThyself(UserWarning):
+    """ 
+    Indicate to the user that there's good reason to expect that what
+    they're about to do will fail.
+    """
+    pass

--- a/pygsti/tools/exceptions.py
+++ b/pygsti/tools/exceptions.py
@@ -101,3 +101,27 @@ class CVXPYFailure(UserWarning):
     behavior in these cases.
     """
     pass
+
+
+class UntouchedModelNoiseKey(UserWarning):
+    """ 
+    Alert the user that they may have incorrectly
+    constructed an OpModelNoise object.
+    """
+    pass
+
+
+class OverparameterizationWarning(UserWarning):
+    """ 
+    Signal that the maximal model has fewer parameters than
+    the current model.
+    """
+    pass
+
+
+class UnnamedReportWarning(UserWarning):
+    """ 
+    Signal that we're generating a name for a report automatically
+    and randomly, since a user didn't provide a name.
+    """
+    pass

--- a/pygsti/tools/exceptions.py
+++ b/pygsti/tools/exceptions.py
@@ -83,3 +83,21 @@ class PrepareThyself(UserWarning):
     they're about to do will fail.
     """
     pass
+
+
+class UnknownGaugeSpaceDimension(UserWarning):
+    """ 
+    Inform the user that we weren't sure of the dimension of gauge
+    space in current model parameterization. We use some kind of a
+    default value in these cases instead.
+    """
+    pass
+
+
+class CVXPYFailure(UserWarning):
+    """ 
+    Numerical solvers dispatched by CVXPY failed when trying
+    to solve a pyGSTi-constructed problem. We have fallback
+    behavior in these cases.
+    """
+    pass

--- a/pygsti/tools/exceptions.py
+++ b/pygsti/tools/exceptions.py
@@ -23,3 +23,54 @@ class GSTValueError(Exception):
     Gate Set Tomography value error exception class.
     """
     pass
+
+
+class MissingDependencyWarning(UserWarning):
+    """
+    Inform the user that we're missing an optional dependency they
+    PROBABLY want, but isn't strictly required.
+    """
+    pass
+
+
+class DeprecatedPositionalArgumentsWarning(UserWarning):
+    """
+    Inform the user that they're using positional arguments
+    that should be specified as keyword arguments.
+    """
+    pass
+
+
+class NumericalDomainWarning(UserWarning):
+    """
+    Inform the user that some mathematical function is being applied on
+    an input that's slightly outside of its usual domain. E.g., we're
+    computing the fidelity between states (x, y) where trace(x) < 1.
+    """
+    pass
+
+
+class pyGSTiDeprecationWarning(UserWarning, DeprecationWarning):
+    """
+    A helper class so users (and pyGSTi developers) can distinguish
+    between deprecation warnings raised by us versus by other
+    libraries.
+    """
+    pass
+
+
+class ForwardSimulatorSuitabilityWarning(UserWarning):
+    """
+    Inform the user that they should consider using a different
+    forward simulator class in a given context.
+    """
+    pass
+
+
+class HashingEditableCircuitWarning(UserWarning):
+    """
+    Inform the user that a Circuit.__hash__ has been called
+    on a Circuit with Circuit.editable == True. This is often
+    triggered when performing a check like 
+    `if c in dict_of_circuits: ...`.
+    """

--- a/pygsti/tools/legacytools.py
+++ b/pygsti/tools/legacytools.py
@@ -13,6 +13,7 @@ Functions related deprecating other functions
 import sys as _sys
 import types as _types
 import warnings as _warnings
+from pygsti.tools.exceptions import pyGSTiDeprecationWarning as _pyGSTiDeprecationWarning
 
 
 def warn_deprecated(name, replacement=None):
@@ -35,7 +36,7 @@ def warn_deprecated(name, replacement=None):
     if replacement is not None:
         message += '\n    '
         message += 'Please use {} instead.'.format(replacement)
-    _warnings.warn(message)
+    _warnings.warn(message, _pyGSTiDeprecationWarning)
 
 
 def deprecate(replacement=None):

--- a/pygsti/tools/likelihoodfns.py
+++ b/pygsti/tools/likelihoodfns.py
@@ -18,6 +18,7 @@ import scipy.stats as _stats
 from pygsti.tools import basistools as _bt
 from pygsti.tools import jamiolkowski as _jam
 from pygsti.tools import listtools as _lt
+from pygsti.tools.exceptions import OverparameterizationWarning as _OverparameterizationWarning
 
 #from ..baseobjs.smartcache import smart_cached
 
@@ -789,7 +790,8 @@ def two_delta_logl(model, dataset, circuits=None,
     ds_dof = dataset.degrees_of_freedom(ds_strs)
     k = max(ds_dof - mdl_dof, 1)
     if ds_dof <= mdl_dof:
-        _warnings.warn("Max-model params (%d) <= model params (%d)!  Using k == 1." % (ds_dof, mdl_dof))
+        msg = "Max-model params (%d) <= model params (%d)!  Using k == 1." % (ds_dof, mdl_dof)
+        _warnings.warn(msg, _OverparameterizationWarning)
 
     nsigma = (two_delta_logl - k) / _np.sqrt(2 * k)
     pvalue = 1.0 - _stats.chi2.cdf(two_delta_logl, k)

--- a/pygsti/tools/lindbladtools.py
+++ b/pygsti/tools/lindbladtools.py
@@ -273,10 +273,11 @@ def create_elementary_errorgen(typ, p, q=None, sparse=False):
     """
     d = p.shape[0]
     d2 = d**2
+    dtype = (1j*_np.array(1, dtype=p.dtype)).dtype
     if sparse:
-        elem_errgen = _sps.lil_matrix((d2, d2), dtype=p.dtype)
+        elem_errgen = _sps.lil_matrix((d2, d2), dtype=dtype)
     else:
-        elem_errgen = _np.empty((d2, d2), dtype=p.dtype)
+        elem_errgen = _np.empty((d2, d2), dtype=dtype)
 
     assert(typ in ('H', 'S', 'C', 'A')), "`typ` must be one of 'H', 'S', 'C', or 'A'"
     assert((typ in 'HS' and q is None) or (typ in 'CA' and q is not None)), \
@@ -315,15 +316,15 @@ def create_elementary_errorgen(typ, p, q=None, sparse=False):
                     rho1[i, :] += 1j*p[j, :]
                 elif typ == 'S':
                     pdag_p = (pdag @ p)
-                    rho1 = p[:,i].reshape((d,1))@pdag[j,:].reshape((1,d))
+                    rho1 = p[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d))
                     rho1[:, j] += -0.5*pdag_p[:, i]
                     rho1[i, :] += -0.5*pdag_p[j, :]
                 elif typ == 'C':
-                    rho1 = p[:,i].reshape((d,1))@qdag[j,:].reshape((1,d)) + q[:,i].reshape((d,1))@pdag[j,:].reshape((1,d))
+                    rho1 = p[:,i].reshape((d,1)) @ qdag[j,:].reshape((1,d)) + q[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d))
                     rho1[:, j] += -0.5*pq_plus_qp[:, i]
                     rho1[i, :] += -0.5*pq_plus_qp[j, :]
                 elif typ == 'A':
-                    rho1 = 1j*(p[:,i].reshape((d,1))@ qdag[j,:].reshape((1,d))) - 1j*(q[:,i].reshape((d,1))@pdag[j,:].reshape((1,d)))
+                    rho1 = 1j*(p[:,i].reshape((d,1)) @ qdag[j,:].reshape((1,d))) - 1j*(q[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d)))
                     rho1[:, j] += 1j*.5*pq_minus_qp[:, i]
                     rho1[i, :] += 1j*.5*pq_minus_qp[j, :]
 

--- a/pygsti/tools/matrixmod2.py
+++ b/pygsti/tools/matrixmod2.py
@@ -283,7 +283,7 @@ def albert_factor(d, failcount=0, rand_state=None):
         n = Axb_mod2(B, z).T
         x = _np.array(_np.dot(n, L), dtype='int')
         zer = _np.zeros([t - ind - 1, 1])
-        L = _np.array(_np.bmat([[_np.eye(1), x], [zer, L]]), dtype='int')
+        L = _np.block([[_np.eye(1), x], [zer, L]]).astype('int')
 
     Qinv = inv_mod2(dot_mod2(P, N))
     L = dot_mod2(_np.array(Qinv), L)
@@ -500,7 +500,7 @@ def proper_permutation(a):
     for ind in range(t):
         perm = fix_top(a[ind:, ind:])
         zer = _np.zeros([ind, t - ind])
-        full_perm = _np.array(_np.bmat([[_np.eye(ind), zer], [zer.T, perm]]))
+        full_perm = _np.block([[_np.eye(ind), zer], [zer.T, perm]])
         a = multidot_mod2([full_perm, a, full_perm.T])
         Ps += [full_perm]
 #     return Ps

--- a/pygsti/tools/mcfetools.py
+++ b/pygsti/tools/mcfetools.py
@@ -198,7 +198,7 @@ def adjusted_success_probability(hamming_distance_counts: _np.ndarray) -> float:
     Compute the adjusted success probability `adjSP` of a circuit
     from its Hamming distance counts, according to the formula
 
-    adjSP = \sum_{k=0}^n (-1/2)^k * h_k,
+    adjSP = \\sum_{k=0}^n (-1/2)^k * h_k,
 
     where h_k is the probability of Hamming distance k.
 

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -25,6 +25,7 @@ from pygsti.tools import jamiolkowski as _jam
 from pygsti.tools import lindbladtools as _lt
 from pygsti.tools import matrixtools as _mt
 from pygsti.tools import sdptools as _sdps
+from pygsti.tools.exceptions import NumericalDomainWarning as _NumericalDomainWarning
 from pygsti.baseobjs import basis as _pgb
 from pygsti.baseobjs.basis import (
     Basis as _Basis,
@@ -146,12 +147,12 @@ def fidelity(a, b):
     _mt.assert_hermitian(a, __SCALAR_TOL__)
     _mt.assert_hermitian(b, __SCALAR_TOL__)
 
-    trace_warning = f"The input matrix %s is not trace-1 up to tolerance {__SCALAR_TOL__}. Beware result!"
+    trace_warning = f"The input matrix %s has trace %s, which deviates from 1 by more than {__SCALAR_TOL__}. Beware result!"
 
     if _np.abs(_np.trace(a) - 1) > __SCALAR_TOL__:
-        _warnings.warn(trace_warning % 'a')
+        _warnings.warn(trace_warning % ('a', str(_np.trace(a))), _NumericalDomainWarning)
     if _np.abs(_np.trace(b) - 1) > __SCALAR_TOL__:
-        _warnings.warn(trace_warning % 'b')
+        _warnings.warn(trace_warning % ('b', str(_np.trace(b))), _NumericalDomainWarning)
 
     r, vec = fast_density_rank(a, __SCALAR_TOL__)
     if r <= 1:
@@ -173,10 +174,11 @@ def fidelity(a, b):
         evals, U = _np.linalg.eigh(mat)
         if _np.min(evals) < -__SCALAR_TOL__:
             message = f"""
-            Input matrix is not PSD up to tolerance {__SCALAR_TOL__}.
+            Input matrix has smallest eigenvalue {_np.min(evals)}, and so is not
+            PSD up to tolerance {__SCALAR_TOL__}.
             We'll project out the bad eigenspaces to only work with the PSD part.
             """
-            _warnings.warn(message)
+            _warnings.warn(message, _NumericalDomainWarning)
         evals[evals < 0] = 0.0
         sqrt_mat = U @ (_np.sqrt(evals).reshape((-1, 1)) * U.T.conj())
         return sqrt_mat

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -25,7 +25,10 @@ from pygsti.tools import jamiolkowski as _jam
 from pygsti.tools import lindbladtools as _lt
 from pygsti.tools import matrixtools as _mt
 from pygsti.tools import sdptools as _sdps
-from pygsti.tools.exceptions import NumericalDomainWarning as _NumericalDomainWarning
+from pygsti.tools.exceptions import (
+    NumericalDomainWarning as _NumericalDomainWarning,
+    CVXPYFailure as _CVXPYFailure
+)
 from pygsti.baseobjs import basis as _pgb
 from pygsti.baseobjs.basis import (
     Basis as _Basis,
@@ -391,7 +394,9 @@ def diamonddist(a, b, mx_basis='pp', return_x=False):
     sdp_solvers = ['MOSEK', 'CLARABEL', 'CVXOPT']
     for i, solver in enumerate(sdp_solvers):
         try:
-            prob.solve(solver=solver)
+            with _warnings.catch_warnings():
+                _warnings.filterwarnings('ignore','.*Solution may be inaccurate.*', UserWarning)
+                prob.solve(solver=solver)
             objective_val = prob.value
             varvals = [v.value for v in vars]
             break
@@ -403,7 +408,7 @@ def diamonddist(a, b, mx_basis='pp', return_x=False):
                 else:
                     failure_msg = f"Trying {sdp_solvers[i+1]} next."
                 msg += f'\n{failure_msg}'
-                _warnings.warn(msg)
+                _warnings.warn(msg, _CVXPYFailure)
 
     if return_x:
         return objective_val, varvals

--- a/pygsti/tools/rbtheory.py
+++ b/pygsti/tools/rbtheory.py
@@ -326,11 +326,11 @@ def L_matrix(model, target_model, weights=None):  # noqa N802
             weights[key] = 1.
 
     normalizer = _np.sum(_np.array([weights[key] for key in list(target_model.operations.keys())]))
-    L_matrix = (1 / normalizer) * _np.sum(
+    L_matrix = (1 / normalizer) * _np.sum([
         weights[key] * _np.kron(
             model.operations[key].to_dense("HilbertSchmidt").T,
             _np.linalg.inv(target_model.operations[key].to_dense("HilbertSchmidt"))
-        ) for key in target_model.operations.keys())
+        ) for key in target_model.operations.keys()])
 
     return L_matrix
 

--- a/test/test_packages/extras/test_interpygate.py
+++ b/test/test_packages/extras/test_interpygate.py
@@ -6,6 +6,7 @@ from pygsti.extras import interpygate as interp
 from pygsti.extras.interpygate.process_tomography import run_process_tomography, unvec_square
 from pygsti.tools import change_basis
 from ..testutils import BaseTestCase
+from ...unit.util import needs_csaps
 
 try:
     from mpi4py import MPI
@@ -21,6 +22,7 @@ mpi_workers_per_process = 1
 
 
 class ExampleProcess(interp.PhysicalProcess):
+
     def __init__(self):
         self.Hx = _np.array([[0, 0, 0, 0],
                             [0, 0, 0, 0],
@@ -72,6 +74,7 @@ class ExampleProcess(interp.PhysicalProcess):
 
 
 class ExampleProcess_timedep(interp.PhysicalProcess):
+
     def __init__(self):
         self.Hx = _np.array([[0, 0, 0, 0],
                             [0, 0, 0, 0],
@@ -124,6 +127,7 @@ class ExampleProcess_timedep(interp.PhysicalProcess):
 
 class InterpygateTestCase(BaseTestCase):
 
+    @needs_csaps
     def test_timedep_op(self):
         example_process = ExampleProcess_timedep()
         target_mxs = example_process.create_process_matrices(_np.array([1.0, 0.0, 0.0, 0.0, 0.0]), [[_np.pi / 2]], comm=_comm)
@@ -163,6 +167,7 @@ class InterpygateTestCase(BaseTestCase):
         #print(interp_op.to_dense())
         self.assertArraysAlmostEqual(expected, interp_op.to_dense())
 
+    @needs_csaps
     def test_timedep_factory(self):
         class TargetOpFactory(pygsti.modelmembers.operations.OpFactory):
             def __init__(self):
@@ -216,6 +221,7 @@ class InterpygateTestCase(BaseTestCase):
         self.assertArraysAlmostEqual(expected, op.to_dense())
         self.assertAlmostEqual(op.aux_info, 1.749)
 
+    @needs_csaps
     def test_timeindep_op(self):
         example_process = ExampleProcess()
         target_mx = example_process.create_process_matrix(_np.array([1.0, 0.0, 0.0, 0.0, 0.0, _np.pi / 2]), comm=_comm)
@@ -254,6 +260,7 @@ class InterpygateTestCase(BaseTestCase):
         #print(interp_op.to_dense())
         self.assertArraysAlmostEqual(expected, interp_op.to_dense())
 
+    @needs_csaps
     def test_timeindep_factory(self):
         class TargetOpFactory(pygsti.modelmembers.operations.OpFactory):
             def __init__(self):

--- a/test/test_packages/objects/test_gatesets.py
+++ b/test/test_packages/objects/test_gatesets.py
@@ -288,31 +288,6 @@ class TestGateSetMethods(GateSetTestCase):
                 except MemoryError:
                     pass #OK - when memlimit is too small and splitting is unproductive
 
-    @unittest.skip("TODO: add backward compatibility for old gatesets?")
-    def test_load_old_gateset(self):
-        #pygsti.baseobjs.results.enable_old_python_results_unpickling()
-        from pygsti.io import enable_old_object_unpickling
-        with enable_old_object_unpickling(), patched_uuid():
-            with open(compare_files + "/pygsti0.9.6.gateset.pkl", 'rb') as f:
-                mdl = pickle.load(f)
-        #pygsti.baseobjs.results.disable_old_python_results_unpickling()
-        #pygsti.io.disable_old_object_unpickling()
-        with open(temp_files + "/repickle_old_gateset.pkl", 'wb') as f:
-            pickle.dump(mdl, f)
-
-        with enable_old_object_unpickling("0.9.7"), patched_uuid():
-            with open(compare_files + "/pygsti0.9.7.gateset.pkl", 'rb') as f:
-                mdl = pickle.load(f)
-        with open(temp_files + "/repickle_old_gateset.pkl", 'wb') as f:
-            pickle.dump(mdl, f)
-
-        #OLD: we don't do this anymore (_calcClass has been removed)
-        #also test automatic setting of _calcClass
-        #mdl = self.model.copy()
-        #del mdl._calcClass
-        #c = mdl._fwdsim() #automatically sets _calcClass
-        #self.assertTrue(hasattr(mdl,'_calcClass'))
-
     def test_ondemand_probabilities(self):
         #First create a "sparse" dataset
         # # Columns = 0 count, 1 count

--- a/test/test_packages/objects/test_gatesets.py
+++ b/test/test_packages/objects/test_gatesets.py
@@ -16,8 +16,6 @@ from ..testutils import BaseTestCase, compare_files, temp_files
 from pygsti.baseobjs import Label as L
 
 from pygsti.modelpacks.legacy import std1Q_XYI
-#from pygsti.io import enable_old_object_unpickling
-from pygsti.baseobjs._compatibility import patched_uuid
 
 def Ls(*args):
     """ Convert args to a tuple to Labels """

--- a/test/test_packages/objects/test_hessian.py
+++ b/test/test_packages/objects/test_hessian.py
@@ -310,13 +310,13 @@ class TestHessianMethods(BaseTestCase):
                 u = v.item()
                 return float(u)
             def fnOfSpam_0D(rhoVecs, povms):
-                u = fnOfGate_float(rhoVecs, povms)
+                u = fnOfSpam_float(rhoVecs, povms)
                 return np.array( u )
             def fnOfSpam_1D(rhoVecs, povms):
-                u = fnOfGate_float(rhoVecs, povms)
+                u = fnOfSpam_float(rhoVecs, povms)
                 return np.array( [u, 0] )
             def fnOfSpam_2D(rhoVecs, povms):
-                u = fnOfGate_float(rhoVecs, povms)
+                u = fnOfSpam_float(rhoVecs, povms)
                 return np.array([[u, 0], [0,0]] )
             def fnOfSpam_3D(rhoVecs, povms):
                 return np.zeros( (2,2,2), 'd') # just to test for error

--- a/test/test_packages/objects/test_hessian.py
+++ b/test/test_packages/objects/test_hessian.py
@@ -304,21 +304,22 @@ class TestHessianMethods(BaseTestCase):
                     df, f0 = self.runSilent(ci_cur.compute_confidence_interval,
                                             FnObj, return_fn_val=True, verbosity=4)
 
-
             def fnOfSpam_float(rhoVecs, povms):
                 lbls = list(povms[0].keys())
-                return float( np.dot( rhoVecs[0].T, povms[0][lbls[0]] ) )
+                v = rhoVecs[0].T @ povms[0][lbls[0]]
+                u = v.item()
+                return float(u)
             def fnOfSpam_0D(rhoVecs, povms):
-                lbls = list(povms[0].keys())
-                return np.array( float( np.dot( rhoVecs[0].T, povms[0][lbls[0]] ) ) )
+                u = fnOfGate_float(rhoVecs, povms)
+                return np.array( u )
             def fnOfSpam_1D(rhoVecs, povms):
-                lbls = list(povms[0].keys())
-                return np.array( [ float(np.dot( rhoVecs[0].T, povms[0][lbls[0]]) ), 0] )
+                u = fnOfGate_float(rhoVecs, povms)
+                return np.array( [u, 0] )
             def fnOfSpam_2D(rhoVecs, povms):
-                lbls = list(povms[0].keys())
-                return np.array( [[ float(np.dot( rhoVecs[0].T, povms[0][lbls[0]] )), 0],[0,0]] )
+                u = fnOfGate_float(rhoVecs, povms)
+                return np.array([[u, 0], [0,0]] )
             def fnOfSpam_3D(rhoVecs, povms):
-                return np.zeros( (2,2,2), 'd') #just to test for error
+                return np.zeros( (2,2,2), 'd') # just to test for error
 
             for fnOfSpam in (fnOfSpam_float, fnOfSpam_0D, fnOfSpam_1D, fnOfSpam_2D, fnOfSpam_3D):
                 FnClass = gsf.spamfn_factory(fnOfSpam)

--- a/test/unit/algorithms/test_gaugeopt_correctness.py
+++ b/test/unit/algorithms/test_gaugeopt_correctness.py
@@ -21,8 +21,8 @@ import pytest
 def gate_metrics_dict(model, target):
     metrics = {'infids': OrderedDict(), 'frodists': OrderedDict(), 'tracedists': OrderedDict()}
     for lbl in model.operations.keys():
-        model_gate = model[lbl]
-        target_gate = target[lbl]
+        model_gate = model.operations[lbl]
+        target_gate = target.operations[lbl]
         metrics['infids'][lbl] = pgo.entanglement_infidelity(model_gate, target_gate)
         metrics['frodists'][lbl] = pgo.frobeniusdist(model_gate, target_gate)
         metrics['tracedists'][lbl] = pgo.tracedist(model_gate, target_gate)

--- a/test/unit/extras/interpygate/test_construction.py
+++ b/test/unit/extras/interpygate/test_construction.py
@@ -93,7 +93,7 @@ class InterpygateConstructionTester(BaseCase):
     @classmethod
     def setUpClass(cls):
         super(InterpygateConstructionTester, cls).setUpClass()
-        cls.static_target = np.bmat([[np.eye(2),np.zeros([2,2])],
+        cls.static_target = np.block([[np.eye(2),np.zeros([2,2])],
                                      [np.zeros([2,2]),np.sqrt(2)/2*(sigI++1.j*sigY)]])
         cls.target_op = SingleQubitTargetOp()
 

--- a/test/unit/extras/interpygate/test_construction.py
+++ b/test/unit/extras/interpygate/test_construction.py
@@ -159,19 +159,19 @@ class InterpygateGSTTester(BaseCase):
         y_gate = opfactory.create_op([np.pi/2,np.pi/4]) 
 
         cls.model = pygsti.models.ExplicitOpModel([0],'pp')
-        cls.model['rho0'] = [ 1/np.sqrt(2), 0, 0, 1/np.sqrt(2) ] # density matrix [[1, 0], [0, 0]] in Pauli basis
-        cls.model['Mdefault'] = pygsti.modelmembers.povms.UnconstrainedPOVM(
+        cls.model.preps['rho0'] = [ 1/np.sqrt(2), 0, 0, 1/np.sqrt(2) ] # density matrix [[1, 0], [0, 0]] in Pauli basis
+        cls.model.povms['Mdefault'] = pygsti.modelmembers.povms.UnconstrainedPOVM(
             {'0': [ 1/np.sqrt(2), 0, 0, 1/np.sqrt(2) ],   # projector onto [[1, 0], [0, 0]] in Pauli basis
              '1': [ 1/np.sqrt(2), 0, 0, -1/np.sqrt(2) ] }, evotype="default") # projector onto [[0, 0], [0, 1]] in Pauli basis
-        cls.model['Gxpi2',0] = x_gate
-        cls.model['Gypi2',0] = y_gate
+        cls.model.operations['Gxpi2',0] = x_gate
+        cls.model.operations['Gypi2',0] = y_gate
 
     def test_gpindices(self):
         model = self.model.copy()
-        model['rho0'].set_gpindices(slice(0,4),model)
-        model['Mdefault'].set_gpindices(slice(4,12),model)
-        model['Gxpi2',0].set_gpindices(slice(12,13),model)
-        model['Gypi2',0].set_gpindices(slice(12,13),model)
+        model.preps['rho0'].set_gpindices(slice(0,4),model)
+        model.povms['Mdefault'].set_gpindices(slice(4,12),model)
+        model.operations['Gxpi2',0].set_gpindices(slice(12,13),model)
+        model.operations['Gypi2',0].set_gpindices(slice(12,13),model)
         model._rebuild_paramvec()
         self.assertEqual(model.num_params,13)
         

--- a/test/unit/modelmembers/test_operation.py
+++ b/test/unit/modelmembers/test_operation.py
@@ -815,8 +815,9 @@ class StochasticNoiseOpTester(BaseCase):
         self.assertArraysAlmostEqual(sop.to_dense(), expected_mx)
 
         rho = create_spam_vector("0", "Q0", Basis.cast("pp", [4]))
-        self.assertAlmostEqual(float(np.dot(rho.T, np.dot(sop.to_dense(), rho))),
-                               0.99)  # b/c X dephasing w/rate is 0.1^2 = 0.01
+        v = (rho.T @ sop.to_dense() @ rho).item()
+        u = float(v)
+        self.assertAlmostEqual(u, 0.99)  # b/c X dephasing w/rate is 0.1^2 = 0.01
 
 
 class DepolarizeOpTester(BaseCase):
@@ -832,4 +833,6 @@ class DepolarizeOpTester(BaseCase):
 
         rho = create_spam_vector("0", "Q0", Basis.cast("pp", [4]))
         # b/c both X and Y dephasing rates => 0.01 reduction
-        self.assertAlmostEqual(float(np.dot(rho.T, np.dot(dop.to_dense(), rho))), 0.98)
+        v = (rho.T @ dop.to_dense() @ rho).item()
+        u = float(v)
+        self.assertAlmostEqual(u, 0.98)

--- a/test/unit/objects/test_circuit.py
+++ b/test/unit/objects/test_circuit.py
@@ -2,11 +2,13 @@ import copy
 import pickle
 import unittest
 import numpy as np
+import warnings
 
 from pygsti.circuits import circuit
 from pygsti.baseobjs import Label, CircuitLabel
 from pygsti.processors import QubitProcessorSpec
 from pygsti.tools import symplectic
+from pygsti.tools.exceptions import pyGSTiDeprecationWarning
 from pygsti.models import modelconstruction as mc
 from ..util import BaseCase
 
@@ -723,7 +725,9 @@ MEASURE 2 ro[2]
         # Tests the circuit simulator
         mdl = mc.create_crosstalk_free_model(ps)
         c = circuit.Circuit(layer_labels=[Label('Gh', 'Q0'), Label('Gcnot', ('Q0', 'Q1'))], line_labels=['Q0', 'Q1'])
-        out = c.simulate(mdl)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            out = c.simulate(mdl)
         self.assertLess(abs(out['00'] - 0.5), 10**-10)
         self.assertLess(abs(out['11'] - 0.5), 10**-10)
 
@@ -773,30 +777,34 @@ MEASURE 2 ro[2]
         self.assertAlmostEqual(pdict['1'], 0.5)
 
         ## SAME results from circuit.simulate, except with smaller dicts (because 0s are dropped)
-        pdict = c.simulate(mdl)
-        self.assertEqual(len(pdict), 2)
-        self.assertAlmostEqual(pdict['0000'], 0.5)
-        self.assertAlmostEqual(pdict['1000'], 0.5)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            
+            pdict = c.simulate(mdl)
+            self.assertEqual(len(pdict), 2)
+            self.assertAlmostEqual(pdict['0000'], 0.5)
+            self.assertAlmostEqual(pdict['1000'], 0.5)
 
-        pdict = cp.simulate(mdl)
-        self.assertEqual(len(pdict), 2)
-        self.assertAlmostEqual(pdict['0000'], 0.5)
-        self.assertAlmostEqual(pdict['0010'], 0.5)
+            pdict = cp.simulate(mdl)
+            self.assertEqual(len(pdict), 2)
+            self.assertAlmostEqual(pdict['0000'], 0.5)
+            self.assertAlmostEqual(pdict['0010'], 0.5)
 
-        pdict = c01.simulate(mdl)
-        self.assertEqual(len(pdict), 2)
-        self.assertAlmostEqual(pdict['00'], 0.5)
-        self.assertAlmostEqual(pdict['10'], 0.5)
+            pdict = c01.simulate(mdl)
+            self.assertEqual(len(pdict), 2)
+            self.assertAlmostEqual(pdict['00'], 0.5)
+            self.assertAlmostEqual(pdict['10'], 0.5)
 
-        pdict = c10.simulate(mdl)
-        self.assertEqual(len(pdict), 2)
-        self.assertAlmostEqual(pdict['00'], 0.5)
-        self.assertAlmostEqual(pdict['01'], 0.5)
+            pdict = c10.simulate(mdl)
+            self.assertEqual(len(pdict), 2)
+            self.assertAlmostEqual(pdict['00'], 0.5)
+            self.assertAlmostEqual(pdict['01'], 0.5)
 
-        pdict = c0.simulate(mdl)
-        self.assertEqual(len(pdict), 2)
-        self.assertAlmostEqual(pdict['0'], 0.5)
-        self.assertAlmostEqual(pdict['1'], 0.5)
+            pdict = c0.simulate(mdl)
+            self.assertEqual(len(pdict), 2)
+            self.assertAlmostEqual(pdict['0'], 0.5)
+            self.assertAlmostEqual(pdict['1'], 0.5)
+        return
 
 
 class CircuitOperationTester(BaseCase):

--- a/test/unit/objects/test_errorgenpropagation.py
+++ b/test/unit/objects/test_errorgenpropagation.py
@@ -209,7 +209,7 @@ def probabilities_errorgen_prop(error_propagator, target_model, circuit, use_bch
     for i, effect in enumerate(ideal_meas.values()):
         dense_effect = effect.to_dense().copy()
         dense_prep = ideal_prep.to_dense().copy()
-        prob_vec[i] = np.linalg.multi_dot([dense_effect.reshape((1,len(dense_effect))), eoc_channel, ideal_channel, dense_prep.reshape((len(dense_prep),1))])
+        prob_vec[i] = np.linalg.multi_dot([dense_effect.reshape((1, -1)), eoc_channel, ideal_channel, dense_prep.reshape((-1, 1))]).item()
     return prob_vec
 
 def probabilities_fwdsim(noise_model, circuit):

--- a/test/unit/optimize/test_customcg.py
+++ b/test/unit/optimize/test_customcg.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pygsti.optimize import customcg as cg
 from ..util import BaseCase
 
@@ -5,8 +7,10 @@ from ..util import BaseCase
 class CustomCGTester(BaseCase):
     def test_maximize1D_closed_domain(self):
         def g(x):  # a function with tricky boundaries (|x| only defined in [-2,2]
-            if x < -2.0 or x > 2.0: return None
-            else: return abs(x)
+            if x < -2.0 or x > 2.0:
+                return None
+            else:
+                return abs(x)
 
         start = -2.0
         guess = 4.0  # None
@@ -20,10 +24,14 @@ class CustomCGTester(BaseCase):
 
     def test_maximize1D_open_domain(self):
         def g(x):  # a bad function with a gap between it's boundaries
-            if x > -2.0 and x < 2.0: return None
-            else: return 1.0
+            if x > -2.0 and x < 2.0:
+                return None
+            else:
+                return 1.0
 
         start = -4.0
         guess = 4.0
-        cg._maximize_1d(g, start, guess, g(start))
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', '.*overflow encountered in scalar multiply*', RuntimeWarning)
+            cg._maximize_1d(g, start, guess, g(start))
         # TODO assert correctness

--- a/test/unit/protocols/test_rb.py
+++ b/test/unit/protocols/test_rb.py
@@ -1,9 +1,11 @@
 from ..util import BaseCase
 
+import warnings
 import numpy as _np
 from pathlib import Path
 
 import pygsti
+from pygsti.tools.exceptions import pyGSTiDeprecationWarning
 from pygsti.protocols import rb as _rb
 from pygsti.processors import CliffordCompilationRules as CCR
 from pygsti.processors import QubitProcessorSpec as QPS
@@ -11,6 +13,24 @@ from pygsti.circuits import Circuit
 from pygsti.baseobjs import Label
 
 FILE_PATH = str(Path(__file__).resolve().parent)
+
+from contextlib import contextmanager
+
+@contextmanager
+def degenerate_bootstrap_ignore_warnings():
+    with warnings.catch_warnings():
+        # Running a bootstrap estimate on a noiseless model
+        # will lead to calling np.std(arr) on empty arrays arr.
+        # This leads to runtime warnings, which we filter out here
+        # in case we're testing with `pytest -W error`.
+        warnings.filterwarnings(action="ignore",
+            message="Degrees of freedom <= 0 for slice", category=RuntimeWarning
+        )
+        warnings.filterwarnings(action='ignore',
+            message="invalid value encountered", category=RuntimeWarning
+        )
+        yield
+
 
 class TestCliffordRBDesign(BaseCase):
 
@@ -70,7 +90,12 @@ class TestCliffordRBDesign(BaseCase):
 
         tmodel = pygsti.models.create_crosstalk_free_model(self.pspec)
 
-        [[self.assertAlmostEqual(c.simulate(tmodel)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(mp_design.circuit_lists, mp_design.idealout_lists)]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            for cl, bsl in zip(mp_design.circuit_lists, mp_design.idealout_lists):
+                for c, bs in zip(cl, bsl):
+                    self.assertAlmostEqual(c.simulate(tmodel)[bs], 1.)
+        return
 
     def test_deterministic_compilation(self):
         # TODO: Figure out good test for this. Full circuit is a synthetic idle, we need to somehow check the non-inverted
@@ -223,7 +248,11 @@ class TestDirectRBDesign(BaseCase):
 
         tmodel = pygsti.models.create_crosstalk_free_model(self.pspec)
 
-        [[self.assertAlmostEqual(c.simulate(tmodel)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(mp_design.circuit_lists, mp_design.idealout_lists)]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            for cl, bsl in zip(mp_design.circuit_lists, mp_design.idealout_lists):
+                for c, bs in zip(cl, bsl):
+                    self.assertAlmostEqual(c.simulate(tmodel)[bs], 1.)
 
         #Print more debugging info since this test can fail randomly but we can't reproduce this.
         unequal_circuits = []
@@ -323,7 +352,13 @@ class TestMirrorRBDesign(BaseCase):
                                         localclifford=True, paulirandomize=True, descriptor='A mirror RB experiment',
                                         add_default_protocol=False, seed=None, num_processes=1, verbosity=0)
 
-        [[self.assertAlmostEqual(c.simulate(tmodel1)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(design1.circuit_lists, design1.idealout_lists)]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            for cl, bsl in zip(design1.circuit_lists, design1.idealout_lists):
+                for c, bs in zip(cl, bsl):
+                    self.assertAlmostEqual(c.simulate(tmodel1)[bs], 1.)
+        return
 
     def test_nonclifford_design_type1_construction(self):
 
@@ -344,8 +379,12 @@ class TestMirrorRBDesign(BaseCase):
                                        localclifford=True, paulirandomize=True, descriptor='A mirror RB experiment',
                                        add_default_protocol=False, seed=None, num_processes=1, verbosity=0)
 
-
-        [[self.assertAlmostEqual(c.simulate(tmodel2)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(design2.circuit_lists, design2.idealout_lists)]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            for cl, bsl in zip(design2.circuit_lists, design2.idealout_lists):
+                for c, bs in zip(cl, bsl):
+                    self.assertAlmostEqual(c.simulate(tmodel2)[bs], 1.)
+        return
 
     def test_nonclifford_design_type2_construction(self):
 
@@ -366,8 +405,12 @@ class TestMirrorRBDesign(BaseCase):
                                        localclifford=True, paulirandomize=True, descriptor='A mirror RB experiment',
                                        add_default_protocol=False, seed=None, num_processes=1, verbosity=0)
 
-
-        [[self.assertAlmostEqual(c.simulate(tmodel3)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(design3.circuit_lists, design3.idealout_lists)]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            for cl, bsl in zip(design3.circuit_lists, design3.idealout_lists):
+                for c, bs in zip(cl, bsl):
+                    self.assertAlmostEqual(c.simulate(tmodel3)[bs], 1.) 
+        return
 
 
     def test_serialization(self):
@@ -474,8 +517,8 @@ class TestBiRBProtocol(BaseCase):
     def test_birb_protocol_ideal(self):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='energies', defaultfit='A-fixed', rtype='EI',
                  seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
-
-        result = proto.run(self.data)
+        with degenerate_bootstrap_ignore_warnings():
+            result = proto.run(self.data)
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
 
     def test_birb_protocol_noisy(self):
@@ -531,7 +574,8 @@ class TestCliffordRBProtocol(BaseCase):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
                  seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
 
-        result = proto.run(self.data)
+        with degenerate_bootstrap_ignore_warnings():
+            result = proto.run(self.data)
 
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
 
@@ -595,7 +639,9 @@ class TestDirectRBProtocol(BaseCase):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='success_probabilities', defaultfit='A-fixed', rtype='EI',
                  seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
 
-        result = proto.run(self.data)
+        with degenerate_bootstrap_ignore_warnings():
+            result = proto.run(self.data)
+
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
 
     def test_directrb_protocol_noisy(self):
@@ -650,7 +696,9 @@ class TestMirrorRBProtocol(BaseCase):
         proto = pygsti.protocols.rb.RandomizedBenchmarking(datatype='adjusted_success_probabilities', defaultfit='A-fixed', rtype='EI',
                  seed=(0.8, 0.95), bootstrap_samples=200, depths='all', name=None)
 
-        result = proto.run(self.data)
+        with degenerate_bootstrap_ignore_warnings():
+            result = proto.run(self.data)
+
         self.assertTrue(abs(result.fits['A-fixed'].estimates['r'])<=3e-5)
 
     def test_mirrorrb_protocol_noisy(self):
@@ -701,7 +749,9 @@ class TestInterleavedRBProtocol(BaseCase):
         #running with all default settings
         proto = _rb.InterleavedRandomizedBenchmarking()
 
-        result = proto.run(self.data)
+        with degenerate_bootstrap_ignore_warnings():
+            result = proto.run(self.data)
+
         estimated_irb_num = result.for_protocol['InterleavedRandomizedBenchmarking'].irb_numbers['full']
         self.assertTrue(abs(estimated_irb_num) <= 1e-5)
 

--- a/test/unit/protocols/test_vb.py
+++ b/test/unit/protocols/test_vb.py
@@ -1,6 +1,8 @@
 from ..util import BaseCase
 
+import warnings
 import pygsti
+from pygsti.tools.exceptions import pyGSTiDeprecationWarning
 from pygsti.protocols import vb as _vb
 from pygsti.processors import CliffordCompilationRules as CCR
 from pygsti.processors import QubitProcessorSpec as QPS
@@ -25,5 +27,10 @@ class TestPeriodicMirrorCircuitsDesign(BaseCase):
         design1 = _vb.PeriodicMirrorCircuitDesign (pspec1, depths, 3, qubit_labels=q_set,
                                         clifford_compilations=clifford_compilations, sampler='edgegrab', samplerargs=(0.25,))
 
-        [[self.assertAlmostEqual(c.simulate(tmodel1)[bs],1.) for c, bs in zip(cl, bsl)] for cl, bsl in zip(design1.circuit_lists, design1.idealout_lists)]
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=pyGSTiDeprecationWarning)
+            for cl, bsl in zip(design1.circuit_lists, design1.idealout_lists):
+                 for c, bs in zip(cl, bsl):
+                     self.assertAlmostEqual(c.simulate(tmodel1)[bs], 1.)
+        return
 

--- a/test/unit/tools/test_chi2fns.py
+++ b/test/unit/tools/test_chi2fns.py
@@ -16,15 +16,14 @@ class Chi2LogLTester(BaseCase):
         # TODO rather than faking expensive calls this should really use a simpler dataset
         with mock.patch('pygsti.forwardsims.matrixforwardsim.MatrixForwardSimulator._compute_hproduct_cache') as mock_hproduct_cache:
             mock_hproduct_cache.return_value = np.zeros((868, 60, 60, 4, 4))
-
-            chi2fns.chi2(std.target_model(), self.dataset)
-
-            chi2fns.chi2fn_2outcome(n=100, p=0.5, f=0.6)
-            chi2fns.chi2fn_2outcome_wfreqs(n=100, p=0.5, f=0.6)
-            chi2fns.chi2fn(n=100, p=0.5, f=0.6)
-            chi2fns.chi2fn_wfreqs(n=100, p=0.5, f=0.6)
-            chi2fns.chi2(std.target_model(), self.dataset, mem_limit=1000000000)
             # TODO assert correctness
+            chi2fns.chi2(std.target_model(), self.dataset)
+            chi2fns.chi2(std.target_model(), self.dataset, mem_limit=1000000000)
+            # NOTE: this Chi2LogLTester.test_chi2 function used to invoke deprecated
+            # functions without inspecting their output. Those invocations have been
+            # removed. Invocations of non-deprecated functions remain, without 
+            # checks for correctness.
+        return
 
     def test_chi2_raises_on_out_of_memory(self):
         with self.assertRaises(MemoryError):

--- a/test/unit/tools/test_errgenproptools.py
+++ b/test/unit/tools/test_errgenproptools.py
@@ -590,7 +590,7 @@ def probabilities_errorgen_prop(error_propagator, target_model, circuit, use_bch
     for i, effect in enumerate(ideal_meas.values()):
         dense_effect = effect.to_dense().copy()
         dense_prep = ideal_prep.to_dense().copy()
-        prob_vec[i] = np.linalg.multi_dot([dense_effect.reshape((1,len(dense_effect))), eoc_channel, ideal_channel, dense_prep.reshape((len(dense_prep),1))])
+        prob_vec[i] = np.linalg.multi_dot([dense_effect.reshape((1, -1)), eoc_channel, ideal_channel, dense_prep.reshape((-1, 1))]).item()
     return prob_vec
 
 def pauli_expectation_errorgen_prop(error_propagator, target_model, circuit, pauli, use_bch=False, bch_order=1, truncation_threshold=1e-14):

--- a/test/unit/util.py
+++ b/test/unit/util.py
@@ -38,7 +38,7 @@ def needs_matplotlib(fn):
 
 
 def needs_csaps(fn):
-    """Shortcut decorator for skipping tests that require CVXPY"""
+    """Shortcut decorator for skipping tests that require CSAPS"""
     cond = __csaps_not_importable__ or ('SKIP_CSAPS' in os.environ)
     return unittest.skipIf(cond, "skipping csaps tests")(fn)
 

--- a/test/unit/util.py
+++ b/test/unit/util.py
@@ -8,21 +8,37 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
+import importlib.util
+
+
+__cvxpy_not_importable__ = importlib.util.find_spec('cvxpy') is None
+
+__deap_not_importable__  = importlib.util.find_spec('deap')  is None
+
+__csaps_not_importable__ = importlib.util.find_spec('csaps') is None
 
 
 def needs_cvxpy(fn):
     """Shortcut decorator for skipping tests that require CVXPY"""
-    return unittest.skipIf('SKIP_CVXPY' in os.environ, "skipping cvxpy tests")(fn)
+    cond = __cvxpy_not_importable__ or ('SKIP_CVXPY' in os.environ)
+    return unittest.skipIf(cond, "skipping cvxpy tests")(fn)
 
 
 def needs_deap(fn):
     """Shortcut decorator for skipping tests that require deap"""
-    return unittest.skipIf('SKIP_DEAP' in os.environ, "skipping deap tests")(fn)
+    cond = __deap_not_importable__ or ('SKIP_DEAP' in os.environ)
+    return unittest.skipIf(cond, "skipping deap tests")(fn)
 
 
 def needs_matplotlib(fn):
     """Shortcut decorator for skipping tests that require matplotlib"""
     return unittest.skipIf('SKIP_MATPLOTLIB' in os.environ, "skipping matplotlib tests")(fn)
+
+
+def needs_csaps(fn):
+    """Shortcut decorator for skipping tests that require CVXPY"""
+    cond = __csaps_not_importable__ or ('SKIP_CSAPS' in os.environ)
+    return unittest.skipIf(cond, "skipping csaps tests")(fn)
 
 
 def with_temp_path(fn):

--- a/test/unit/util.py
+++ b/test/unit/util.py
@@ -116,7 +116,7 @@ class BaseCase(unittest.TestCase):
         """
 
         filename = filename or "temp_file"  # yeah looks random to me
-        with TemporaryDirectory() as tmpdir:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             tmp_path = Path(tmpdir) / filename
             # Yield to context with temporary path
             yield str(tmp_path)

--- a/test/unit/util.py
+++ b/test/unit/util.py
@@ -6,10 +6,12 @@ import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-
+from platform import python_version_tuple
 import numpy as np
 import importlib.util
 
+
+py_version_major, py_version_minor = map(int, python_version_tuple()[:2])
 
 __cvxpy_not_importable__ = importlib.util.find_spec('cvxpy') is None
 
@@ -132,7 +134,10 @@ class BaseCase(unittest.TestCase):
         """
 
         filename = filename or "temp_file"  # yeah looks random to me
-        with TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        kwargs = dict()
+        if py_version_major > 3 or py_version_minor >= 10:
+            kwargs['ignore_cleanup_errors'] = True
+        with TemporaryDirectory(**kwargs) as tmpdir:
             tmp_path = Path(tmpdir) / filename
             # Yield to context with temporary path
             yield str(tmp_path)


### PR DESCRIPTION
This PR addresses incompatibilities with numpy 2: calling``float(arr)`` when ``arr.size > 0``, assigning ``x[i] = arr`` when ``arr.size > 0`` and ``x[i].size == 0``, and calling ``np.sum`` on generators.  

To increase the chances that I caught all offenses I ran pytest to error on warnings. Of course, there are a million warnings that get raised in our test suite. So I also introduced a bunch of new warning classes and configured pytest to ignore those specific warnings. In the process I resolved some additional warnings, like ...
 * implicit casting of complex arrays to real arrays,
 * using numpy matrix objects instead of ndarrays,
 * passing unsupported kwargs to scipy.optimize,
 * pygsti code calling other pygsti code that was already deprecated.

This PR contains incidental fixes for invalid escape sequences in non-raw strings.

Finally, I removed the ``compat_uuid`` function that was apparently introduced to handle peculiarities of Python 3.7.

This work isn't really complete, in that there are still lots of lots of warnings that get raised when we run our test suite. But I'd like to merge without increasing its scope. There are other PRs I need to get to.

#### My local pytest.ini (not committed)

```
[pytest]
filterwarnings =
    error
    ignore:write_model(...) is unable to write:pygsti.tools.exceptions.pyGSTiDeprecationWarning
    ignore::pygsti.tools.exceptions.UnnamedReportWarning
    ignore::pygsti.tools.exceptions.ForwardSimulatorSuitabilityWarning
    # ^ TODO: remove the filter above; triggered everywhere in test/test_packages/report and test/test_packages/reportb.
    ignore::pygsti.tools.exceptions.OverparameterizationWarning
    ignore::pygsti.tools.exceptions.pyGSTiDeprecationWarning
    # ^ TODO: remove the filter above; triggered everywhere in /test/test_packages.
    ignore:numpy.core is deprecated and has been renamed to numpy._core:DeprecationWarning
    # ^ TODO: actually try and resolve the deprecation warning above.
    ignore::pygsti.tools.exceptions.UntouchedModelNoiseKey
    ignore::pygsti.tools.exceptions.UnknownGaugeSpaceDimension
    # ^ TODO: remove the filter above; triggered in test/unit/tools/test_leakage_gst_pipeline.py.
    ignore::pygsti.tools.exceptions.PrepareThyself
    ignore:Degrees of freedom <= 0 for slice:RuntimeWarning
    # ^ TODO: remove the filter above; triggered in test_rb.py.
    ignore:invalid value encountered in divide:RuntimeWarning
    # ^ TODO: remove the filter above; triggered in test_rb.py.
    ignore:invalid value encountered in scalar divide:RuntimeWarning
    # ^ TODO: remove the filter above; triggered in test_rb.py.
    ignore::pytest.PytestUnraisableExceptionWarning
    ignore::pygsti.tools.exceptions.NumericalDomainWarning
    ignore::pygsti.tools.exceptions.MissingDependencyWarning
    ignore::pygsti.tools.exceptions.DeprecatedPositionalArgumentsWarning
    ignore:Created an evaluation tree that is inefficient:UserWarning
    ignore:The function find_sufficient_fiducial_pairs is deprecated:UserWarning
    ignore:Using finite differencing to compute LindbladErrorGen derivative!:UserWarning
    ignore:divide by zero encountered in divide:RuntimeWarning
    ignore:divide by zero encountered in log:RuntimeWarning
    ignore:Would have scaled dProd:UserWarning
    ignore:Scaled dProd small in order to keep prod managable:UserWarning
    ignore:hProd is small:UserWarning
    ignore:Scaled hProd small in order to keep prod managable.:UserWarning

python_classes = *Tester
```