### PR TITLE
Notebook regression fixes

### DIFF
--- a/docs/markdown/simulation/DataSimulation.md
+++ b/docs/markdown/simulation/DataSimulation.md
@@ -78,8 +78,8 @@ class MyDataSimulator(pygsti.protocols.ModelFreeformSimulator):
         B = process_matrices['target']
         ret['process fidelity'] = pygsti.tools.entanglement_fidelity(A, B, 'pp')
         
-        state = pygsti.tools.ppvec_to_stdmx(final_states['base'])  
-        target_state = pygsti.tools.ppvec_to_stdmx(final_states['target'])
+        state = pygsti.tools.ppvec_to_stdmx(final_states['base'].to_dense())  
+        target_state = pygsti.tools.ppvec_to_stdmx(final_states['target'].to_dense())
         ret['final state fidelity'] = pygsti.tools.fidelity(state, target_state)
         
         p = probs['base']

--- a/pygsti/algorithms/fiducialpairreduction.py
+++ b/pygsti/algorithms/fiducialpairreduction.py
@@ -1522,7 +1522,7 @@ def construct_compact_evd_cache(fiducial_indices, complete_jacobian, element_map
     for fid_index in fiducial_indices:
         fid_element_indices = element_map[fid_index]
         fid_jacobian_components = _np.take(complete_jacobian, fid_element_indices, axis=0)
-        e, U = compact_EVD(fid_jacobian_components.T@fid_jacobian_components, eigenvalue_tolerance)
+        e, U = compact_EVD(fid_jacobian_components.T@fid_jacobian_components, eigenvalue_tolerance, assume_hermitian=True)
         sqrteU_dict[fid_index]= U@_np.diag(_np.sqrt(e))  
     return sqrteU_dict    
     
@@ -2015,7 +2015,7 @@ def _compute_bulk_directional_ddd_compact(model, circuits, vec_mat, eps,
                 directional_deriv = jac@vec_mat
                 direc_deriv_gram = directional_deriv.T@directional_deriv                                        
                 #now take twirledDerivDerivDagger and construct its compact EVD.
-                e, U= compact_EVD(direc_deriv_gram, evd_tol)
+                e, U= compact_EVD(direc_deriv_gram, evd_tol, assume_hermitian=True)
                 e_list.append(e)
                 
                 #by doing this I am assuming that the matrix is PSD, but since these are all
@@ -2042,7 +2042,7 @@ def _compute_bulk_directional_ddd_compact(model, circuits, vec_mat, eps,
             direc_deriv_gram = directional_deriv.T@directional_deriv
     
             #now take twirledDerivDerivDagger and construct its compact EVD.
-            e, U= compact_EVD(direc_deriv_gram, evd_tol)
+            e, U= compact_EVD(direc_deriv_gram, evd_tol, assume_hermitian=True)
             e_list.append(e)
 
             sqrteU_list.append( U@_np.diag(_np.sqrt(e)) )         

--- a/pygsti/algorithms/fiducialselection.py
+++ b/pygsti/algorithms/fiducialselection.py
@@ -1861,7 +1861,7 @@ def construct_compact_evd_cache(model, fids_list, prep_or_meas, fid_cache, eigen
         fid_mat= _np.concatenate(fidArrayList, axis=1)
         fid_mat_gramian = fid_mat@fid_mat.conj().T
         
-        e, U = compact_EVD(fid_mat_gramian, eigenvalue_tolerance)
+        e, U = compact_EVD(fid_mat_gramian, eigenvalue_tolerance, assume_hermitian=True)
         sqrteU_dict[fiducial]= U@_np.diag(_np.sqrt(e))  
         
         #check reconstruction:

--- a/pygsti/algorithms/germselection.py
+++ b/pygsti/algorithms/germselection.py
@@ -4852,8 +4852,7 @@ def germ_set_spanning_vectors(target_model, germ_list, float_type=None,
                 current_vec_score = compute_composite_vector_set_score(
                                                 current_update_cache= current_update_cache,
                                                 vector_update= composite_twirled_deriv_array[:, [idx]],
-                                                num_nongauge_params= numNonGaugeParams,
-                                                float_type= float_type)
+                                                num_nongauge_params= numNonGaugeParams)
 
                 if current_vec_score < best_vec_score:
                     best_vec_score = current_vec_score


### PR DESCRIPTION
Fixes 3 bugs caught by the notebook regression tests on develop.

- Adds 2 missing to_dense calls.
- Correctly sets the assume_hermitian flag in compact_EVD
- Removes an incorrect float_type arguments.