### PR TITLE
pay down tech debt in lindbladtools.py -- target develop

### DIFF
--- a/pygsti/tools/lindbladtools.py
+++ b/pygsti/tools/lindbladtools.py
@@ -10,15 +10,27 @@ Utility functions relevant to Lindblad forms and projections
 # http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
 #***************************************************************************************************
 
+from __future__ import annotations
+from typing import Literal
+
+Literal_HSCA = Literal['H', 'S', 'C', 'A']
+
 import numpy as _np
 import scipy.sparse as _sps
 
 from pygsti.tools.basistools import basis_matrices
 import pygsti.baseobjs as _bo
-from pygsti.baseobjs.errorgenlabel import GlobalElementaryErrorgenLabel as _GlobalElementaryErrorgenLabel, \
-                                          LocalElementaryErrorgenLabel as _LocalElementaryErrorgenLabel
-from pygsti.baseobjs.statespace import QubitSpace as _QubitSpace
-import warnings as _warnings
+from pygsti.baseobjs.errorgenlabel import (
+    GlobalElementaryErrorgenLabel as _GEEL,
+    LocalElementaryErrorgenLabel as _LEEL
+)
+
+
+from pygsti.baseobjs.statespace import (
+    QubitSpace as _QubitSpace,
+    StateSpace as _StateSpace
+)
+
 
 def create_elementary_errorgen_dual(typ, p, q=None, sparse=False, normalization_factor='auto'):
     """
@@ -125,6 +137,7 @@ def create_elementary_errorgen_dual(typ, p, q=None, sparse=False, normalization_
     elem_errgen *= _np.real_if_close(1 / normalization_factor).item()  # item() -> scalar
     if sparse: elem_errgen = elem_errgen.tocsr()
     return (elem_errgen, normalization_factor) if return_normalization else elem_errgen
+
 
 #TODO: Should be able to leverage the structure of the paulis as generalized permutation
 #matrices to avoid explicitly doing outer products
@@ -236,7 +249,7 @@ def create_elementary_errorgen_dual_pauli(typ, p, q=None, sparse=False):
 
 #TODO: The construction can be made a bit more efficient if we know we will be constructing multiple
 #error generators with overlapping indices by reusing intermediate results.
-def create_elementary_errorgen(typ, p, q=None, sparse=False):
+def create_elementary_errorgen(typ : Literal_HSCA, p, q=None, sparse=False):
     """
     Construct an elementary error generator as a matrix in the "standard" (matrix-unit) basis.
 
