### PR TITLE
Updates wildcard budget invocation from GST to work with gaugeopt_suite=None.

### DIFF
--- a/pygsti/objectivefns/wildcardbudget.py
+++ b/pygsti/objectivefns/wildcardbudget.py
@@ -234,8 +234,10 @@ class WildcardBudget(_NicelySerializable):
             elInds = layout.indices_for_index(i)
             fvec = freqs[elInds]
             qvec = probs_in[elInds]
-            if any(el > 1.0 or el < 0.0 for el in qvec):
+            eps = 1e-8 # tolerance for checking valid probabilities, should be ~ machine precision
+            if any(el > 1.0 + eps or el < 0.0 - eps for el in qvec):
                 raise ValueError("Invalid input probabilities: %s" % str(qvec))
+            qvec = _np.clip(qvec, 0.0, 1.0)  # ensure no negative probs due to numerical error
 
             initialTVD = sum(tvd_precomp[elInds])  # 0.5 * sum(_np.abs(qvec - fvec))
 

--- a/pygsti/objectivefns/wildcardbudget.py
+++ b/pygsti/objectivefns/wildcardbudget.py
@@ -234,6 +234,8 @@ class WildcardBudget(_NicelySerializable):
             elInds = layout.indices_for_index(i)
             fvec = freqs[elInds]
             qvec = probs_in[elInds]
+            if any(el > 1.0 or el < 0.0 for el in qvec):
+                raise ValueError("Invalid input probabilities: %s" % str(qvec))
 
             initialTVD = sum(tvd_precomp[elInds])  # 0.5 * sum(_np.abs(qvec - fvec))
 

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -2302,7 +2302,8 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
                     gauge_opt_params.copy(), go_gs_final, gokey, comm, printer - 1)
 
 
-def _compute_wildcard_budget_1d_model(estimate, mdc_objfn, verbosity, gaugeopt_suite):
+def _compute_wildcard_budget_1d_model(estimate: _Estimate, mdc_objfn: _objfns.ModelDatasetCircuitsStore,
+                                      verbosity: int, gaugeopt_suite: GSTGaugeOptSuite) -> dict[str, _wild.PrimitiveOpsWildcardBudget]:
     """
     Create a wildcard budget for a model estimate. This version of the function produces a wildcard estimate
     using the model introduced in https://doi.org/10.1038/s41534-023-00764-y.
@@ -2314,9 +2315,6 @@ def _compute_wildcard_budget_1d_model(estimate, mdc_objfn, verbosity, gaugeopt_s
 
     mdc_objfn : ModelDatasetCircuitsStore
         An object that stores the model, dataset, and circuits to be used in the computation.
-
-    parameters : dict
-        Various parameters of the estimate at hand.
 
     verbosity : int, optional
         Level of detail printed to stdout.

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -2241,25 +2241,16 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
             #If this estimate is the target model then skip adding the diamond distance wildcard.
             if base_estimate_label != 'Target':
                 try:
-                    budget = _compute_wildcard_budget_1d_model(base_estimate, mdc_objfn, printer - 1, gaugeopt_suite)
-                    #if gaugeopt_labels is None then budget with be a PrimitiveOpsSingleScaleWildcardBudget
-                    #if it was non-empty though then we'll instead have budge as a dictionary with keys
-                    #corresponding to the elements of gaugeopt_labels. In this case let's  make
-                    #base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] a dictionary of
-                    #the serialized PrimitiveOpsSingleScaleWildcardBudget elements
-                    if gaugeopt_suite is not None:
-                        gaugeopt_labels = budget.keys()
-                        base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = {lbl: budget[lbl].to_nice_serialization() for lbl in gaugeopt_labels} 
-                        base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] = None
+                    budgets_by_label = _compute_wildcard_budget_1d_model(base_estimate, mdc_objfn, printer - 1, gaugeopt_suite)
+                    #budgets_by_label is a dictionary with keys labeling different gauge optimizations. We make
+                    # base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] a dictionary of
+                    # the serialized PrimitiveOpsSingleScaleWildcardBudget elements (values of the dict)
+                    gaugeopt_labels = budgets_by_label.keys()
+                    base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = {lbl: budgets_by_label[lbl].to_nice_serialization() for lbl in gaugeopt_labels} 
+                    base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] = None
 
-                        base_estimate.extra_parameters["unmodeled_error"] = {lbl: budget[lbl].to_nice_serialization() for lbl in gaugeopt_labels}
-                        base_estimate.extra_parameters["unmodeled_active_constraints"] = None
-                    else:
-                        base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = budget.to_nice_serialization() 
-                        base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] = None
-
-                        base_estimate.extra_parameters["unmodeled_error"] = budget.to_nice_serialization()
-                        base_estimate.extra_parameters["unmodeled_active_constraints"] = None
+                    base_estimate.extra_parameters["unmodeled_error"] = {lbl: budgets_by_label[lbl].to_nice_serialization() for lbl in gaugeopt_labels}
+                    base_estimate.extra_parameters["unmodeled_active_constraints"] = None
                 except NotImplementedError as e:
                     printer.warning("Failed to get wildcard budget - continuing anyway.  Error was:\n" + str(e))
                     new_params['unmodeled_error'] = None
@@ -2337,7 +2328,7 @@ def _compute_wildcard_budget_1d_model(estimate, mdc_objfn, verbosity, gaugeopt_s
 
     Returns
     -------
-    PrimitiveOpsWildcardBudget or dict
+    dict of PrimitiveOpsWildcardBudget
         A dictionary of budgets keyed by gauge optimization labels.
 
     """
