### PR TITLE
Document no-op local array cleanup

### DIFF
--- a/pygsti/layouts/copalayout.py
+++ b/pygsti/layouts/copalayout.py
@@ -364,19 +364,23 @@ class CircuitOutcomeProbabilityArrayLayout(_NicelySerializable):
         """
         Frees an array allocated by :meth:`allocate_local_array`.
 
-        This method should always be paired with a call to
-        :meth:`allocate_local_array`, since the allocated array
-        may utilize shared memory, which must be explicitly de-allocated.
+        This layout allocates plain NumPy arrays, so there are no external
+        shared-memory handles to release.  This method is intentionally a
+        no-op, but exists so callers can pair every
+        :meth:`allocate_local_array` call with a matching free call without
+        checking the concrete layout type.
 
         Parameters
         ----------
-        local_array : numpy.ndarray or LocalNumpyArray
-            The array to free, as returned from `allocate_local_array`.
+        local_array : numpy.ndarray
+            The NumPy array to free, as returned from `allocate_local_array`.
 
         Returns
         -------
         None
         """
+        # See pyGSTi issue #698.  Distributed layouts may need explicit shared-memory
+        # cleanup; this local layout does not.
         pass
 
     def gather_local_array_base(self, array_type, array_portion, extra_elements=0,

--- a/test/unit/objects/test_forwardsim.py
+++ b/test/unit/objects/test_forwardsim.py
@@ -54,6 +54,18 @@ class AbstractForwardSimTester(BaseCase):
         with self.assertRaises(NotImplementedError):
             self.fwdsim.bulk_fill_hprobs(np.zeros((1,0,0)), layout)
 
+    def test_free_local_array_is_noop_for_numpy_array(self):
+        layout = self.fwdsim.create_layout([self.circuit], array_types=('e',))
+        local_array = layout.allocate_local_array('e', 'd', zero_out=True)
+        local_array[0] = 1.0
+
+        with self.assertNoWarns():
+            self.assertIsNone(layout.free_local_array(local_array))
+
+        self.assertIsInstance(local_array, np.ndarray)
+        self.assertEqual(local_array.shape, (layout.num_elements,))
+        self.assertEqual(local_array[0], 1.0)
+
 
 class ForwardSimBase(object):
     @classmethod


### PR DESCRIPTION
Fixes #698.

`CircuitOutcomeProbabilityArrayLayout.allocate_local_array` returns a plain NumPy array, so `free_local_array` has no shared-memory handle to release. The method is still useful as part of the layout API because callers can pair every allocation with a free call without checking the concrete layout type.

This updates the stale docstring, adds the issue pointer requested in the discussion, and adds a small test for the no-op local cleanup contract.

Testing, Python 3.10 local no-Cython install:
- `python -m py_compile pygsti\layouts\copalayout.py test\unit\objects\test_forwardsim.py`
- `git diff --check`
- `python -m flake8 . --count --show-source --statistics --config=.flake8-critical`
- `python -m pytest -q test\unit\objects\test_forwardsim.py -k "free_local_array_is_noop_for_numpy_array or dprobs_hprobs_empty_for_zero_param_model"`
- `python -m pytest -q test\unit\objects\test_forwardsim.py`