@@ -271,26 +284,39 @@ def create_elementary_errorgen(typ, p, q=None, sparse=False):
     -------
     ndarray or Scipy CSR matrix
     """
+    eeg_dtype : _np.typing.DTypeLike
+    if typ == 'H':
+        assert q is None, "q must not be provided for H-type elementary error generator!"
+        eeg_dtype = _np.complex128
+    elif typ == 'S':
+        assert q is None, "q must not be provided for S-type elementary error generator!"
+        eeg_dtype = p.dtype
+    elif typ == 'C':
+        assert q is not None, "q must be provided for C-type elementary error generator!"
+        eeg_dtype = _np.result_type(p.dtype, q.dtype)
+    elif typ == 'A':
+        assert q is not None, "q must be provided for A-type elementary error generator!"
+        eeg_dtype = _np.complex128
+    else:
+        raise ValueError(f'`typ` must be one of "H", "S", "C", or "A"; received {typ}.')
+
     d = p.shape[0]
     d2 = d**2
-    dtype = (1j*_np.array(1, dtype=p.dtype)).dtype
     if sparse:
-        elem_errgen = _sps.lil_matrix((d2, d2), dtype=dtype)
+        elem_errgen = _sps.lil_matrix((d2, d2), dtype=eeg_dtype)
     else:
-        elem_errgen = _np.empty((d2, d2), dtype=dtype)
-
-    assert(typ in ('H', 'S', 'C', 'A')), "`typ` must be one of 'H', 'S', 'C', or 'A'"
-    assert((typ in 'HS' and q is None) or (typ in 'CA' and q is not None)), \
-        "Wrong number of basis elements provided for %s-type elementary errorgen!" % typ
+        elem_errgen = _np.empty((d2, d2), dtype=eeg_dtype)
 
     pdag = p.T.conjugate()
     qdag = q.T.conjugate() if (q is not None) else None
 
     if typ in 'CA':
-        pq_plus_qp = pdag @ q + qdag @ p
+        pq_plus_qp  = pdag @ q + qdag @ p
         pq_minus_qp = pdag @ q - qdag @ p
+    if typ in 'S':
+        pdag_p = pdag @ p
 
-    #if p or q is a sparse matrix fall back to original implementation
+    # if p or q is a sparse matrix fall back to original implementation
     if not isinstance(p, _np.ndarray) or (q is not None and not isinstance(q, _np.ndarray)):
         # Loop through the standard basis as all possible input density matrices
         for i, rho0 in enumerate(basis_matrices('std', d2)):  # rho0 == input density mx
@@ -298,7 +324,6 @@ def create_elementary_errorgen(typ, p, q=None, sparse=False):
             if typ == 'H':
                 rho1 = -1j * (p @ rho0 - rho0 @ p)  # Add "/2" to have PP ham gens match previous versions of pyGSTi
             elif typ == 'S':
-                pdag_p = (pdag @ p)
                 rho1 = p @ rho0 @ pdag - 0.5 * (pdag_p @ rho0 + rho0 @ pdag_p)
             elif typ == 'C':
                 rho1 = p @ rho0 @ qdag + q @ rho0 @ pdag - 0.5 * (pq_plus_qp @ rho0 + rho0 @ pq_plus_qp)
@@ -307,32 +332,38 @@ def create_elementary_errorgen(typ, p, q=None, sparse=False):
             elem_errgen[:, i] = rho1.flatten()[:, None] if sparse else rho1.flatten()
     else:
         # Loop through the standard basis as all possible input density matrices
+        rho1 = _np.zeros((d,d), dtype=eeg_dtype)
         for i in range(d): 
             for j in range(d):
                 # Only difference between H/S/C/A is how they transform input density matrices
                 if typ == 'H':
-                    rho1 = _np.zeros((d,d), dtype=_np.complex128)
-                    rho1[:, j] = -1j*p[:, i]
-                    rho1[i, :] += 1j*p[j, :]
+                    # rho1 complex
+                    rho1[:] = 0
+                    rho1[:, j]  = -1j*p[:, i]  # plain assignment
+                    rho1[i, :] +=  1j*p[j, :]  # in-place update
                 elif typ == 'S':
-                    pdag_p = (pdag @ p)
-                    rho1 = p[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d))
-                    rho1[:, j] += -0.5*pdag_p[:, i]
-                    rho1[i, :] += -0.5*pdag_p[j, :]
+                    # rho1 same dtype as p
+                    rho1[:] = p[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d))
+                    rho1[:, j] -= 0.5*pdag_p[:, i]
+                    rho1[i, :] -= 0.5*pdag_p[j, :]
                 elif typ == 'C':
-                    rho1 = p[:,i].reshape((d,1)) @ qdag[j,:].reshape((1,d)) + q[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d))
-                    rho1[:, j] += -0.5*pq_plus_qp[:, i]
-                    rho1[i, :] += -0.5*pq_plus_qp[j, :]
+                    # rho1 the result dtype of (p, q)
+                    rho1[:] = p[:,i].reshape((d,1)) @ qdag[j,:].reshape((1,d)) + q[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d))
+                    rho1[:, j] -= 0.5*pq_plus_qp[:, i]
+                    rho1[i, :] -= 0.5*pq_plus_qp[j, :]
                 elif typ == 'A':
-                    rho1 = 1j*(p[:,i].reshape((d,1)) @ qdag[j,:].reshape((1,d))) - 1j*(q[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d)))
-                    rho1[:, j] += 1j*.5*pq_minus_qp[:, i]
-                    rho1[i, :] += 1j*.5*pq_minus_qp[j, :]
+                    # rho1 complex
+                    rho1[:] = 1j*(p[:,i].reshape((d,1)) @ qdag[j,:].reshape((1,d))) - 1j*(q[:,i].reshape((d,1)) @ pdag[j,:].reshape((1,d)))
+                    rho1[:, j] += 0.5j * pq_minus_qp[:, i]
+                    rho1[i, :] += 0.5j * pq_minus_qp[j, :]
 
                 elem_errgen[:, d*i+j] = rho1.flatten()[:, None] if sparse else rho1.flatten()
 
-    if sparse: elem_errgen = elem_errgen.tocsr()
+    if sparse:
+        elem_errgen = elem_errgen.tocsr()
 
     return elem_errgen
+
 
 #TODO: Should be able to leverage the structure of the paulis as generalized permutation
 #matrices to avoid explicitly doing outer products
@@ -495,9 +526,8 @@ def create_lindbladian_term_errorgen(typ, Lm, Ln=None, sparse=False):  # noqa N8
         # Only difference between H/S/C/A is how they transform input density matrices
         if typ == 'H':
             rho1 = -1j * (Lm @ rho0 - rho0 @ Lm)
-        elif typ == 'O':
+        else: # typ == 'O':
             rho1 = Ln @ rho0 @ Lm_dag - 0.5 * (Lmdag_Ln @ rho0 + rho0 @ Lmdag_Ln)
-        else: raise ValueError("Invalid lindblad term errogen type!")
         lind_errgen[:, i] = rho1.ravel()
         # ^ That line used to branch based on the value of sparse, but both branches
         #   produced the same result.
@@ -507,71 +537,293 @@ def create_lindbladian_term_errorgen(typ, Lm, Ln=None, sparse=False):  # noqa N8
     return lind_errgen
 
 
-def random_CPTP_error_generator_rates(num_qubits, errorgen_types=('H', 'S', 'C', 'A'), max_weights=None,
-                                 H_params=(0.,.01), SCA_params=(0.,.01), error_metric=None, error_metric_value=None, 
-                                 relative_HS_contribution=None, fixed_errorgen_rates=None, sslbl_overlap=None, 
-                                 label_type='global', seed=None, qubit_labels=None):
+def _filtered_leeldict_to_array(
+        d: dict[_LEEL, float],
+        t: Literal_HSCA,
+    ) -> _np.ndarray:
+    """Return the values of d whose key's errorgen type matches t."""
+    return _np.array([val for key, val in d.items() if key.errorgen_type == t])
+
+
+def _validate_random_CPTP_params(
+        errorgen_types       : tuple[Literal_HSCA, ...],
+        H_params             : tuple[float, float],
+        SCA_params           : tuple[float, float],
+        error_metric         : Literal['generator_infidelity', 'total_generator_error'] | None,
+        error_metric_value   : float | None,
+        rel_HS_contrib       : tuple[float, float] | None,
+        fixed_errorgen_rates : dict[_LEEL, float],
+        max_weights          : dict[str, int] | None
+    ) -> tuple[float, float]:
+    """Validate inputs for random_CPTP_error_generator_rates. Returns (fixed_H_contrib, fixed_S_contrib)."""
+
+    if 'C' in errorgen_types or 'A' in errorgen_types:
+        msg = 'Must include S terms when C or A present. Cannot have a CP error generator otherwise.'
+        assert 'S' in errorgen_types, msg
+
+    if max_weights is not None:
+        msg = 'The maximum weight of the %s terms should be <= the maximum weight of S.'
+        assert max_weights.get('C', 0) <= max_weights.get('S', 0), msg % 'C'
+        assert max_weights.get('A', 0) <= max_weights.get('S', 0), msg % 'A'
+
+    if len(fixed_errorgen_rates) == 0 or error_metric is None:
+        return 0.0, 0.0
+    
+    msg = 'Specifying non-zero HSCA means together with a target error metric is not supported.'
+    assert H_params[0] == 0. and SCA_params[0] == 0., msg
+
+    msg = 'error_metric_value must be specified when error_metric is not None.'
+    assert error_metric_value is not None, msg
+    
+    msg = 'All keys of fixed_errorgen_rates must be LocalElementaryErrorgenLabel.'
+    assert all([isinstance(key, _LEEL) for key in fixed_errorgen_rates.keys()]), msg
+    
+    fixed_S_rates = _filtered_leeldict_to_array(fixed_errorgen_rates, 'S')
+    fixed_S_contrib = _np.sum(fixed_S_rates)
+
+    fixed_H_rates = _filtered_leeldict_to_array(fixed_errorgen_rates, 'H')
+    if error_metric == 'generator_infidelity':
+        fixed_H_rates = fixed_H_rates ** 2
+    if error_metric == 'total_generator_error':
+        fixed_H_rates = _np.abs(fixed_H_rates)
+    fixed_H_contrib = _np.sum(fixed_H_rates)
+
+    fixed_error_metric_value = fixed_S_contrib + fixed_H_contrib
+    msg  = f'Incompatible values of error_metric_value and fixed_errorgen_rates. The value of '
+    msg += f'{error_metric}={error_metric_value} is less than the value of {fixed_error_metric_value} '
+    msg += f'corresponding to the given fixed_errorgen_rates_dict.'
+    assert fixed_error_metric_value <= error_metric_value, msg
+    
+    if rel_HS_contrib is not None:
+
+        msg = f'Fixed %s contribution to {error_metric} of %f exceeds overall %s contribution target value of %f.'
+        abs_H_contrib = rel_HS_contrib[0]*error_metric_value
+        abs_S_contrib = rel_HS_contrib[1]*error_metric_value
+        assert fixed_H_contrib <= abs_H_contrib, msg % ('H', fixed_H_contrib, 'H', abs_H_contrib )
+        assert fixed_S_contrib <= abs_S_contrib, msg % ('S', fixed_S_contrib, 'S', abs_S_contrib )
+
+        msg = 'Invalid rel_HS_contrib, %s is not in errorgen_types.'
+        assert 'H' in errorgen_types, msg % 'H'
+        assert 'S' in errorgen_types, msg % 'S'
+        assert abs(1-sum(rel_HS_contrib)) <= 1e-7, 'The rel_HS_contrib should sum to 1.'
+
+    return fixed_H_contrib, fixed_S_contrib
+
+
+def _filter_ca_labels_for_cp(
+        labels:   list[_LEEL],
+        s_labels: list[_LEEL]
+    ) -> list[_LEEL]:
+    """Return only those labels whose both basis element labels have matching S labels in s_labels."""
+    filtered = []
+    for lbl in labels:
+        comp1, comp2 = lbl.basis_element_labels
+        lbl1 = _LEEL('S', (comp1,))
+        lbl2 = _LEEL('S', (comp2,))
+        if lbl1 in s_labels and lbl2 in s_labels:
+            filtered.append(lbl)
+    return filtered
+
+
+def _check_ca_cp_constraint(
+        ca_rates_dict: dict[_LEEL, float],
+        s_rates_dict : dict[_LEEL, float],
+        errgen_type: str
+    ) -> None:
+    """Raise ValueError if any rate in ca_rates_dict violates |rate| <= sqrt(S1 * S2)."""
+    for lbl, rate in ca_rates_dict.items():
+        comp1, comp2 = lbl.basis_element_labels
+        lbl1 = _LEEL('S', (comp1,))
+        lbl2 = _LEEL('S', (comp2,))
+        rate1 = s_rates_dict[lbl1]
+        rate2 = s_rates_dict[lbl2]
+        if not (abs(rate) <= _np.sqrt(rate1 * rate2)):
+            print(f'{lbl}: {rate}')
+            raise ValueError(f'Invalid {errgen_type} rate')
+    return
+
+
+def _generate_random_rates(
+        errgen_labels_H: list[_LEEL],
+        errgen_labels_S: list[_LEEL],
+        errgen_labels_C: list[_LEEL],
+        errgen_labels_A: list[_LEEL],
+        H_params    : tuple[float, float],
+        SCA_params  : tuple[float, float],
+        rng         : _np.random.Generator
+    ) -> dict[Literal_HSCA, dict[_LEEL, float]]:
+    """Generate random H/S/C/A rates; S/C/A come from PSD matrices to satisfy CP constraints."""
+    num_H_rates = len(errgen_labels_H)
+    num_S_rates = len(errgen_labels_S)
+    rates = {}
+    rates['H'] = {lbl: val for lbl, val in zip(errgen_labels_H,
+                  rng.normal(loc=H_params[0], scale=H_params[1], size=num_H_rates))}
+    random_SC_gen_mat = rng.normal(loc=SCA_params[0], scale=SCA_params[1], size=(num_S_rates, num_S_rates))
+    random_SA_gen_mat = rng.normal(loc=SCA_params[0], scale=SCA_params[1], size=(num_S_rates, num_S_rates))
+    random_SC_mat = random_SC_gen_mat @ random_SC_gen_mat.T
+    random_SA_mat = random_SA_gen_mat @ random_SA_gen_mat.T
+    random_S_rates = _np.real(_np.diag(random_SC_mat) + _np.diag(random_SA_mat))
+    rates['S'] = {lbl: val for lbl, val in zip(errgen_labels_S, random_S_rates)}
+    rates['C'] = {lbl: val for lbl, val in zip(errgen_labels_C,
+                  random_SC_mat[_np.triu_indices_from(random_SC_mat, k=1)])}
+    rates['A'] = {lbl: val for lbl, val in zip(errgen_labels_A,
+                  random_SA_mat[_np.triu_indices_from(random_SA_mat, k=1)])}
+    return rates
+
+
+def _rescale_to_error_metric(
+        random_rates_dicts: dict[Literal_HSCA, dict[_LEEL, float]],
+        error_metric: Literal['generator_infidelity', 'total_generator_error'],
+        error_metric_value: float,
+        relative_HS_contribution: tuple[float, float] | None,
+        fixed_H_contrib: float,
+        fixed_S_contrib: float,
+        errorgen_types: tuple[str, ...],
+        H_free_keys: list[_LEEL],
+        S_free_keys: list[_LEEL],
+        C_free_keys: list[_LEEL],
+        A_free_keys: list[_LEEL]
+    ) -> None:
+    """Scale free H/S/C/A rates so the overall error metric equals error_metric_value (mutates random_rates_dicts)."""
+
+    current_S_sum_free = 0.0 
+    current_H_sum_free = 0.0
+
+    if 'S' in errorgen_types:
+        rrd = random_rates_dicts['S']
+        current_S_sum_free = _np.sum( [ rrd[key] for key in S_free_keys ] )
+
+    if 'H' in errorgen_types:
+        rrd = random_rates_dicts['H']
+        if error_metric == 'generator_infidelity':
+            current_H_sum_free = _np.sum( [ rrd[key] ** 2 for key in H_free_keys ] )
+        if error_metric == 'total_generator_error':
+            current_H_sum_free = _np.sum( [ abs(rrd[key]) for key in H_free_keys ] )
+
+    total_H_sum = current_H_sum_free + fixed_H_contrib
+    total_S_sum = current_S_sum_free + fixed_S_contrib
+
+    if relative_HS_contribution is not None:
+        req_H_sum = relative_HS_contribution[0] * error_metric_value
+        req_S_sum = relative_HS_contribution[1] * error_metric_value
+    else:
+        current_H_contribution = total_H_sum / (total_H_sum + total_S_sum)
+        req_H_sum = current_H_contribution * error_metric_value
+        req_S_sum = (1 - current_H_contribution) * error_metric_value
+
+    needed_H_free = req_H_sum - fixed_H_contrib
+    needed_S_free = req_S_sum - fixed_S_contrib
+
+    if 'H' in errorgen_types:
+        if error_metric == 'generator_infidelity':
+            H_scale_factor = _np.sqrt(needed_H_free / current_H_sum_free)
+        if error_metric == 'total_generator_error':
+            H_scale_factor = needed_H_free / current_H_sum_free
+        for key in H_free_keys:
+            random_rates_dicts['H'][key] *= H_scale_factor
+
+    if 'S' in errorgen_types:
+        S_scale_factor = needed_S_free / current_S_sum_free
+        for key in S_free_keys:
+            random_rates_dicts['S'][key] *= S_scale_factor
+        for key in C_free_keys:
+            random_rates_dicts['C'][key] *= S_scale_factor
+        for key in A_free_keys:
+            random_rates_dicts['A'][key] *= S_scale_factor
+
+    return
+
+
+def _convert_to_global_labels(
+        errorgen_rates_dict: dict[_LEEL, float],
+        state_space: _StateSpace,
+        qubit_labels: list | None
+    ) -> dict[_GEEL, float]:
+    """Cast local error generator labels to global labels and apply any qubit label remapping."""
+    result = {_GEEL.cast(lbl, sslbls=state_space.state_space_labels): val
+              for lbl, val in errorgen_rates_dict.items()}
+    if qubit_labels is not None:
+        mapper = {i: lbl for i, lbl in enumerate(qubit_labels)}
+        result = {lbl.map_state_space_labels(mapper): val for lbl, val in result.items()}
+    return result
+
+
+def random_CPTP_error_generator_rates(
+        num_qubits        : int,
+        errorgen_types    : tuple[Literal_HSCA, ...] = ('H', 'S', 'C', 'A'),
+        max_weights       : dict[str, int] | None = None,
+        H_params          : tuple[float, float] = (0., .01),
+        SCA_params        : tuple[float, float] = (0., .01),
+        error_metric      : Literal['generator_infidelity', 'total_generator_error'] | None = None,
+        error_metric_value        : float | None = None,
+        relative_HS_contribution  : tuple[float, float] | None = None,
+        fixed_errorgen_rates      : dict[_LEEL, float] | None = None,
+        sslbl_overlap             : list | None = None,
+        label_type                : Literal['global', 'local'] = 'global',
+        seed           : int | None = None,
+        qubit_labels   : list | None = None
+    ) -> dict:
     """
     Function for generating a random set of CPTP error generator rates.
-    
+
     Parameters
     ----------
     num_qubits : int
         Number of qubits the error generator acts upon.
-    
+
     errorgen_types : tuple of str, optional (default('H', 'S', 'C', 'A'))
         Tuple of strings designating elementary error generator types to include in this
         basis. Note that due to the CP constraint, certain values are not allowed,
         and any tuple containing 'C' or 'A' terms must also include 'S'.
-    
+
     max_weights : dict, optional (default None)
         An optional dictionary specifying the maximum weight
         for each of the elementary error generator types, with keys
-        given by the strings 'H', 'S', 'C' and 'A'. If None then 
+        given by the strings 'H', 'S', 'C' and 'A'. If None then
         there is no maximum weight. If specified, any error generator
         types without entries will have no maximum weight associated
         with them.
-        
+
     H_params : tuple of floats, optional (default (0.,.01))
         Mean and standard deviation parameters for a normal distribution
         from which the H rates will be sampled. Note that specifying a non-zero
         value for the mean with generator_infidelity set to a non-trivial value
         is not supported, and will raise an error.
-    
+
     SCA_params : tuple of floats, optional (default (0.,.01))
         Mean and standard deviation parameters for a normal distribution
         from which the entries of the matrix used in the construction of the S, C and A rates
         will be construction is sampled. Note that specifying a non-zero
         value for the mean with generator_infidelity set to a non-trivial value
         is not supported, and will raise an error.
-    
+
     error_metric : str, optional (default None)
         An optional string, used in conjunction with the error_metric_value
         kwarg which specifies which metric to use in setting the sampled
         channel's overall error rate. If None, no target value for the channel's
         overall error rate is used. Currently supported options include:
-        
+
         - 'generator_infidelity'
         - 'total_generator_error'
-    
+
     error_metric_value : float, optional (default None)
         An float between 0 and 1 which gives the target value of the
         error metric specified in 'error_metric' for the channel induced by
         the randomly produced error generator. If None
         then no target value is used and the returned error generator
         will have a random generator infidelity.
-        
+
     relative_HS_contribution : tuple, optional (default None)
         An optional tuple, used in conjunction with the `generator_infidelity` kwarg,
         specifying the relative contributions of the H and S error generators to the
         generator infidelity. The values in this tuple should sum to 1. The first entry
         corresponds to the H sector, and the second the S sector.
-        
+
     sslbl_overlap : list of sslbls, optional (default None)
         A list of state space labels corresponding to qudits the support of
         an error generator must overlap with (i.e. the support must include at least
         one of these qudits) in order to be included in this basis.
-        
+
     fixed_errorgen_rates : dict, optional (default None)
         An optional dictionary whose keys are `LocalElementaryErrorgenLabel`
         objects, and whose values are error generator rates. When specified, the
@@ -581,7 +833,7 @@ def random_CPTP_error_generator_rates(num_qubits, errorgen_types=('H', 'S', 'C',
         control the weight and allowed types of the error generators in this
         model. If specifying fixed C and A rates it is possible for the final
         error generator to be non-CP.
-    
+
     label_type : str, optional (default 'global')
         String which can be either 'global' or 'local', indicating whether to
         return a dictionary with keys which are `GlobalElementaryErrorgenLabel`
@@ -593,231 +845,65 @@ def random_CPTP_error_generator_rates(num_qubits, errorgen_types=('H', 'S', 'C',
     qubit_labels : list or int or str, optional (default None)
         An optional list of qubit labels upon which the error generator should act.
         Only utilized when returning global labels.
-    
+
     Returns
     -------
-    Dictionary of error generator coefficient labels and rates 
+    Dictionary of error generator coefficient labels and rates
     """
