### PR TITLE
Bind lazy cvxpy import in SDP solver

### DIFF
--- a/pygsti/tools/sdptools.py
+++ b/pygsti/tools/sdptools.py
@@ -46,6 +46,7 @@ SDP_SOLVER_PRIORITY = ['MOSEK', 'CLARABEL', 'CVXOPT']
 
 
 def solve_sdp(prob: cp.Problem, **kwargs) -> tuple[np.floating, dict[str, np.ndarray]]:
+    cp = _get_cvxpy()
 
     objective_val : np.floating = np.array(np.nan).item()
     varvals : dict[str, np.ndarray] = dict()


### PR DESCRIPTION
Follow-up to #803.

`solve_sdp` catches `cp.SolverError`, so it still needs a local `cvxpy` binding after the eager module-level import was removed. Without this, environments where the first SDP solver is unavailable fail with `NameError: name 'cp' is not defined` before trying the next solver.

Checks run:

```text
python -m pytest test/unit/tools/test_optools.py::GateOpsTester::test_diamond_distance test/unit/tools/test_optools.py::GateOpsTester::test_diamond_norm_epigraph test/unit/protocols/test_gst.py::GateSetTomographyTester::test_run_with_no_gaugeoptsuite test/test_packages/tools/test_imports.py -q
# 4 passed
```

Also verified `import pygsti` still leaves `cvxpy` unloaded before importing `grpc`.
