### PR TITLE
Enable A/D line label prefixes.

### DIFF
--- a/pygsti/circuits/circuitparser/fastcircuitparser.pyx
+++ b/pygsti/circuits/circuitparser/fastcircuitparser.pyx
@@ -273,9 +273,10 @@ cdef get_next_simple_lbl(unicode s, INT start, INT end, bool integerize_sslbls, 
                 # These reserved characters (all uppercase letters) indicate that we've already
                 # seen everything there is to see for the most recent/current label.
                 break
-            elif last == i and c in (u'Q', u'T', u'L'):
+            elif last == i and c in (u'Q', u'T', u'L', u'A', u'D'):
                 # Labels can start with reserved uppercase letters Q, T, and L, per the 
-                # StateSpace documentation.
+                # StateSpace documentation. Also added A and D for "auxiliary" or "data" qubits
+                # for interfacing with LoQS/futureproofing for QEC
                 i += 1
                 is_int = False
             elif last == i and u'A' <= c <= u'Z':

--- a/pygsti/circuits/circuitparser/slowcircuitparser.py
+++ b/pygsti/circuits/circuitparser/slowcircuitparser.py
@@ -211,9 +211,10 @@ def _get_next_simple_lbl(s, start, end, integerize_sslbls, segment):
                 # These reserved characters (all uppercase letters) indicate that we've already
                 # seen everything there is to see for the most recent/current label.
                 break
-            elif last == i and c in (u'Q', u'T', u'L'):
+            elif last == i and c in (u'Q', u'T', u'L', u'A', u'D'):
                 # Labels can start with reserved uppercase letters Q, T, and L, per the 
-                # StateSpace documentation.
+                # StateSpace documentation. Also added A and D for "auxiliary" or "data" qubits
+                # for interfacing with LoQS/futureproofing for QEC
                 i += 1
                 is_int = False
             elif last == i and u'A' <= c <= u'Z':

--- a/pygsti/tools/lindbladtools.py
+++ b/pygsti/tools/lindbladtools.py
@@ -51,9 +51,9 @@ def create_elementary_errorgen_dual(typ: Literal_HSCA, p: _np.ndarray, q: Option
     error generator `L` on an input density matrix `rho` is given by:
 
     Hamiltonian:  `L(rho) = -1j/(2d^2) * [ p, rho ]`
-    Stochastic:   `L(rho) = 1/(d^2) p * rho * p^\dag`
-    Correlation:  `L(rho) = 1/(2d^2) ( p * rho * q^\dag + q * rho * p^\dag)`
-    Active:       `L(rho) = 1j/(2d^2) ( p * rho * q^\dag - q * rho * p^\dag)`
+    Stochastic:   `L(rho) = 1/(d^2) p * rho * p^\\dag`
+    Correlation:  `L(rho) = 1/(2d^2) ( p * rho * q^\\dag + q * rho * p^\\dag)`
+    Active:       `L(rho) = 1j/(2d^2) ( p * rho * q^\\dag - q * rho * p^\\dag)`
 
     where `d` is the dimension of the Hilbert space, e.g. 2 for a single qubit.  Square
     brackets denotes the commutator and curly brackets the anticommutator.
@@ -263,9 +263,9 @@ def create_elementary_errorgen(typ : Literal_HSCA, p: _np.ndarray,
     error generator `L` on an input density matrix `rho` is given by:
 
     Hamiltonian:  `L(rho) = -1j * [ p, rho ]`
-    Stochastic:   `L(rho) = p * rho * p^\dag - 0.5*{p^\dag p, rho}`
-    Correlation:  `L(rho) = p * rho * q^\dag + q * rho * p^\dag - 0.5 {(p^\dag @ q + q^\dag @ p), rho}`
-    Active:       `L(rho) = 1j( p * rho * q^\dag - q * rho * p^\dag + 0.5 {(p^\dag @ q - q^\dag @ p)), rho} )`
+    Stochastic:   `L(rho) = p * rho * p^\\dag - 0.5*{p^\\dag p, rho}`
+    Correlation:  `L(rho) = p * rho * q^\\dag + q * rho * p^\\dag - 0.5 {(p^\\dag @ q + q^\\dag @ p), rho}`
+    Active:       `L(rho) = 1j( p * rho * q^\\dag - q * rho * p^\\dag + 0.5 {(p^\\dag @ q - q^\\dag @ p)), rho} )`
 
     Square brackets denotes the commutator and curly brackets the anticommutator.
     `L` is returned as a superoperator matrix that acts on vectorized density matrices.

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -88,7 +88,7 @@ class CircuitTester(BaseCase):
 
     def test_construct_malformed_input(self):
         with pytest.raises(ValueError):
-            c = circuit.Circuit([("Gxpi2", "A0")])
+            c = circuit.Circuit([("Gxpi2", "B0")])
         return
 
     def test_create_circuitlabel(self):


### PR DESCRIPTION
Short fix for #809 that enables the use of A and D prefixes on line labels for Circuits, primarily for use with labeling qubits as "auxiliary" or "data", respectively.

Also fixes a few unescaped \ characters in docstrings since these warn out in Python 3.14.