-    
-    #Add various assertions
     if fixed_errorgen_rates is None:
-        fixed_errorgen_rates = dict()
-    
-    if error_metric is not None:
-        assert H_params[0] == 0. and SCA_params[0] == 0., 'Specifying non-zero HSCA means together with a target error metric is not supported.'
-        if error_metric not in ('generator_infidelity', 'total_generator_error'):
-            raise ValueError('Unsupported error metric type. Currently supported options are generator_infidelity and total_generator_error')
-        #Add a check that the desired error metric value is attainable given the values of fixed_errorgen_rates.
-        if fixed_errorgen_rates:
-            #verify that all of the keys are LocalElementaryErrorgenLabel objects.
-            msg = 'All keys of fixed_errorgen_rates must be LocalElementaryErrorgenLabel.'
-            assert all([isinstance(key, _LocalElementaryErrorgenLabel) for key in fixed_errorgen_rates.keys()]), msg
-            
-            #get the H and S rates from the dictionary.
-            fixed_H_rates = _np.array([val for key, val in fixed_errorgen_rates.items() if key.errorgen_type == 'H'])
-            fixed_S_rates = _np.array([val for key, val in fixed_errorgen_rates.items() if key.errorgen_type == 'S'])
-            fixed_S_contribution = _np.sum(fixed_S_rates)
-            if error_metric == 'generator_infidelity':
-                fixed_H_contribution = _np.sum(fixed_H_rates**2)
-                fixed_error_metric_value = fixed_S_contribution + fixed_H_contribution
-            elif error_metric == 'total_generator_error':
-                fixed_H_contribution = _np.sum(_np.abs(fixed_H_rates))
-                fixed_error_metric_value = fixed_S_contribution + fixed_H_contribution
-            msg = f'Incompatible values of error_metric_value and fixed_errorgen_rates. The value of {error_metric}={error_metric_value}'\
-                  + f' is less than the value of {fixed_error_metric_value} corresponding to the given fixed_errorgen_rates_dict.'
-            assert fixed_error_metric_value < error_metric_value, msg
-            
-            if relative_HS_contribution is not None:
-                msg_H = f'Fixed H contribution to {error_metric} of {fixed_H_contribution} exceeds overall H contribution target value of {relative_HS_contribution[0]*error_metric_value}.'
-                msg_S = f'Fixed S contribution to {error_metric} of {fixed_S_contribution} exceeds overall S contribution target value of {relative_HS_contribution[1]*error_metric_value}.'
-                assert fixed_H_contribution < relative_HS_contribution[0]*error_metric_value, msg_H
-                assert fixed_S_contribution < relative_HS_contribution[1]*error_metric_value, msg_S
-        else:
-            fixed_H_contribution = 0
-            fixed_S_contribution = 0
-                      
-    if relative_HS_contribution is not None:
-        assert ('H' in errorgen_types and 'S' in errorgen_types), 'Invalid relative_HS_contribution, one of either H or S is not in errorgen_types.'
-        if error_metric is None:
-            _warnings.warn('The relative_HS_contribution kwarg is only utilized when error_metric is not None, the specified value is ignored otherwise.')
-        else:
-            assert abs(1-sum(relative_HS_contribution))<=1e-7, 'The relative_HS_contribution should sum to 1.'
-    
-    if 'C' in errorgen_types or 'A' in errorgen_types:
-        assert 'S' in errorgen_types, 'Must include S terms when C and A present. Cannot have a CP error generator otherwise.'
+        fixed_errorgen_rates = {}
 
