### PR TITLE
Return empty derivative arrays for zero-parameter models

### DIFF
--- a/pygsti/forwardsims/forwardsim.py
+++ b/pygsti/forwardsims/forwardsim.py
@@ -496,6 +496,17 @@ class ForwardSimulator(_NicelySerializable):
         global_layout = copa_layout.global_layout
 
         resource_alloc = _ResourceAllocation.cast(resource_alloc)
+        if self.model.num_params == 0:
+            # No free parameters => empty derivative arrays (avoids an opaque IndexError, see #604).
+            vdp = _np.empty((global_layout.num_elements, 0), 'd')
+            if resource_alloc.comm_rank == 0:
+                ret = _collections.OrderedDict()
+                for elInds, c, outcomes in global_layout.iter_unique_circuits():
+                    if isinstance(elInds, slice): elInds = _slct.indices(elInds)
+                    ret[c] = _ld.OutcomeLabelDict([(outLbl, vdp[ei]) for ei, outLbl in zip(elInds, outcomes)])
+                return ret
+            else:
+                return None
         with resource_alloc.temporarily_track_memory(global_layout.num_elements * self.model.num_params):  # 'EP' (vdp)
             #Note: don't use smartc for now.
             local_vdp = copa_layout.allocate_local_array('ep', 'd')
@@ -544,6 +555,16 @@ class ForwardSimulator(_NicelySerializable):
         global_layout = copa_layout.global_layout
 
         resource_alloc = _ResourceAllocation.cast(resource_alloc)
+        if self.model.num_params == 0:
+            # No free parameters => empty Hessian arrays (avoids an opaque IndexError, see #604).
+            zero_hessian = _np.empty((0, 0), 'd')
+            if resource_alloc.comm_rank == 0:
+                ret = _collections.OrderedDict()
+                for elInds, c, outcomes in global_layout.iter_unique_circuits():
+                    ret[c] = _ld.OutcomeLabelDict([(outLbl, zero_hessian) for outLbl in outcomes])
+                return ret
+            else:
+                return None
         with resource_alloc.temporarily_track_memory(global_layout.num_elements * self.model.num_params**2):  # 'EPP'
             #Note: don't use smartc for now.
             local_vhp = copa_layout.allocate_local_array('epp', 'd')

--- a/test/unit/objects/test_forwardsim.py
+++ b/test/unit/objects/test_forwardsim.py
@@ -145,6 +145,24 @@ class MapForwardSimTester(ForwardSimBase, BaseCase):
         cls.model.sim = MapForwardSimulator()
 
 
+class ZeroParamModelTester(BaseCase):
+    def test_dprobs_hprobs_empty_for_zero_param_model(self):
+        # static model has no free params -> dprobs/hprobs return empty arrays
+        # quietly instead of an opaque IndexError (#604)
+        model = smq1Q_XYI.target_model('static')
+        self.assertEqual(model.num_params, 0)
+        circuit = Circuit([L('Gxpi2', 0)], line_labels=(0,))
+        for sim in (MapForwardSimulator(), MatrixForwardSimulator()):
+            model.sim = sim
+            with self.assertNoWarns():
+                dprobs = model.sim.bulk_dprobs([circuit])
+                hprobs = model.sim.bulk_hprobs([circuit])
+            for dprob in next(iter(dprobs.values())).values():
+                self.assertEqual(dprob.shape, (0,))
+            for hprob in next(iter(hprobs.values())).values():
+                self.assertEqual(hprob.shape, (0, 0))
+
+
 class BaseProtocolData:
 
     @classmethod


### PR DESCRIPTION
Fixes #604.

For zero-parameter models, `bulk_dprobs` now returns zero-width derivative arrays and `bulk_hprobs` returns `(0, 0)` Hessian arrays. Both methods warn that the model has no free parameters. `bulk_probs` is unchanged.

Testing:
- `py -3.10 -m pytest -q test\unit\objects\test_forwardsim.py -k ZeroParamModelTester`
- `py -3.10 -m py_compile pygsti\forwardsims\forwardsim.py test\unit\objects\test_forwardsim.py`