### PR TITLE
Fix: Replace `np.sum` with built-in `sum` for generator to fix TypeError in NumPy 2.4+

### DIFF
--- a/pygsti/tools/rbtheory.py
+++ b/pygsti/tools/rbtheory.py
@@ -325,8 +325,8 @@ def L_matrix(model, target_model, weights=None):  # noqa N802
         for key in list(target_model.operations.keys()):
             weights[key] = 1.
 
-    normalizer = _np.sum(_np.array([weights[key] for key in list(target_model.operations.keys())]))
-    L_matrix = (1 / normalizer) * _np.sum(
+    normalizer = sum(_np.array([weights[key] for key in list(target_model.operations.keys())]))
+    L_matrix = (1 / normalizer) * sum(
         weights[key] * _np.kron(
             model.operations[key].to_dense("HilbertSchmidt").T,
             _np.linalg.inv(target_model.operations[key].to_dense("HilbertSchmidt"))


### PR DESCRIPTION
Hi PyGSTi team,
This PR fixes a `TypeError` that occurs in the `L_matrix` function when running the code with newer versions of NumPy (2.4.0 and above). 
As per the [NumPy 2.4.0 Release Notes](https://numpy.org/devdocs/release/2.4.0-notes.html):
"Calling np.sum(generator) directly on a generator object now raises a TypeError. This behavior was deprecated in NumPy 1.15.0. Use np.sum(np.fromiter(generator)) or the python sum builtin instead."
Error message:
`TypeError: Calling np.sum(generator) is deprecated. Use np.sum(np.fromiter(generator)) or the python sum builtin instead.`
Note: Since I am not deeply familiar with PyGSTi's core internals, I would really appreciate it if you could double-check this change to ensure it doesn't have any unintended side effects elsewhere.
I hope my contribution is useful.