-    if max_weights is not None:
-        assert max_weights.get('C', 0) <= max_weights.get('S', 0) and max_weights.get('A', 0) <= max_weights.get('S', 0), 'The maximum weight of the C and A terms should be less than or equal to the maximum weight of S.'
+    if label_type not in ['global', 'local']:
+        raise ValueError('Unsupported label type {label_type}.')
+
+    fixed_H_contrib, fixed_S_contrib = _validate_random_CPTP_params(
+        errorgen_types, H_params, SCA_params, error_metric, error_metric_value,
+        relative_HS_contribution, fixed_errorgen_rates, max_weights
+    )
     rng = _np.random.default_rng(seed)
- 
-    #create a state space with this dimension.
-    state_space = _QubitSpace.cast(num_qubits)
+
+    state_space    = _QubitSpace.cast(num_qubits)
+    errorgen_basis = _bo.CompleteElementaryErrorgenBasis('PP', state_space, errorgen_types, max_weights, sslbl_overlap, 'local')
     
-    #create an error generator basis according the our weight specs
-    errorgen_basis = _bo.CompleteElementaryErrorgenBasis('PP', state_space, elementary_errorgen_types=errorgen_types,
-                                                         max_weights=max_weights, sslbl_overlap=sslbl_overlap, default_label_type='local')
-    
-    #Get the labels, broken out by sector, of each of the error generators in this basis.
     errgen_labels_H = _sort_errorgen_labels(errorgen_basis.sublabels('H'))
     errgen_labels_S = _sort_errorgen_labels(errorgen_basis.sublabels('S'))
     errgen_labels_C = _sort_errorgen_labels(errorgen_basis.sublabels('C'))
     errgen_labels_A = _sort_errorgen_labels(errorgen_basis.sublabels('A'))
