### PR TITLE
Release of pygsti 0.10.1

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 # CHANGELOG
 
-## [0.10] - 2026-07-03
+## [0.10.1] - 2026-07-06
+
+Bugfix release. The only updates are to pyproject.toml to declare import-time dependencies.
+Thanks to @basnijholt for reporting this bug and creating a PR to fix.
+
+## [0.10.0] - 2026-07-03
 
 Major new features: symbolic error generator propagation (error generator polynomials), Lindblad-parameterized instruments, new GST objective functions, a generalized `pygsti.leakage` subpackage, turn-key MPI/SLURM helpers, and JupyterBook/ReadTheDocs documentation. Supported Python versions are now 3.10-3.13.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,7 +54,6 @@ This is a bugfix release patching the following issues:
 
 Development-related change: Pushes to the `bugfix` branch no longer trigger automatic merges into `develop`, and these changes will need to be merged in manually going forward.
 
-
 ## [0.9.14.2] - 2025-11-08
 
 This is a bugfix release patching the following issues:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies=[
     'stim',
     'plotly>=3.8.0',
     'pandas',
+    'matplotlib',
     'networkx',
+    'typing_extensions',
     'tqdm>=4.42.0'
 ]
 requires-python='>=3.10'


### PR DESCRIPTION
This PR has `develop` merging into `master`. Once merged, it will mark the release of pygsti 0.10.1.