@@ -2363,6 +2354,8 @@ def _compute_wildcard_budget_1d_model(estimate, mdc_objfn, verbosity, gaugeopt_s
     two_dlogl_threshold = _chi2.ppf(1 - percentile, max(ds_dof - nparams, 1))
     redbox_threshold = _chi2.ppf(1 - percentile / nboxes, 1)
 
+    if gaugeopt_suite is None:
+        gaugeopt_suite = GSTGaugeOptSuite()
     target = gaugeopt_suite.gaugeopt_target
     if target is None:
         target = estimate.models['target']

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -2241,15 +2241,15 @@ def _add_badfit_estimates(results, base_estimate_label, badfit_options,
             #If this estimate is the target model then skip adding the diamond distance wildcard.
             if base_estimate_label != 'Target':
                 try:
-                    budgets_by_label = _compute_wildcard_budget_1d_model(base_estimate, mdc_objfn, printer - 1, gaugeopt_suite)
-                    #budgets_by_label is a dictionary with keys labeling different gauge optimizations. We make
+                    budget_dict = _compute_wildcard_budget_1d_model(base_estimate, mdc_objfn, printer - 1, gaugeopt_suite)
+                    #budgets_dict is a dictionary with keys labeling different gauge optimizations. We make
                     # base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] a dictionary of
                     # the serialized PrimitiveOpsSingleScaleWildcardBudget elements (values of the dict)
-                    gaugeopt_labels = budgets_by_label.keys()
-                    base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = {lbl: budgets_by_label[lbl].to_nice_serialization() for lbl in gaugeopt_labels} 
+                    gaugeopt_labels = budget_dict.keys()
+                    base_estimate.extra_parameters['wildcard1d' + "_unmodeled_error"] = {lbl: budget_dict[lbl].to_nice_serialization() for lbl in gaugeopt_labels} 
                     base_estimate.extra_parameters['wildcard1d' + "_unmodeled_active_constraints"] = None
 
-                    base_estimate.extra_parameters["unmodeled_error"] = {lbl: budgets_by_label[lbl].to_nice_serialization() for lbl in gaugeopt_labels}
+                    base_estimate.extra_parameters["unmodeled_error"] = {lbl: budget_dict[lbl].to_nice_serialization() for lbl in gaugeopt_labels}
                     base_estimate.extra_parameters["unmodeled_active_constraints"] = None
                 except NotImplementedError as e:
                     printer.warning("Failed to get wildcard budget - continuing anyway.  Error was:\n" + str(e))

--- a/pygsti/protocols/gst.py
+++ b/pygsti/protocols/gst.py
@@ -2463,7 +2463,15 @@ def _compute_1d_reference_values(target_model: _ExplicitOpModel, gopped_models: 
             Y = target_ops[key].to_dense()
             X_restricted = X @ P
             Y_restricted = Y @ P
-            dd[lbl][key] : float = 0.5 * _tools.diamonddist(X_restricted, Y_restricted, mx_basis=basis) # type: ignore
+
+            # Get basis for this operation.
+            op_basis = basis # start with the model's basis
+            if (basis.dim != X_restricted.shape[0] and isinstance(basis, _tools.TensorProdBasis)
+                and basis.component_bases[0].dim == X_restricted.shape[0]):
+                # use first component of a TensorProdBasis if a smaller dim is needed and matches.
+                op_basis = basis.component_bases[0]
+
+            dd[lbl][key] : float = 0.5 * _tools.diamonddist(X_restricted, Y_restricted, mx_basis=op_basis) # type: ignore
             if dd[lbl][key] < 0:  # indicates that diamonddist failed (cvxpy failure)
                 msg = f"""
                 Diamond distance failed to compute {key} reference value for 1D wildcard budget!

--- a/test/unit/protocols/test_gst.py
+++ b/test/unit/protocols/test_gst.py
@@ -3,6 +3,7 @@ from pygsti.forwardsims.mapforwardsim import MapForwardSimulator
 from pygsti.modelpacks import smq1Q_XYI
 from pygsti.modelpacks.legacy import std1Q_XYI, std2Q_XYICNOT
 from pygsti.objectivefns.objectivefns import PoissonPicDeltaLogLFunction
+from pygsti.models.explicitmodel import ExplicitOpModel as _ExplicitOpModel
 from pygsti.models.gaugegroup import TrivialGaugeGroup
 from pygsti.objectivefns import FreqWeightedChi2Function
 from pygsti.optimize.simplerlm import SimplerLMOptimizer
@@ -232,7 +233,7 @@ class MapForwardSimulatorWrapper(MapForwardSimulator):
         super(MapForwardSimulatorWrapper, self)._bulk_fill_probs_atom(array_to_fill, layout_atom, resource_alloc)
 
 
-class TestGateSetTomography(BaseProtocolData):
+class GateSetTomographyTester(BaseProtocolData):
     """
     Tests for methods in the GateSetTomography class.
 
@@ -261,9 +262,21 @@ class TestGateSetTomography(BaseProtocolData):
 
         for estimate in results.estimates.values():
             for model in estimate.models.values():
-                assert isinstance(model, MapForwardSimulatorWrapper)
+                assert isinstance(model, _ExplicitOpModel)
         pass
 
+    def test_run_with_no_gaugeoptsuite(self, capfd: pytest.LogCaptureFixture):
+        self.setUpClass()
+        proto = gst.GateSetTomography(smq1Q_XYI.target_model("CPTPLND"),
+                                      gaugeopt_suite=None, name="testGST",
+                                      badfit_options={"threshold": -1000, "actions": ("wildcard1d",)},)
+        results = proto.run(self.gst_data, simulator=MapForwardSimulatorWrapper())
+        stdout, _ = capfd.readouterr()
+        assert MapForwardSimulatorWrapper.Message in stdout
+
+        mdl_result = results.estimates["testGST"].models['final iteration estimate']
+        twoDLogL = two_delta_logl(mdl_result, self.gst_data.dataset)
+        assert twoDLogL <= 1.0  # should be near 0 for perfect data
     
     def test_write_and_read_to_dir(self):
         #integration test to at least confirm we are writing and reading


### PR DESCRIPTION
Some recent updates cause `protocols.gst._compute_wildcard_budget_1d_model` to now return a dictionary of budget objects rather than a single one, and this introduced two issues:

1. `_compute_wildcard_budget_1d_model` takes an *optional* `gaugeopt_suite`
 argument (that should be allowed to be `None`) but internally it assumes
 a valid budget object.  This PR adds a line creating an empty default
 `GSTGaugeOptSuite` object when `None` is passed in.

2. the processing code "bad fit" processing code in
 `protocols.gst._add_badfit_estimates` was only updated to account
 for _compute_wildcard_budget_1d_model returning a dict when
 `gaugeopt_suite is not None` was True.  This PR removes this
 conditional branch so that returned value is always processed as
 a dictionary of budgets, as it should be.

Also, this PR adds an unrelated update to wildcardbudget.py's `precompute_for_same_probs_freqs` function to raise a `ValueError` when the probabilities given are out of range (outside [0.0,1.0]). This results in a more informative error message to users, as out-of-range probabilities will cause downstream assertion failures that are difficult to make sense of.