-    
-    #filter out any C or A terms which can't be present with CP constraints due to lack of correct S term.
-    filtered_errgen_labels_C = []
-    for lbl in errgen_labels_C:
-        first_label = _LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[0],))
-        second_label = _LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[1],))
-        if first_label not in errgen_labels_S or second_label not in errgen_labels_S:
-            continue
-        else:
-            filtered_errgen_labels_C.append(lbl)
-    filtered_errgen_labels_A = []
-    for lbl in errgen_labels_A:
-        first_label = _LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[0],))
-        second_label = _LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[1],))
-        if first_label not in errgen_labels_S or second_label not in errgen_labels_S:
-            continue
-        else:
-            filtered_errgen_labels_A.append(lbl)
-    errgen_labels_C = filtered_errgen_labels_C
-    errgen_labels_A = filtered_errgen_labels_A
+    errgen_labels_C = _filter_ca_labels_for_cp(errgen_labels_C, errgen_labels_S)
+    errgen_labels_A = _filter_ca_labels_for_cp(errgen_labels_A, errgen_labels_S)
 
-    #Get the number of H and S error generators. These are stored in HSCA order in the labels 
-    num_H_rates = len(errgen_labels_H)
-    num_S_rates = len(errgen_labels_S)
-    
-    random_rates_dicts = dict()
-    #Generate random H rates
-    random_rates_dicts['H'] = {lbl: val for lbl,val in zip(errgen_labels_H, rng.normal(loc=H_params[0], scale=H_params[1], size = num_H_rates))}
-    
-    #Create a random matrix with complex gaussian entries which will be used to generator a PSD matrix for the SCA rates.
-    random_SC_gen_mat = rng.normal(loc=SCA_params[0], scale=SCA_params[1], size=(num_S_rates, num_S_rates))    
-    random_SA_gen_mat = rng.normal(loc=SCA_params[0], scale=SCA_params[1], size=(num_S_rates, num_S_rates))    
-    random_SC_mat = random_SC_gen_mat @ random_SC_gen_mat.T
-    random_SA_mat = random_SA_gen_mat @ random_SA_gen_mat.T
-    random_S_rates = _np.real(_np.diag(random_SC_mat) + _np.diag(random_SA_mat))
+    random_rates_dicts : dict[Literal_HSCA, dict[_LEEL, float]] = _generate_random_rates(
+        errgen_labels_H, errgen_labels_S, errgen_labels_C, errgen_labels_A, H_params, SCA_params, rng
+    )
+    _check_ca_cp_constraint(random_rates_dicts['C'], random_rates_dicts['S'], 'C')
+    _check_ca_cp_constraint(random_rates_dicts['A'], random_rates_dicts['S'], 'A')
+    for egtyp, rate_dict in random_rates_dicts.items():
+        for leel, rate in fixed_errorgen_rates.items():
+            if leel.errorgen_type == egtyp:
+                rate_dict[leel] = rate
 
-    #The random S rates are just the sum of the diagonals of random SC and SA mats.
-    random_rates_dicts['S'] = {lbl: val for lbl,val in zip(errgen_labels_S,  random_S_rates)}
-    #The random C rates are the real part of the off diagonal entries, and the A rates the imaginary part.
-    random_rates_dicts['C'] =  {lbl: val for lbl,val in zip(errgen_labels_C, random_SC_mat[_np.triu_indices_from(random_SC_mat, k=1)])}
-    random_rates_dicts['A'] =  {lbl: val for lbl,val in zip(errgen_labels_A, random_SA_mat[_np.triu_indices_from(random_SA_mat, k=1)])}
-    #manually check conditions on C and A
-    for lbl, rate in random_rates_dicts['C'].items():
-        first_S_rate = random_rates_dicts['S'][_LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[0],))]
-        second_S_rate = random_rates_dicts['S'][_LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[1],))]
-
-        if not (abs(rate) <= _np.sqrt(first_S_rate*second_S_rate)):
-            print(f'{lbl}: {rate}')
-            raise ValueError('Invalid C rate')
-        
-    #manually check conditions on C and A
-    for lbl, rate in random_rates_dicts['A'].items():
-        first_S_rate = random_rates_dicts['S'][_LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[0],))]
-        second_S_rate = random_rates_dicts['S'][_LocalElementaryErrorgenLabel('S', (lbl.basis_element_labels[1],))]
-
-        if not (abs(rate) <= _np.sqrt(first_S_rate*second_S_rate)):
-            print(f'{lbl}: {rate}')
-            raise ValueError('Invalid A rate')
-
-    #Add in/override the fixed rates for each of the sectors.
-    H_fixed_keys = []
-    S_fixed_keys = []
-    C_fixed_keys = []
-    A_fixed_keys = []
-    for key in fixed_errorgen_rates:
-        if key.errorgen_type == 'H':
-            H_fixed_keys.append(key)
-        elif key.errorgen_type == 'S':
-            S_fixed_keys.append(key)
-        elif key.errorgen_type == 'C':
-            C_fixed_keys.append(key)
-        else:
-            A_fixed_keys.append(key)
-          
-    random_rates_dicts['H'].update({key:fixed_errorgen_rates[key] for key in H_fixed_keys})
-    random_rates_dicts['S'].update({key:fixed_errorgen_rates[key] for key in S_fixed_keys})
-    random_rates_dicts['C'].update({key:fixed_errorgen_rates[key] for key in C_fixed_keys})
-    random_rates_dicts['A'].update({key:fixed_errorgen_rates[key] for key in A_fixed_keys})
-    
-    #For each sector construct a complementary structure of the free(ish) parameters error generator parameters for
-    #that sector.
-    H_free_keys = [key for key in errgen_labels_H if key not in fixed_errorgen_rates] #membership checking is (often) faster with dicts
+    H_free_keys = [key for key in errgen_labels_H if key not in fixed_errorgen_rates]
     S_free_keys = [key for key in errgen_labels_S if key not in fixed_errorgen_rates]
     C_free_keys = [key for key in errgen_labels_C if key not in fixed_errorgen_rates]
     A_free_keys = [key for key in errgen_labels_A if key not in fixed_errorgen_rates]
     
-    #Now it is time to apply the various normalizations necessary to get the desired target
-    #generator infidelity and sector weights.
-    if error_metric is not None:
-        #Get the free parameter's  For both generator infidelity we use the sum of the S rates
-        current_S_sum_free = _np.sum([random_rates_dicts['S'][key] for key in S_free_keys])
-        if error_metric == 'generator_infidelity':
-            #for generator infidelity we use the sum of the squared H rates.
-            current_H_sum_free = _np.sum([random_rates_dicts['H'][key]**2 for key in H_free_keys])
-        elif error_metric == 'total_generator_error':
-            #for total generator error we use the sum of the H rates directly.
-            current_H_sum_free = _np.sum([abs(random_rates_dicts['H'][key]) for key in H_free_keys])
-        
-        total_H_sum = current_H_sum_free + fixed_H_contribution
-        total_S_sum = current_S_sum_free + fixed_S_contribution
-        
-        if relative_HS_contribution is not None:
-            #calculate the target values of the H and S contributions to the error metric 
-            #given the specified contributions
-            req_H_sum = relative_HS_contribution[0]*error_metric_value
-            req_S_sum = relative_HS_contribution[1]*error_metric_value
-                        
-        #If we haven't specified a relative contribution for H and S then we will scale these
-        #to give the correct generator infidelity while preserving whatever relative contribution
-        #to the generator infidelity they were randomly sampled to have.
-        else:
-            #Get the current relative contributions.
-            current_H_contribution = total_H_sum/(total_H_sum+total_S_sum)
-            current_S_contribution = 1-current_H_contribution
-            req_H_sum = current_H_contribution*error_metric_value
-            req_S_sum = current_S_contribution*error_metric_value
-            
-        #this is how much we still need to be contributed by the free parameters
-        needed_H_free = req_H_sum - fixed_H_contribution
-        needed_S_free = req_S_sum - fixed_S_contribution
-        
-        if error_metric == 'generator_infidelity':
-            #The scale factor for the H rates is sqrt(req_squared_H_sum/current_squared_H_sum)
-            H_scale_factor = _np.sqrt(needed_H_free/current_H_sum_free)
-        elif error_metric == 'total_generator_error':
-            #The scale factor for the S rates is req_S_sum/current_S_sum
-            H_scale_factor = needed_H_free/current_H_sum_free    
-        #The scale factor for the S rates is req_S_sum/current_S_sum
-        S_scale_factor = needed_S_free/current_S_sum_free    
+    if error_metric is not None and error_metric_value is not None: 
+        # ^ The `and` in that check is redundant, but keep it for type checking.
+        _rescale_to_error_metric(
+            random_rates_dicts, error_metric, error_metric_value,
+            relative_HS_contribution, fixed_H_contrib, fixed_S_contrib,
+            errorgen_types, H_free_keys, S_free_keys, C_free_keys, A_free_keys
+        )
 
-        #Rescale the free random rates, note that the free SCA terms will all be scaled by the S_scale_factor
-        #to preserve PSD.
-        for key in H_free_keys:
-            random_rates_dicts['H'][key]*=H_scale_factor
-        for key in S_free_keys:
-            random_rates_dicts['S'][key]*=S_scale_factor
-        for key in C_free_keys:
-            random_rates_dicts['C'][key]*=S_scale_factor
-        for key in A_free_keys:
-            random_rates_dicts['A'][key]*=S_scale_factor
-                
-    #Now turn this into a rates dict
-    errorgen_rates_dict = dict()
+    errorgen_rates_dict = {}
     for errgen_type in errorgen_types:
         errorgen_rates_dict.update(random_rates_dicts[errgen_type])
-    
-    if label_type not in ['global', 'local']:
-        raise ValueError('Unsupported label type {label_type}.')
 
     if label_type == 'global':
-        errorgen_rates_dict = {_GlobalElementaryErrorgenLabel.cast(lbl, sslbls=state_space.state_space_labels): val 
-                               for lbl, val in  errorgen_rates_dict.items()}
-        if qubit_labels is not None:
-            mapper= {i:lbl for i,lbl in enumerate(qubit_labels)} 
-            errorgen_rates_dict = {lbl.map_state_space_labels(mapper):val for lbl,val in errorgen_rates_dict.items()}
+        errorgen_rates_dict = _convert_to_global_labels(errorgen_rates_dict, state_space, qubit_labels)
+
     return errorgen_rates_dict
+
 
 def _sort_errorgen_labels(errgen_labels):
     """
@@ -827,7 +913,7 @@ def _sort_errorgen_labels(errgen_labels):
     if not errgen_labels:
         return []
     
-    assert isinstance(errgen_labels[0], _LocalElementaryErrorgenLabel), 'Can only sort local labels at the moment'
+    assert isinstance(errgen_labels[0], _LEEL), 'Can only sort local labels at the moment'
 
     errorgen_types = [lbl.errorgen_type for lbl in errgen_labels]
     assert len(set(errorgen_types))==1, 'only one error generator type at a time is supported presently'

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -735,7 +735,8 @@ def entanglement_infidelity(a, b, mx_basis: BasisLike = 'pp', is_tp=None, is_uni
     """
     return 1 - entanglement_fidelity(a, b, mx_basis, is_tp, is_unitary)
 
-def generator_infidelity(a, b, mx_basis = 'pp'):
+
+def generator_infidelity(a, b, mx_basis = 'pp') -> float:
     """
     Returns the generator infidelity between a and b, where b is the "target" operation.
     Generator infidelity is given by the sum of the squared hamiltonian error generator
@@ -783,7 +784,8 @@ def generator_infidelity(a, b, mx_basis = 'pp'):
         if coeff_block._block_type == 'other': #S terms on diagonal, added directly
             gen_infid+= _np.sum(_np.diag(coeff_block.block_data))
 
-    return _np.real_if_close(gen_infid)
+    return _np.real_if_close(gen_infid).item()
+
 
 def gateset_infidelity(model, target_model, itype='EI',
                        weights=None, mx_basis=None, is_tp=None, is_unitary=None):
@@ -2129,6 +2131,7 @@ def create_elementary_errorgen_nqudit(typ, basis_element_labels, basis_1q, norma
                                               normalize, sparse, tensorprod_basis, create_dual=False)
     return eglist[0]
 
+
 def create_elementary_errorgen_nqudit_dual(typ, basis_element_labels, basis_1q, normalize=False,
                                            sparse=False, tensorprod_basis=False):
     """
@@ -2165,6 +2168,7 @@ def create_elementary_errorgen_nqudit_dual(typ, basis_element_labels, basis_1q, 
     eglist =  _create_elementary_errorgen_nqudit([typ], [basis_element_labels], basis_1q,
                                               normalize, sparse, tensorprod_basis, create_dual=True)
     return eglist[0]
+
 
 def bulk_create_elementary_errorgen_nqudit(typ, basis_element_labels, basis_1q, normalize=False,
                                            sparse=False, tensorprod_basis=False):
@@ -2242,6 +2246,7 @@ def bulk_create_elementary_errorgen_nqudit_dual(typ, basis_element_labels, basis
 
     return _create_elementary_errorgen_nqudit(typ, basis_element_labels, basis_1q, normalize,
                                               sparse, tensorprod_basis, create_dual=True)
+
 
 def _create_elementary_errorgen_nqudit(typ, basis_element_labels, basis_1q, normalize=False,
                                        sparse=False, tensorprod_basis=False, create_dual=False):

--- a/test/unit/tools/test_lindbladtools.py
+++ b/test/unit/tools/test_lindbladtools.py
@@ -1,6 +1,7 @@
 import numpy as np
 import scipy.sparse as sps
-
+import scipy.linalg as spl
+from pygsti.tools import generator_infidelity
 from pygsti.tools import lindbladtools as lt
 from pygsti.modelmembers.operations import LindbladErrorgen
 from pygsti.baseobjs import Basis, QubitSpace
@@ -241,3 +242,17 @@ class RandomErrorgenRatesTester(BaseCase):
         #with CPTP parameterization. This should fail if the error generator dictionary is not CPTP.
         errorgen = LindbladErrorgen.from_elementary_errorgens(random_errorgen_rates, parameterization='CPTPLND', truncate=False, state_space=QubitSpace(2))
 
+    def test_respect_fidelity_constraint_issue_716(self):
+        # This test is meant to confirm that the issue described in
+        # https://github.com/sandialabs/pyGSTi/issues/716.
+        #
+        random_Honly_errors = lt.random_CPTP_error_generator_rates(
+            1, ('H',),
+            error_metric="generator_infidelity",
+            error_metric_value=1e-2,
+            label_type="local")
+        errgen = LindbladErrorgen.from_elementary_errorgens(random_Honly_errors, state_space=["Q0"])
+        noisy_ptm = spl.expm(errgen.to_dense("HilbertSchmidt"))
+        actual = generator_infidelity(noisy_ptm, np.eye(4))
+        self.assertAlmostEqual(actual, 1e-2, places=5)
+        return


### PR DESCRIPTION
This fixes issue #716 **on develop**. It's a forwarding of PR #731, which was merged into bugfix.

Description from the superceded PR is below. The additional changes in _this_ PR are to restructure a good chunk of lindbladtools.py to have shorter, more easily-maintained functions.

> Fix a bug in tools.lindbladtools.random_CPTP_error_generator_rates that was resulting in the wrong value of the fidelity or generator error when using the constraints but only one of 'H' or 'S' for the allowed error generator types. The bug arose because the code generates the S rates even when they are not returned in the final output (this should get changes, but would involve some more disentangling), meaning these were still entering into the computations to determine the relative contributions expected from each sector. To patch this we now simply check which sectors are allowed to gate the relevant parts of the computation.

---------