### PR TITLE
Qiskit interop: warning hygiene, 3.0-proofing, honest dependency floors

### DIFF
--- a/.github/workflows/qiskit-interop.yml
+++ b/.github/workflows/qiskit-interop.yml
@@ -1,0 +1,64 @@
+# Weekly qiskit interop version-matrix job.
+#
+# The qiskit-facing test files run against the floor and the latest of the tested
+# qiskit range (TESTED_QISKIT_RANGE in pygsti/tools/_qiskit_interop.py, mirrored by
+# the 'ibmq' extra in pyproject.toml), so the range stays continuously honest: when
+# a new qiskit release breaks the interop -- most notably qiskit 3.0 -- this flags
+# it when it ships instead of at user-report time.
+
+name: Qiskit interop version matrix
+
+on:
+  schedule:
+    - cron: '17 6 * * 1' # weekly, Mondays 06:17 UTC
+  workflow_dispatch: # Allow manual running from GitHub
+
+jobs:
+  qiskit-interop:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Floor of the tested conversion range, without qiskit-ibm-runtime
+          # (no runtime release is compatible with both qiskit 1.4 and our
+          # declared runtime floor): the circuit-conversion/mirroring interop
+          # supports bare qiskit 1.4; runtime-dependent tests skip themselves.
+          - label: qiskit-floor-no-runtime
+            pins: 'qiskit==1.4.*'
+            uninstall-runtime: true
+          # Floor of the declared ibmq extra (runtime 0.44 adds the optional
+          # ConvertToMidCircuitMeasure pass; 0.40 is the supported floor without it).
+          - label: runtime-floor
+            pins: 'qiskit-ibm-runtime==0.40.* qiskit<3'
+          # Whatever pip resolves today.
+          - label: latest
+            pins: 'qiskit qiskit-ibm-runtime'
+    name: Qiskit interop (${{ matrix.label }})
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+    - name: Install pyGSTi and test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # testing_no_cython_mpi already pulls in the ibmq extra; the matrix pins
+        # then override the resolved qiskit/runtime versions.
+        python -m pip install -e .[testing_no_cython_mpi]
+        if [ "${{ matrix.uninstall-runtime }}" = "true" ]; then
+          python -m pip uninstall -y qiskit-ibm-runtime
+        fi
+        python -m pip install ${{ matrix.pins }}
+        python -c "import qiskit; print('qiskit', qiskit.__version__)"
+        python -c "import qiskit_ibm_runtime; print('runtime', qiskit_ibm_runtime.__version__)" || echo "qiskit-ibm-runtime not installed"
+    - name: Run qiskit interop tests
+      run: |
+        python -m pytest -v \
+          test/unit/tools/test_qiskit_interop.py \
+          test/unit/circuits/test_circuit.py \
+          test/unit/objects/test_subcirc_selection.py \
+          test/unit/protocols/test_mirror_edesign.py \
+          test/unit/protocols/test_scarab.py \
+          test/unit/extras/ibmq/test_ibmqexperiment.py

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -29,6 +29,7 @@ from pygsti.tools import internalgates as _itgs
 from pygsti.tools import slicetools as _slct
 from pygsti.tools.exceptions import ImplicitlyDoneEditingCircuitWarning
 from pygsti.tools.exceptions import QiskitInteropWarning as _QiskitInteropWarning
+from pygsti.tools._qiskit_interop import check_qiskit_version as _check_qiskit_version
 from pygsti.tools.legacytools import deprecate as _deprecate_fn
 
 
@@ -4289,6 +4290,7 @@ class Circuit(object):
                     qiskit_gate_conversion: Optional[Dict[str, str]] = None,
                     use_standard_gate_conversion_as_backup: bool = True,
                     allow_different_gates_in_same_layer: bool = True,
+                    lossy: Literal['warn', 'ignore', 'raise'] = 'warn',
                     verbose: bool = False
                     ) -> Tuple[Circuit, Dict[int, str]]:
         """
@@ -4322,6 +4324,15 @@ class Circuit(object):
             they will either be placed in the same layer (if True) or split into
             separate layers (if False).
 
+        lossy : {'warn', 'ignore', 'raise'}, optional (default 'warn')
+            Controls how lossy aspects of the conversion are reported. The conversion
+            is lossy when the Qiskit circuit contains structure that a pyGSTi Circuit
+            cannot represent: multiple quantum registers (qreg structure is flattened),
+            classical registers/bits (discarded), or measure instructions (dropped).
+            If 'warn', a QiskitInteropWarning is emitted for each kind of loss.
+            If 'ignore', the conversion silently proceeds.
+            If 'raise', a ValueError is raised instead.
+
         Returns
         -------
         Tuple:
@@ -4333,14 +4344,16 @@ class Circuit(object):
                 to the corresponding pyGSTi qubit.
         """
 
-        try:
-            import qiskit
-            if qiskit.__version__ != '2.1.1':
-                _warnings.warn("Circuit class method `from_qiskit()` is designed for qiskit version 2.1.1 and may not \
-                                function properly for your qiskit version, which is " + qiskit.__version__,
-                               _QiskitInteropWarning)
-        except:
-            raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+        _check_qiskit_version('Circuit.from_qiskit()')
+
+        assert lossy in ('warn', 'ignore', 'raise'), \
+            f"'lossy' must be 'warn', 'ignore', or 'raise', not {lossy!r}"
+
+        def _lossy_notice(message):
+            if lossy == 'warn':
+                _warnings.warn(message, _QiskitInteropWarning, stacklevel=3)
+            elif lossy == 'raise':
+                raise ValueError(message)
 
         # mapping between qiskit gates and pygsti gate names:
         if qiskit_gate_conversion is not None:
@@ -4355,12 +4368,10 @@ class Circuit(object):
 
         # get all of the qubits in the Qiskit circuit
         if len(circuit.qregs) > 1:
-            _warnings.warn('pyGSTi circuit mapping does not preserve Qiskit qreg structure.',
-                           _QiskitInteropWarning)
+            _lossy_notice('pyGSTi circuit mapping does not preserve Qiskit qreg structure.')
 
-        if len(circuit.cregs):
-            _warnings.warn('pyGSTi circuit mapping discards classical registers.',
-                           _QiskitInteropWarning)
+        if len(circuit.clbits):
+            _lossy_notice('pyGSTi circuit mapping discards classical registers and classical bits.')
 
         qubits = circuit.qubits
 
@@ -4369,14 +4380,12 @@ class Circuit(object):
             unmapped_qubits = set(qubits).difference(set(qubit_conversion.keys()))
             assert len(unmapped_qubits) == 0, f'Missing Qiskit to pygsti conversions for some qubits: {unmapped_qubits}'
 
-            qubit_idx_conversion = {i: qubit_conversion[circuit._qbit_argument_conversion(i)[0]] for i in range(circuit.num_qubits)}
+            qubit_idx_conversion = {i: qubit_conversion[circuit.qubits[i]] for i in range(circuit.num_qubits)}
 
         #if it is None, build a default mapping.
         else:
             # default mapping is the identity mapping: qubit i in the Qiskit circuit maps to qubit i in the pyGSTi circuit
-            qubit_conversion = {circuit._qbit_argument_conversion(i)[0]: f'Q{i}' for i in range(circuit.num_qubits)}
-            # ^ in Qiskit 1.1.1, the method is called qbit_argument_conversion. In Qiskit >=1.2 (as far as Noah can tell),
-            #   the method is called _qbit_argument_conversion.
+            qubit_conversion = {circuit.qubits[i]: f'Q{i}' for i in range(circuit.num_qubits)}
 
             qubit_idx_conversion = {i: f'Q{i}' for i in range(circuit.num_qubits)}
 
@@ -4418,7 +4427,8 @@ class Circuit(object):
             pygsti_gate_qubits = [qubit_conversion[qubit] for qubit in instruction.qubits]
 
             if name == 'measure':
-                _warnings.warn('skipping measure')
+                _lossy_notice('Circuit.from_qiskit() drops measure instructions; measurement '
+                              'outcomes are not represented in the pyGSTi circuit.')
                 continue
 
             if name == 'barrier':
@@ -4691,14 +4701,7 @@ class Circuit(object):
             a Qiskit QuantumCircuit corresponding to the pyGSTi circuits.
         """
 
-        try:
-            import qiskit
-            if qiskit.__version__ != '2.1.1':
-                _warnings.warn("Circuit class method `convert_to_qiskit()` is designed for qiskit version 2.1.1 and may not \
-                                function properly for your qiskit version, which is " + qiskit.__version__,
-                               _QiskitInteropWarning)
-        except:
-            raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+        qiskit = _check_qiskit_version('Circuit.convert_to_qiskit()')
 
         depth = self.depth
 

--- a/pygsti/circuits/subcircuit_selection.py
+++ b/pygsti/circuits/subcircuit_selection.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     except ImportError:
         pass
 
-import warnings as _warnings
 from collections import defaultdict as _defaultdict
 import networkx as _nx
 
@@ -31,21 +30,8 @@ from pygsti.circuits.circuit import Circuit as _Circuit
 from pygsti.baseobjs.label import Label as _Label
 from pygsti.protocols.protocol import FreeformDesign as _FreeformDesign
 from pygsti.tools import internalgates as _itgs
-from pygsti.tools.exceptions import MissingDependencyWarning, QiskitInteropWarning
+from pygsti.tools._qiskit_interop import check_qiskit_version as _check_qiskit_version
 
-
-QISKIT_VERSION_MISMATCH_MESSAGE_TEMPLATE = \
-f"""
-Simple subcircuit selection with a qiskit CouplingMap and/or InstructionDurations object
-is designed for qiskit version 2.1.1, and may not function properly for your qiskit version,
-which is %s.
-"""
-
-QISKIT_MISSING_MESSAGE = \
-"""
-Qiskit is required if using a CouplingMap or InstructionDurations object
-for subcircuit selection, and does not appear to be installed.
-"""
 
 MAX_STARTING_LAYER_ATTEMPTS = 1000
 
@@ -127,13 +113,8 @@ def sample_subcircuits(full_circs: Union[_Circuit, List[_Circuit]],
         A FreeformDesign object containing the sampled subcircuits and auxiliary
         information, including a circuit ID and depth.
     """
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn(QISKIT_VERSION_MISMATCH_MESSAGE_TEMPLATE % qiskit.__version__, QiskitInteropWarning)
-    except:
-        _warnings.warn(QISKIT_MISSING_MESSAGE, MissingDependencyWarning)
-    
+    _check_qiskit_version('sample_subcircuits()', required=False)
+
     if rand_state is None:
         rand_state = _np.random.RandomState()
     
@@ -260,12 +241,7 @@ def simple_weighted_subcirc_selection(full_circ: _Circuit,
         the number of dangling gates in each subcircuit and the indices of added layers.
     """
 
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn(QISKIT_VERSION_MISMATCH_MESSAGE_TEMPLATE % qiskit.__version__, QiskitInteropWarning)
-    except:
-        _warnings.warn(QISKIT_MISSING_MESSAGE, MissingDependencyWarning)
+    qiskit = _check_qiskit_version('simple_weighted_subcirc_selection()', required=False)
 
     full_width = len(full_circ.line_labels)
     full_depth = len(full_circ)
@@ -320,13 +296,10 @@ def simple_weighted_subcirc_selection(full_circ: _Circuit,
         layer_durations = []
 
         if use_qiskit_for_instruction_durations is None:
-            try:
-                if isinstance(instruction_durations, qiskit.transpiler.InstructionDurations):
-                    use_qiskit_for_instruction_durations = True
-                    gate_name_conversions = _itgs.standard_gatenames_qiskit_conversions() 
-                else:
-                    use_qiskit_for_instruction_durations = False
-            except:
+            if qiskit is not None and isinstance(instruction_durations, qiskit.transpiler.InstructionDurations):
+                use_qiskit_for_instruction_durations = True
+                gate_name_conversions = _itgs.standard_gatenames_qiskit_conversions()
+            else:
                 use_qiskit_for_instruction_durations = False
 
 
@@ -360,14 +333,13 @@ def simple_weighted_subcirc_selection(full_circ: _Circuit,
             G.add_edges_from(coupling_map)
             qubit_subset = random_connected_subgraph(G, width, rand_state)
 
-        else: # likely the coupling_map is a CouplingMap instance    
-            try:
-                if not isinstance(coupling_map, qiskit.transpiler.CouplingMap):
-                    raise RuntimeError("If `coupling_map` is not 'all-to-all, 'linear', or a list," \
-                    "it must be a qiskit CouplingMap object.")
-            except:
-                raise ImportError('Qiskit is required when providing a CouplingMap for subcircuit selection,' \
-                'and does not appear to be installed.')
+        else: # likely the coupling_map is a CouplingMap instance
+            if qiskit is None:
+                raise ImportError('Qiskit is required when providing a CouplingMap for subcircuit selection, '
+                                  'and does not appear to be installed.')
+            if not isinstance(coupling_map, qiskit.transpiler.CouplingMap):
+                raise RuntimeError("If `coupling_map` is not 'all-to-all', 'linear', or a list, "
+                                   "it must be a qiskit CouplingMap object.")
 
             edges = []
             for cs in coupling_map:

--- a/pygsti/extras/ibmq/ibmqexperiment.py
+++ b/pygsti/extras/ibmq/ibmqexperiment.py
@@ -32,29 +32,26 @@ except:
     _GenericBackendV2 = None
 
 # Try to load IBM Runtime
-try: 
-    from qiskit_ibm_runtime.transpiler.passes import ConvertToMidCircuitMeasure
+try:
     from qiskit_ibm_runtime import SamplerV2 as _Sampler
     from qiskit_ibm_runtime import Session as _Session
     from qiskit_ibm_runtime import RuntimeJobV2 as _RuntimeJobV2
     from qiskit_ibm_runtime import IBMBackend as _IBMBackend
-except:
+except ImportError:
     _Sampler = None
+
+# The ConvertToMidCircuitMeasure pass was added in qiskit-ibm-runtime 0.44, so guard it
+# separately: older runtimes can still submit jobs as long as they don't need the
+# mid-circuit-measurement conversion.
+try:
+    from qiskit_ibm_runtime.transpiler.passes import ConvertToMidCircuitMeasure
+except ImportError:
+    ConvertToMidCircuitMeasure = None
 
 try:
     from qiskit_aer import AerSimulator as _AerSimulator
-except:
+except ImportError:
     _AerSimulator = None
-
-# Tim updated to Qiskit 2.1.0
-# OLD COMMENT FROM STEFAN?
-# # Most recent version of QisKit that this has been tested on:
-# # qiskit.__version__ = '1.1.1'
-# # qiskit_ibm_runtime.__version__ = '0.25.0'
-# # Note that qiskit<1.0 is going EOL in August 2024,
-# # and v1 backends are also being deprecated (we now support only v2)
-# # Also qiskit-ibm-provider is ALSO being deprecated,
-# # so I'm only supporting runtime here
 
 try:
     from bson import json_util as _json_util
@@ -723,6 +720,10 @@ class IBMQExperiment(_TreeNode, _HasPSpec):
         # into measure_2, but only if the backend advertises measure_2.
         mcm_pm = None
         if 'measure_2' in ibmq_backend.operation_names and use_ibm_mcm:
+            assert ConvertToMidCircuitMeasure is not None, \
+                ("Converting mid-circuit measurements requires the ConvertToMidCircuitMeasure "
+                 "transpiler pass, which was added in qiskit-ibm-runtime 0.44. Upgrade "
+                 "qiskit-ibm-runtime or set use_ibm_mcm=False.")
             mcm_pm = _PassManager([
                 ConvertToMidCircuitMeasure(
                     target=ibmq_backend.target,

--- a/pygsti/protocols/mirror_edesign.py
+++ b/pygsti/protocols/mirror_edesign.py
@@ -261,10 +261,10 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
         """
 
         active_qubits = set()
-        for instruction, qargs, _ in circ.data:
-            if instruction.name in ignore:
+        for instruction in circ.data:
+            if instruction.operation.name in ignore:
                 continue
-            for qubit in qargs:
+            for qubit in instruction.qubits:
                 active_qubits.add(qubit)
 
         return active_qubits
@@ -309,9 +309,8 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
             uses_ancilla = False
 
             for qubit in active_qubits:
-                idx = qubit._index
-                init_register = qk_test_circ.layout.initial_layout[idx]._register
-                if init_register.name == 'ancilla':
+                idx = qk_test_circ.find_bit(qubit).index
+                if isinstance(qk_test_circ.layout.initial_layout[idx], qiskit.circuit.AncillaQubit):
                     uses_ancilla = True
                     print(qubit)
                     break
@@ -372,9 +371,8 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
             uses_ancilla = False
 
             for qubit in active_qubits:
-                idx = qubit._index
-                init_register = qk_ref_inv_circ.layout.initial_layout[idx]._register
-                if init_register.name == 'ancilla':
+                idx = qk_ref_inv_circ.find_bit(qubit).index
+                if isinstance(qk_ref_inv_circ.layout.initial_layout[idx], qiskit.circuit.AncillaQubit):
                     uses_ancilla = True
                     print(qubit)
                     break
@@ -393,7 +391,7 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
 
         qk_ref_circ = qk_ref_inv_circ.inverse()
 
-        qubit_map = {qk_ref_inv_circ._qbit_argument_conversion(i)[0]: f'Q{qk_final_opt_layout[i]}'
+        qubit_map = {qk_ref_inv_circ.qubits[i]: f'Q{qk_final_opt_layout[i]}'
                          for i in qk_init_ref_inv_reduced_layout}
 
         ps_ref_circ, qubit_idx_map = _Circuit.from_qiskit(qk_ref_circ, qubit_conversion=qubit_map,
@@ -573,8 +571,7 @@ def qiskit_circuits_to_subcircuit_mirror_edesign(
                                     )
 
             # convert those reference circuits back to pyGSTi (layer blocking required to separate u3 and cz)
-            qubit_mapping_dict_2 = {qk_test_circ._qbit_argument_conversion(i)[0]: sslbl for sslbl, i in qubit_mapping_dict.items()} # now map back
-            # in Qiskit 1.1.1, the method is called qbit_argument_conversion. In Qiskit >=1.2 (as far as Noah can tell), the method is called _qbit_argument_conversion.
+            qubit_mapping_dict_2 = {qk_test_circ.qubits[i]: sslbl for sslbl, i in qubit_mapping_dict.items()} # now map back
 
             ps_ref_circ, _ = _Circuit.from_qiskit(qk_ref_circ,
                                                   qubit_conversion=qubit_mapping_dict_2,

--- a/pygsti/protocols/mirror_edesign.py
+++ b/pygsti/protocols/mirror_edesign.py
@@ -32,6 +32,7 @@ from pygsti.protocols.protocol import FreeformDesign as _FreeformDesign
 from pygsti.protocols.protocol import CombinedExperimentDesign as _CombinedExperimentDesign
 from pygsti.processors import random_compilation as _rc
 from pygsti.tools.exceptions import QiskitInteropWarning as _QiskitInteropWarning
+from pygsti.tools._qiskit_interop import check_qiskit_version as _check_qiskit_version
 
 
 def qiskit_circuits_to_mirror_edesign(qk_circs: Union[Dict[Any, qiskit.QuantumCircuit], List[qiskit.QuantumCircuit]],
@@ -71,16 +72,8 @@ def qiskit_circuits_to_mirror_edesign(qk_circs: Union[Dict[Any, qiskit.QuantumCi
                 Experiment design containing all mirror circuits that must be executed
                 in order to perform mirror circuit fidelity estimation.         
     """
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("The function 'qiskit_circuits_to_mirror_edesign' is designed for qiskit 2.1.1." \
-            "Your version is " + qiskit.__version__,
-                           _QiskitInteropWarning)
-
-        from qiskit import transpile
-    except:
-        raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+    _check_qiskit_version('qiskit_circuits_to_mirror_edesign()')
+    from qiskit import transpile
 
     test_circ_dict = defaultdict(list)
     ref_circ_dict = defaultdict(list)
@@ -100,8 +93,10 @@ def qiskit_circuits_to_mirror_edesign(qk_circs: Union[Dict[Any, qiskit.QuantumCi
                                 approximation_degree=1.0,
                                 seed_transpiler=0)
         
-        ps_test_circ, _ = _Circuit.from_qiskit(qk_test_circ, allow_different_gates_in_same_layer=True)
-        ps_ref_circ, _ = _Circuit.from_qiskit(qk_ref_circ, allow_different_gates_in_same_layer=False)
+        ps_test_circ, _ = _Circuit.from_qiskit(qk_test_circ, allow_different_gates_in_same_layer=True,
+                                               lossy='ignore')
+        ps_ref_circ, _ = _Circuit.from_qiskit(qk_ref_circ, allow_different_gates_in_same_layer=False,
+                                              lossy='ignore')
 
         ps_test_circ = ps_test_circ.delete_idling_lines()
         ps_ref_circ = ps_ref_circ.delete_idling_lines()
@@ -227,18 +222,18 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
                 amount of time spent in Qiskit transpiler.        
     """
 
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("The function 'qiskit_circuits_to_fullstack_mirror_edesign' is designed for qiskit 2.1.1." \
-            "Your version is " + qiskit.__version__,
-                           _QiskitInteropWarning)
-        from qiskit import transpile
-    except:
-        raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+    qiskit = _check_qiskit_version('qiskit_circuits_to_fullstack_mirror_edesign()')
+    from qiskit import transpile
 
     if qk_backend is None:
         assert coupling_map is not None and basis_gates is not None, "'coupling_map' and 'basis_gates' must be provided if 'qk_backend is not provided."
+    else:
+        if coupling_map is not None:
+            _warnings.warn("'coupling_map' is ignored when 'qk_backend' is provided.",
+                           _QiskitInteropWarning)
+        if basis_gates is not None:
+            _warnings.warn("'basis_gates' is ignored when 'qk_backend' is provided.",
+                           _QiskitInteropWarning)
 
 
     def get_active_qubits_no_dag(circ: qiskit.QuantumCircuit,
@@ -297,16 +292,8 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
             if return_qiskit_time: start = time.time()
 
             if qk_backend is not None:
-                if coupling_map is not None:
-                    _warnings.warn("'coupling_map' is ignored when 'qk_backend' is provided.",
-                                   _QiskitInteropWarning)
-                if basis_gates is not None:
-                    _warnings.warn("'basis_gates' is ignored when 'qk_backend' is provided.",
-                                   _QiskitInteropWarning)
-
                 qk_test_circ = transpile(qk_circ,
                                          backend=qk_backend,
-                                         coupling_map=coupling_map,
                                          **transpiler_kwargs_dict)
             else:
                 qk_test_circ = transpile(qk_circ,
@@ -339,7 +326,8 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
 
         assert set(qk_init_opt_layout) == set(qk_final_opt_layout)
 
-        ps_test_circ, qubit_mapping = _Circuit.from_qiskit(qk_test_circ, allow_different_gates_in_same_layer=False)
+        ps_test_circ, qubit_mapping = _Circuit.from_qiskit(qk_test_circ, allow_different_gates_in_same_layer=False,
+                                                           lossy='ignore')
         ps_test_circ = ps_test_circ.delete_idling_lines()
 
         assert len(ps_test_circ.line_labels) <= num_virtual_qubits
@@ -408,7 +396,9 @@ def qiskit_circuits_to_fullstack_mirror_edesign(
         qubit_map = {qk_ref_inv_circ._qbit_argument_conversion(i)[0]: f'Q{qk_final_opt_layout[i]}'
                          for i in qk_init_ref_inv_reduced_layout}
 
-        ps_ref_circ, qubit_idx_map = _Circuit.from_qiskit(qk_ref_circ, qubit_conversion=qubit_map, allow_different_gates_in_same_layer=False)
+        ps_ref_circ, qubit_idx_map = _Circuit.from_qiskit(qk_ref_circ, qubit_conversion=qubit_map,
+                                                          allow_different_gates_in_same_layer=False,
+                                                          lossy='ignore')
         ps_ref_circ = ps_ref_circ.delete_idling_lines()
 
         assert len(ps_ref_circ.line_labels) <= num_virtual_qubits
@@ -523,24 +513,18 @@ def qiskit_circuits_to_subcircuit_mirror_edesign(
                 if `aggregate_subcircs` is False, otherwise a FreeformDesign is returned.
     """
 
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("The function 'qiskit_circuits_to_subcircuit_mirror_edesign' is designed for qiskit 2.1.1." \
-            "Your version is " + qiskit.__version__,
-                           _QiskitInteropWarning)
+    _check_qiskit_version('qiskit_circuits_to_subcircuit_mirror_edesign()')
+    from qiskit import transpile
 
-        from qiskit import transpile
-    except:
-        raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
-    
+
     if isinstance(qk_circs, list):
         qk_circs = {i: qk_circ for i, qk_circ in enumerate(qk_circs)}
 
 
     ps_circs = {}
     for k, qk_circ in qk_circs.items():
-        ps_circ, _ = _Circuit.from_qiskit(qk_circ, allow_different_gates_in_same_layer=True)
+        ps_circ, _ = _Circuit.from_qiskit(qk_circ, allow_different_gates_in_same_layer=True,
+                                          lossy='ignore')
         ps_circ = ps_circ.delete_idling_lines()
 
         ps_circs[k] = ps_circ
@@ -593,7 +577,9 @@ def qiskit_circuits_to_subcircuit_mirror_edesign(
             # in Qiskit 1.1.1, the method is called qbit_argument_conversion. In Qiskit >=1.2 (as far as Noah can tell), the method is called _qbit_argument_conversion.
 
             ps_ref_circ, _ = _Circuit.from_qiskit(qk_ref_circ,
-                                                  qubit_conversion=qubit_mapping_dict_2, allow_different_gates_in_same_layer=False)
+                                                  qubit_conversion=qubit_mapping_dict_2,
+                                                  allow_different_gates_in_same_layer=False,
+                                                  lossy='ignore')
             ps_ref_circ = ps_ref_circ.delete_idling_lines()
             
             for aux in auxlist:

--- a/pygsti/protocols/scarab.py
+++ b/pygsti/protocols/scarab.py
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
         pass
 
 
-import warnings as _warnings
-
 from pygsti.protocols import (
     ProtocolData as _ProtocolData,
     FreeformDesign as _FreeformDesign,
@@ -29,7 +27,7 @@ from pygsti.protocols import (
     VBDataFrame as _VBDataFrame,
     mirror_edesign as _mirror
 )
-from pygsti.tools.exceptions import QiskitInteropWarning as _QiskitInteropWarning
+from pygsti.tools._qiskit_interop import check_qiskit_version as _check_qiskit_version
 
 import numpy as _np
 
@@ -72,15 +70,7 @@ def lowlevel_mirror_benchmark(qk_circs: Union[Dict[Any, qiskit.QuantumCircuit], 
                 in order to perform mirror circuit fidelity estimation.
     """
 
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("The function 'noise_mirror_benchmark' is designed for qiskit 2.1.1." \
-            "Your version is " + qiskit.__version__,
-                           _QiskitInteropWarning)
-
-    except:
-        raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+    _check_qiskit_version('lowlevel_mirror_benchmark()')
 
     return _mirror.qiskit_circuits_to_mirror_edesign(qk_circs, mirroring_kwargs_dict)
 
@@ -170,15 +160,7 @@ def fullstack_mirror_benchmark(qk_circs: Union[Dict[Any, qiskit.QuantumCircuit],
                 amount of time spent in Qiskit transpiler.            
     """
 
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("The function 'fullstack_mirror_benchmark' is designed for qiskit 2.1.1." \
-            "Your version is " + qiskit.__version__,
-                           _QiskitInteropWarning)
-
-    except:
-        raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+    _check_qiskit_version('fullstack_mirror_benchmark()')
 
     return _mirror.qiskit_circuits_to_fullstack_mirror_edesign(qk_circs, #not transpiled
                                                     qk_backend,
@@ -270,15 +252,7 @@ def subcircuit_mirror_benchmark(qk_circs: Union[Dict[Any, qiskit.QuantumCircuit]
                 if `aggregate_subcircs` is False, otherwise a FreeformDesign is returned.
     """
 
-    try:
-        import qiskit
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("The function 'noise_mirror_benchmark' is designed for qiskit 2.1.1." \
-            "Your version is " + qiskit.__version__,
-                           _QiskitInteropWarning)
-
-    except:
-        raise RuntimeError('Qiskit is required for this operation, and does not appear to be installed.')
+    _check_qiskit_version('subcircuit_mirror_benchmark()')
 
     return _mirror.qiskit_circuits_to_subcircuit_mirror_edesign(qk_circs,
                                               aggregate_subcircs,

--- a/pygsti/tools/_qiskit_interop.py
+++ b/pygsti/tools/_qiskit_interop.py
@@ -1,0 +1,82 @@
+"""
+Internal helpers for qiskit interoperability.
+"""
+#***************************************************************************************************
+# Copyright 2015, 2019, 2025 National Technology & Engineering Solutions of Sandia, LLC (NTESS).
+# Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains certain rights
+# in this software.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0 or in the LICENSE file in the root pyGSTi directory.
+#***************************************************************************************************
+
+import warnings as _warnings
+
+from pygsti.tools.exceptions import (QiskitInteropWarning as _QiskitInteropWarning,
+                                     MissingDependencyWarning as _MissingDependencyWarning)
+
+# Half-open interval [min, max) of qiskit versions that pyGSTi's qiskit interop code is
+# tested against, compared as tuples of release components. Keep this consistent with
+# the 'ibmq' optional dependency in pyproject.toml.
+TESTED_QISKIT_RANGE = ((1, 4), (3,))
+
+
+def _parse_release(version_string):
+    """Parse the leading numeric release components of a version string into a tuple of ints.
+
+    Pre-release/dev suffixes are ignored: '3.0.0rc1' -> (3, 0), '2.5.0' -> (2, 5, 0).
+    """
+    release = []
+    for part in version_string.split('.'):
+        if part.isdigit():
+            release.append(int(part))
+        else:
+            leading_digits = ''
+            for char in part:
+                if char.isdigit():
+                    leading_digits += char
+                else:
+                    break
+            if leading_digits:
+                release.append(int(leading_digits))
+            break
+    return tuple(release)
+
+
+def check_qiskit_version(context, required=True):
+    """
+    Import qiskit and warn if the installed version is outside the tested range.
+
+    Parameters
+    ----------
+    context : str
+        Name of the calling function/method, used in the warning and error messages.
+
+    required : bool, optional
+        If True (default), a missing qiskit installation raises a RuntimeError.
+        If False, it emits a MissingDependencyWarning and returns None instead,
+        for callers that can proceed without qiskit.
+
+    Returns
+    -------
+    module or None
+        The imported qiskit module, or None if qiskit is missing and `required` is False.
+    """
+    try:
+        import qiskit
+    except ImportError as err:
+        if required:
+            raise RuntimeError(f"Qiskit is required for {context}, and does not appear "
+                               "to be installed.") from err
+        _warnings.warn(f"Qiskit does not appear to be installed; {context} may not function "
+                       "properly without it.", _MissingDependencyWarning, stacklevel=3)
+        return None
+
+    release = _parse_release(qiskit.__version__)
+    minimum, maximum = TESTED_QISKIT_RANGE
+    if not (minimum <= release < maximum):
+        range_str = f"[{'.'.join(map(str, minimum))}, {'.'.join(map(str, maximum))})"
+        _warnings.warn(f"{context} is tested against qiskit versions in the range {range_str} "
+                       f"and may not function properly for your qiskit version, which is "
+                       f"{qiskit.__version__}.", _QiskitInteropWarning, stacklevel=3)
+    return qiskit

--- a/pygsti/tools/internalgates.py
+++ b/pygsti/tools/internalgates.py
@@ -18,13 +18,10 @@ if TYPE_CHECKING:
     except:
         pass
     
-import warnings as _warnings
-
 import numpy as _np
 import scipy.linalg as _spl
 
-from pygsti.tools.exceptions import (QiskitInteropWarning as _QiskitInteropWarning,
-                                     MissingDependencyWarning as _MissingDependencyWarning)
+from pygsti.tools._qiskit_interop import check_qiskit_version as _check_qiskit_version
 
 from pygsti.tools import optools as _ot
 from pygsti.tools import symplectic as _symp
@@ -958,19 +955,9 @@ def standard_gatenames_qiskit_conversions() -> Dict[str, Tuple[qiskit.circuit.In
         a later version of qiskit.
     """
 
-    try:
-        import qiskit
-        from qiskit.circuit import Delay
-        from qiskit.circuit.library import standard_gates
-
-        if qiskit.__version__ != '2.1.1':
-            _warnings.warn("function 'standard_gatenames_qiskit_conversions()' is designed for qiskit version 2.1.1 \
-                    and may not function properly for your qiskit version, which is " + qiskit.__version__,
-                           _QiskitInteropWarning)
-            
-    except ImportError:
-        _warnings.warn("This operation requires qiskit, which does not appear to be installed.",
-                       _MissingDependencyWarning)
+    _check_qiskit_version('standard_gatenames_qiskit_conversions()')
+    from qiskit.circuit import Delay
+    from qiskit.circuit.library import standard_gates
 
     std_gatenames_to_qiskit = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,11 @@ evolutionary_optimization = ['deap']
 extensions = ['cython']
 html_reports = ['jinja2', 'MarkupSafe']
 ibmq = [
-    'qiskit>1',
-    'qiskit-ibm-runtime>=0.17.1',
+    # Keep consistent with TESTED_QISKIT_RANGE in pygsti/tools/_qiskit_interop.py.
+    'qiskit>=1.4,<3',
+    # >=0.44 additionally provides ConvertToMidCircuitMeasure (optional; see
+    # pygsti/extras/ibmq/ibmqexperiment.py).
+    'qiskit-ibm-runtime>=0.40',
     'dill'
 ]
 interpygate = ['csaps']

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,7 @@ filterwarnings =
     error::pygsti.tools.exceptions.StolenResourceWarning
     error::pygsti.tools.exceptions.OverparameterizationWarning
     error::pygsti.tools.exceptions.UntouchedModelNoiseKey
+    error::pygsti.tools.exceptions.QiskitInteropWarning
     error::scipy.optimize.OptimizeWarning
     ignore:Created an evaluation tree that is inefficient:UserWarning
     ignore:invalid escape sequence:DeprecationWarning

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -733,9 +733,53 @@ MEASURE 2 ro[2]
         expected_mapping = {i: f'Q{i}' for i in range(4)}
 
         self.assertEqual(expected_ps_circ, observed_ps_circ)
-        self.assertEqual(expected_mapping, observed_mapping)   
+        self.assertEqual(expected_mapping, observed_mapping)
 
-        
+
+    def test_convert_to_qiskit_measurement_options(self):
+        try:
+            import qiskit
+        except ImportError:
+            self.skipTest('Qiskit is required for this operation, and does not appear to be installed.')
+
+        ps_circ = circuit.Circuit([Label([Label('Gxpi', 'Q0'), Label('Gh', 'Q2')]),
+                                   Label('Gcnot', ('Q0', 'Q1'))], line_labels=('Q0', 'Q1', 'Q2'))
+
+        def num_measures(qk_circ):
+            return sum(1 for inst in qk_circ.data if inst.operation.name == 'measure')
+
+        # default: no measurements, empty classical register
+        qk_circ = ps_circ.convert_to_qiskit(qubit_conversion='remove-Q')
+        self.assertEqual(qk_circ.num_clbits, 0)
+        self.assertEqual(num_measures(qk_circ), 0)
+        self.assertIsNone(qk_circ.metadata['ordered_data_indices'])
+
+        # 'all' measures every qubit of the register, which may be larger than the circuit width
+        qk_circ = ps_circ.convert_to_qiskit(qubit_conversion='remove-Q', num_qubits=5,
+                                            qubits_to_measure='all')
+        self.assertEqual(qk_circ.num_qubits, 5)
+        self.assertEqual(qk_circ.num_clbits, 5)
+        self.assertEqual(num_measures(qk_circ), 5)
+
+        # 'active' measures only the qubits with a conversion entry
+        qk_circ = ps_circ.convert_to_qiskit(qubit_conversion='remove-Q', num_qubits=5,
+                                            qubits_to_measure='active')
+        self.assertEqual(qk_circ.num_qubits, 5)
+        self.assertEqual(qk_circ.num_clbits, 3)
+        self.assertEqual(num_measures(qk_circ), 3)
+
+        # an explicit list of pyGSTi line labels
+        qk_circ = ps_circ.convert_to_qiskit(qubit_conversion='remove-Q',
+                                            qubits_to_measure=['Q0', 'Q2'])
+        self.assertEqual(qk_circ.num_clbits, 2)
+        self.assertEqual(num_measures(qk_circ), 2)
+        self.assertEqual(qk_circ.metadata['ordered_data_indices'], [0, 2])
+
+        # unknown string option
+        with self.assertRaises(ValueError):
+            ps_circ.convert_to_qiskit(qubit_conversion='remove-Q', qubits_to_measure='bogus')
+
+
     def test_convert_to_stim_tableau(self):
         #TODO: Add correctness checks for generated Tableaus.
         #these tests (with the exception of two explicitly meant to raise caught exceptions)

--- a/test/unit/objects/test_subcirc_selection.py
+++ b/test/unit/objects/test_subcirc_selection.py
@@ -6,6 +6,7 @@ from pygsti.tools.exceptions import MissingDependencyWarning
 
 import numpy as _np
 import networkx as _nx
+import unittest
 import warnings
 
 from collections import defaultdict
@@ -453,3 +454,139 @@ class TestSubcircuitSelection(BaseCase):
         self.assertListEqual(sorted(reshaped_width_depths), sorted(created_width_depths.keys()))
         self.assertTrue(all(created_width_depths[k] == num_subcircs_per_width_depth
                             for k in reshaped_width_depths))
+
+
+    def _five_qubit_u3_cx_cz_circuit(self):
+        line_labels = ['Q1', 'Q2', 'Q3', 'Q4', 'Q5']
+
+        I_args = [0, 0, 0]
+        X_args = [_np.pi, 0, _np.pi]
+        Y_args = [_np.pi, _np.pi/2, _np.pi/2]
+        Z_args = [0, 0, _np.pi]
+
+        layers = [
+            [L('Gu3', ['Q1'], args=Z_args), L('Gu3', ['Q2'], args=Y_args), L('Gu3', ['Q3'], args=X_args), L('Gu3', ['Q4'], args=I_args), L('Gu3', ['Q5'], args=I_args)],
+            [L('Gcnot', ['Q1', 'Q2'], args=None), L('Gcnot', ['Q4', 'Q3'], args=None)],
+            [L('Gu3', ['Q1'], args=Y_args), L('Gu3', ['Q2'], args=Z_args), L('Gu3', ['Q3'], args=X_args), L('Gu3', ['Q4'], args=I_args), L('Gu3', ['Q5'], args=X_args)],
+            [L('Gcnot', ['Q2', 'Q3'], args=None), L('Gcnot', ['Q4', 'Q5'], args=None)],
+            [L('Gcphase', ['Q1', 'Q2'], args=None), L('Gcphase', ['Q3', 'Q4'], args=None)],
+            [L('Gcnot', ['Q3', 'Q2'], args=None), L('Gcnot', ['Q4', 'Q5'], args=None)],
+            [L('Gu3', ['Q1'], args=X_args), L('Gu3', ['Q2'], args=Y_args), L('Gu3', ['Q3'], args=I_args), L('Gu3', ['Q4'], args=I_args), L('Gu3', ['Q5'], args=Y_args)],
+            [L('Gu3', ['Q1'], args=X_args), L('Gu3', ['Q2'], args=Y_args), L('Gu3', ['Q3'], args=I_args), L('Gu3', ['Q4'], args=Y_args), L('Gu3', ['Q5'], args=Y_args)],
+            [L('Gu3', ['Q1'], args=Y_args), L('Gu3', ['Q2'], args=X_args), L('Gu3', ['Q3'], args=Z_args), L('Gu3', ['Q4'], args=Y_args), L('Gu3', ['Q5'], args=I_args)],
+            [L('Gcphase', ['Q1', 'Q2'], args=None), L('Gcphase', ['Q4', 'Q5'], args=None)]
+        ]
+
+        return C(layers, line_labels=line_labels)
+
+
+    def test_greedy_growth_subcirc_selection(self):
+        rand_state = _np.random.RandomState(0)
+        circ = self._five_qubit_u3_cx_cz_circuit()
+
+        num_subcircs = 2
+        width = 3
+        depth = 4
+
+        subcircs, drops, depths, start_ends = _subcircsel.greedy_growth_subcirc_selection(
+            circ, width, depth, num_subcircs=num_subcircs, num_test_subcircs=100,
+            rand_state=rand_state, verbosity=0, return_depth_info=True)
+
+        self.assertEqual(len(subcircs), num_subcircs)
+        self.assertEqual(len(drops), num_subcircs)
+        self.assertEqual(len(depths), num_subcircs)
+        self.assertEqual(len(start_ends), num_subcircs)
+
+        for subcirc, subcirc_depth, (start, end) in zip(subcircs, depths, start_ends):
+            self.assertEqual(subcirc.width, width)
+            # candidates whose physical depth misses the target are pruned
+            self.assertEqual(subcirc_depth, depth)
+            self.assertTrue(set(subcirc.line_labels).issubset(set(circ.line_labels)))
+            self.assertTrue(0 <= start <= end < circ.depth)
+
+        # results are sorted so the best (fewest dropped gates) come first
+        self.assertTrue(all(drops[i] <= drops[i + 1] for i in range(len(drops) - 1)))
+
+        # reproducibility
+        subcircs_2, _, _, _ = _subcircsel.greedy_growth_subcirc_selection(
+            circ, width, depth, num_subcircs=num_subcircs, num_test_subcircs=100,
+            rand_state=_np.random.RandomState(0), verbosity=0, return_depth_info=True)
+        self.assertEqual(subcircs, subcircs_2)
+
+
+    def test_greedy_strategy_via_sample_subcircuits(self):
+        class NoDelayInstructions(object):
+            def get(self, *args):
+                return 0.0
+
+        rand_state = _np.random.RandomState(0)
+        circ = self._five_qubit_u3_cx_cz_circuit()
+
+        width_depths = {3: [4]}
+        num_subcircs_per_width_depth = 2
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", MissingDependencyWarning)
+            design = _subcircsel.sample_subcircuits(
+                circ, width_depths=width_depths,
+                instruction_durations=NoDelayInstructions(),
+                coupling_map='linear',
+                num_samples_per_width_depth=num_subcircs_per_width_depth,
+                strategy='greedy',
+                rand_state=rand_state)
+
+        flat_aux = [aux for auxlist in design.aux_info.values() for aux in auxlist]
+        self.assertEqual(len(flat_aux), num_subcircs_per_width_depth)
+        for subcirc, auxlist in design.aux_info.items():
+            self.assertEqual(subcirc.width, 3)
+            for aux in auxlist:
+                self.assertEqual(aux['width'], 3)
+                self.assertEqual(aux['depth'], 4)
+
+
+    # The stochastic-2q-drops path is currently broken: it re-adds dangling gates
+    # whose support extends outside the selected qubit subset, then constructs the
+    # subcircuit with line_labels=sorted(qubit_subset), which raises
+    # "ValueError: line labels must contain at least {...}" whenever any dangling
+    # gate is retained. This test describes the intended behavior and should start
+    # passing once the line-label handling for retained dangling gates is fixed.
+    @unittest.expectedFailure
+    def test_stochastic_2q_drops(self):
+        class NoDelayInstructions(object):
+            def get(self, *args):
+                return 0.0
+
+        rand_state = _np.random.RandomState(0)
+        circ = self._five_qubit_u3_cx_cz_circuit()
+
+        num_subcircs = 4
+        width = 3
+        depth = 4
+
+        subcircs, drops, compiled_depths, start_ends, dangling_counts, added_layers = \
+            _subcircsel.simple_weighted_subcirc_selection(
+                circ, width, depth, num_subcircs=num_subcircs,
+                coupling_map='linear',
+                instruction_durations=NoDelayInstructions(),
+                rand_state=rand_state,
+                return_depth_info=True,
+                stochastic_2q_drops=True,
+                verbosity=0)
+
+        self.assertEqual(len(subcircs), num_subcircs)
+        self.assertEqual(len(drops), num_subcircs)
+        self.assertEqual(len(compiled_depths), num_subcircs)
+        self.assertEqual(len(start_ends), num_subcircs)
+        self.assertEqual(len(dangling_counts), num_subcircs)
+        self.assertEqual(len(added_layers), num_subcircs)
+
+        for subcirc, drop_count, dangling_count, added in zip(subcircs, drops, dangling_counts,
+                                                              added_layers):
+            self.assertEqual(subcirc.width, width)
+            self.assertTrue(set(subcirc.line_labels).issubset(set(circ.line_labels)))
+            self.assertTrue(drop_count >= 0)
+            # each retained dangling gate is counted twice (in-layer + added layer)
+            self.assertEqual(dangling_count % 2, 0)
+            # every added layer index must be a valid layer of the subcircuit
+            for layer_idx in added:
+                self.assertTrue(0 <= layer_idx < subcirc.depth)

--- a/test/unit/objects/test_subcirc_selection.py
+++ b/test/unit/objects/test_subcirc_selection.py
@@ -275,7 +275,8 @@ class TestSubcircuitSelection(BaseCase):
 
         backend = qiskit_ibm_runtime.fake_provider.FakeFez()
 
-        qk_circ = qiskit.circuit.library.QFT(4)
+        qk_circ = qiskit.QuantumCircuit(4)
+        qk_circ.append(qiskit.circuit.library.QFTGate(4), range(4))
         qk_circ = qiskit.transpile(qk_circ, backend=backend)
 
         ps_circ, _ = C.from_qiskit(qk_circ)

--- a/test/unit/protocols/test_mirror_edesign.py
+++ b/test/unit/protocols/test_mirror_edesign.py
@@ -144,7 +144,8 @@ class TestScalableBenchmarks(BaseCase):
         mirroring_kwargs_dict = {'num_mcs_per_circ': num_mcs_per_circ,
                                  'num_ref_per_qubit_subset': num_ref_per_qubit_subset}
 
-        qk_circ = qiskit.circuit.library.QFT(6)
+        qk_circ = qiskit.QuantumCircuit(6)
+        qk_circ.append(qiskit.circuit.library.QFTGate(6), range(6))
         qk_circ = qiskit.transpile(qk_circ, backend=backend)
 
         test_edesign, mirror_edesign = qiskit_circuits_to_mirror_edesign([qk_circ],
@@ -204,7 +205,8 @@ class TestScalableBenchmarks(BaseCase):
                                  'num_ref_per_qubit_subset': num_ref_per_qubit_subset}
         transpiler_kwargs_dict = {'optimization_level': 2}
 
-        qk_circ = qiskit.circuit.library.QFT(6)
+        qk_circ = qiskit.QuantumCircuit(6)
+        qk_circ.append(qiskit.circuit.library.QFTGate(6), range(6))
 
         test_edesign, mirror_edesign = qiskit_circuits_to_fullstack_mirror_edesign([qk_circ],
                                                                                    qk_backend=backend,
@@ -280,7 +282,8 @@ class TestScalableBenchmarks(BaseCase):
         
 
 
-        qk_circ = qiskit.circuit.library.QFT(6)
+        qk_circ = qiskit.QuantumCircuit(6)
+        qk_circ.append(qiskit.circuit.library.QFTGate(6), range(6))
         qk_circ = qiskit.transpile(qk_circ, backend=backend)
 
         test_edesign, mirror_edesign = qiskit_circuits_to_subcircuit_mirror_edesign(

--- a/test/unit/protocols/test_scarab.py
+++ b/test/unit/protocols/test_scarab.py
@@ -1,0 +1,114 @@
+from ..util import BaseCase
+
+import numpy as _np
+
+from pygsti.protocols import scarab
+
+
+class ScarabBenchmarkTester(BaseCase):
+    """
+    Smoke tests for the scarab benchmark-creation wrappers. These are thin wrappers
+    around the mirror_edesign pipeline (tested in depth in test_mirror_edesign.py),
+    so these tests just exercise each wrapper end-to-end on small circuits and check
+    the shape of the returned edesigns.
+    """
+
+    def _require_qiskit(self):
+        try:
+            import qiskit
+            return qiskit
+        except ImportError:
+            self.skipTest('Qiskit is required for this operation, and does not appear to be installed.')
+
+    def test_lowlevel_mirror_benchmark(self):
+        qiskit = self._require_qiskit()
+
+        num_mcs_per_circ = 2
+        num_ref_per_qubit_subset = 3
+
+        qc = qiskit.QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qk_circ = qiskit.transpile(qc, basis_gates=['u3', 'cz'], optimization_level=1,
+                                   seed_transpiler=0)
+
+        test_edesign, mirror_edesign = scarab.lowlevel_mirror_benchmark(
+            [qk_circ],
+            mirroring_kwargs_dict={'num_mcs_per_circ': num_mcs_per_circ,
+                                   'num_ref_per_qubit_subset': num_ref_per_qubit_subset,
+                                   'rand_state': _np.random.RandomState(0)})
+
+        self.assertEqual(len(test_edesign.aux_info), 1)
+        self.assertEqual(2 * num_mcs_per_circ + num_ref_per_qubit_subset,
+                         len(mirror_edesign.all_circuits_needing_data))
+        for key in ('br', 'rr', 'ref'):
+            self.assertTrue(len(mirror_edesign[key].all_circuits_needing_data) > 0)
+
+    def test_fullstack_mirror_benchmark(self):
+        qiskit = self._require_qiskit()
+        from qiskit.providers.fake_provider import GenericBackendV2
+
+        num_mcs_per_circ = 2
+        num_ref_per_qubit_subset = 3
+
+        backend = GenericBackendV2(num_qubits=2, seed=0)
+        qc = qiskit.QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+
+        test_edesign, mirror_edesign = scarab.fullstack_mirror_benchmark(
+            [qc],
+            qk_backend=backend,
+            transpiler_kwargs_dict={'seed_transpiler': 0},
+            mirroring_kwargs_dict={'num_mcs_per_circ': num_mcs_per_circ,
+                                   'num_ref_per_qubit_subset': num_ref_per_qubit_subset,
+                                   'rand_state': _np.random.RandomState(0)})
+
+        self.assertEqual(len(test_edesign.aux_info), 1)
+        self.assertEqual(2 * num_mcs_per_circ + num_ref_per_qubit_subset,
+                         len(mirror_edesign.all_circuits_needing_data))
+
+        # full-stack benchmarks track the transpiler's layout choices
+        for auxlist in test_edesign.aux_info.values():
+            for aux in auxlist:
+                self.assertIn('routing_permutation', aux)
+
+    def test_subcircuit_mirror_benchmark(self):
+        qiskit = self._require_qiskit()
+        from qiskit.transpiler import CouplingMap, InstructionDurations
+
+        coupling_map = CouplingMap.from_line(4)
+        instruction_durations = InstructionDurations(
+            [('u', None, 100), ('cz', None, 100), ('delay', None, 100)])
+
+        qc = qiskit.QuantumCircuit(4)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.cx(2, 3)
+        qk_circ = qiskit.transpile(qc, basis_gates=['u3', 'cz'], coupling_map=coupling_map,
+                                   optimization_level=1, seed_transpiler=0)
+
+        width_depth_dict = {2: [2, 3]}
+        num_samples_per_width_depth = 2
+
+        test_edesign, mirror_edesign = scarab.subcircuit_mirror_benchmark(
+            [qk_circ],
+            aggregate_subcircs=True,
+            width_depth_dict=width_depth_dict,
+            coupling_map=coupling_map,
+            instruction_durations=instruction_durations,
+            subcirc_kwargs_dict={'num_samples_per_width_depth': num_samples_per_width_depth,
+                                 'rand_state': _np.random.RandomState(0)},
+            mirroring_kwargs_dict={'num_mcs_per_circ': 1,
+                                   'num_ref_per_qubit_subset': 1,
+                                   'rand_state': _np.random.RandomState(0)})
+
+        # 2 subcircuits per (width, depth) pair were requested
+        flat_aux = [aux for auxlist in test_edesign.aux_info.values() for aux in auxlist]
+        self.assertEqual(len(flat_aux), num_samples_per_width_depth * 2)
+        for aux in flat_aux:
+            self.assertEqual(aux['width'], 2)
+            self.assertIn(aux['depth'], (2, 3))
+
+        self.assertTrue(len(mirror_edesign.all_circuits_needing_data) > 0)

--- a/test/unit/tools/test_qiskit_interop.py
+++ b/test/unit/tools/test_qiskit_interop.py
@@ -1,0 +1,154 @@
+"""
+Tests for pygsti.tools._qiskit_interop and the QiskitInteropWarning paths of
+Circuit.from_qiskit / the mirror-edesign qiskit entry points.
+"""
+import sys
+from unittest import mock
+
+import pytest
+
+try:
+    import qiskit
+    HAVE_QISKIT = True
+except ImportError:
+    HAVE_QISKIT = False
+
+from pygsti.tools._qiskit_interop import TESTED_QISKIT_RANGE, _parse_release, check_qiskit_version
+from pygsti.tools.exceptions import MissingDependencyWarning, QiskitInteropWarning
+
+needs_qiskit = pytest.mark.skipif(not HAVE_QISKIT, reason='qiskit is not installed')
+
+
+def test_parse_release():
+    assert _parse_release('2.5.0') == (2, 5, 0)
+    assert _parse_release('1.4') == (1, 4)
+    assert _parse_release('3.0.0rc1') == (3, 0, 0)
+    assert _parse_release('2.1.1.dev0+abc') == (2, 1, 1)
+
+
+@needs_qiskit
+def test_version_out_of_range_warns():
+    for bad_version in ('1.3.9', '3.0.0'):
+        with mock.patch.object(qiskit, '__version__', bad_version):
+            with pytest.warns(QiskitInteropWarning, match='tested against qiskit versions'):
+                check_qiskit_version('test_context()')
+
+
+@needs_qiskit
+def test_version_in_range_no_warning():
+    import warnings
+    minimum, _ = TESTED_QISKIT_RANGE
+    in_range_version = '.'.join(map(str, minimum)) + '.0'
+    for version in (in_range_version, '2.99.0'):
+        with mock.patch.object(qiskit, '__version__', version):
+            with warnings.catch_warnings():
+                warnings.simplefilter('error')
+                assert check_qiskit_version('test_context()') is qiskit
+
+
+def test_missing_qiskit_required_raises():
+    with mock.patch.dict(sys.modules, {'qiskit': None}):
+        with pytest.raises(RuntimeError, match='Qiskit is required for test_context()'):
+            check_qiskit_version('test_context()')
+
+
+def test_missing_qiskit_optional_warns_and_returns_none():
+    with mock.patch.dict(sys.modules, {'qiskit': None}):
+        with pytest.warns(MissingDependencyWarning, match='does not appear to be installed'):
+            assert check_qiskit_version('test_context()', required=False) is None
+
+
+@needs_qiskit
+class TestFromQiskitLossyWarnings:
+
+    @staticmethod
+    def _measure_free_circuit():
+        qc = qiskit.QuantumCircuit(qiskit.QuantumRegister(2))
+        qc.h(0)
+        qc.cx(0, 1)
+        return qc
+
+    def test_clean_circuit_round_trip_is_silent(self):
+        import warnings
+        from pygsti.circuits import Circuit
+        ps_circ = Circuit([('Gh', 'Q0'), ('Gcnot', 'Q0', 'Q1')], line_labels=('Q0', 'Q1'))
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            # convert_to_qiskit always attaches an (empty) classical register named 'cr';
+            # the round trip back through from_qiskit must not warn about it.
+            qk_circ = ps_circ.convert_to_qiskit(qubit_conversion='remove-Q')
+            assert len(qk_circ.cregs) == 1 and len(qk_circ.clbits) == 0
+            Circuit.from_qiskit(qk_circ)
+
+    def test_multiple_qregs_warn(self):
+        from pygsti.circuits import Circuit
+        qc = qiskit.QuantumCircuit(qiskit.QuantumRegister(1, 'a'), qiskit.QuantumRegister(1, 'b'))
+        qc.h(0)
+        with pytest.warns(QiskitInteropWarning, match='does not preserve Qiskit qreg structure'):
+            Circuit.from_qiskit(qc)
+
+    def test_classical_bits_warn(self):
+        from pygsti.circuits import Circuit
+        qc = qiskit.QuantumCircuit(qiskit.QuantumRegister(2), qiskit.ClassicalRegister(2))
+        qc.h(0)
+        with pytest.warns(QiskitInteropWarning, match='discards classical registers'):
+            Circuit.from_qiskit(qc)
+
+    def test_measure_warns(self):
+        from pygsti.circuits import Circuit
+        qc = qiskit.QuantumCircuit(qiskit.QuantumRegister(2), qiskit.ClassicalRegister(2))
+        qc.h(0)
+        qc.measure(0, 0)
+        # both the classical-bits warning and the measure warning fire here
+        with pytest.warns(QiskitInteropWarning) as record:
+            Circuit.from_qiskit(qc)
+        assert any('drops measure instructions' in str(w.message) for w in record)
+
+    def test_lossy_ignore_is_silent(self):
+        import warnings
+        from pygsti.circuits import Circuit
+        qc = qiskit.QuantumCircuit(qiskit.QuantumRegister(1, 'a'), qiskit.QuantumRegister(1, 'b'),
+                                   qiskit.ClassicalRegister(2))
+        qc.h(0)
+        qc.measure(0, 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            Circuit.from_qiskit(qc, lossy='ignore')
+
+    def test_lossy_raise_raises(self):
+        from pygsti.circuits import Circuit
+        qc = qiskit.QuantumCircuit(qiskit.QuantumRegister(2), qiskit.ClassicalRegister(2))
+        qc.h(0)
+        with pytest.raises(ValueError, match='discards classical registers'):
+            Circuit.from_qiskit(qc, lossy='raise')
+
+    def test_lossy_invalid_value_rejected(self):
+        from pygsti.circuits import Circuit
+        with pytest.raises(AssertionError, match="'lossy' must be"):
+            Circuit.from_qiskit(self._measure_free_circuit(), lossy='bogus')
+
+
+@needs_qiskit
+def test_fullstack_mirror_edesign_ignored_args_warn():
+    from qiskit.providers.fake_provider import GenericBackendV2
+    from pygsti.protocols.mirror_edesign import qiskit_circuits_to_fullstack_mirror_edesign
+
+    backend = GenericBackendV2(num_qubits=2, basis_gates=['u', 'cz'], seed=0)
+    qc = qiskit.QuantumCircuit(2)
+    qc.h(0)
+    qc.cx(0, 1)
+
+    mirroring_kwargs = {'num_mcs_per_circ': 1, 'num_ref_per_qubit_subset': 1,
+                        'rand_state': __import__('numpy').random.RandomState(0)}
+
+    with pytest.warns(QiskitInteropWarning, match="'basis_gates' is ignored"):
+        qiskit_circuits_to_fullstack_mirror_edesign(
+            [qc], qk_backend=backend, basis_gates=['u', 'cz'],
+            transpiler_kwargs_dict={'seed_transpiler': 0},
+            mirroring_kwargs_dict=mirroring_kwargs)
+
+    with pytest.warns(QiskitInteropWarning, match="'coupling_map' is ignored"):
+        qiskit_circuits_to_fullstack_mirror_edesign(
+            [qc], qk_backend=backend, coupling_map=backend.coupling_map,
+            transpiler_kwargs_dict={'seed_transpiler': 0},
+            mirroring_kwargs_dict=mirroring_kwargs)


### PR DESCRIPTION
This makes pyGSTi's qiskit interop clean under `error::pygsti.tools.exceptions.QiskitInteropWarning`, which this PR promotes from a defined-but-inert exception class to a `pytest.ini` error. Getting there required fixing several real bugs that were hiding behind warnings nobody could see (or that were misclassified so they wouldn't fire at all), removing qiskit APIs slated for removal in 3.0, and correcting the `ibmq` extra's dependency floors, which were stale enough to break on qiskit versions we claim to support.

Five commits, one per phase, each leaving the suite green under the strict filter: `7e39339dc` → `73a4f54bc` → `f4178a8c3` → `962c67a1e` → `1bb2ae93f`.

### What changed

**Warning hygiene (`pygsti/tools/_qiskit_interop.py`, new)**
- Eleven copy-pasted exact-version checks against `qiskit==2.1.1`, scattered across `circuit.py`, `internalgates.py`, `subcircuit_selection.py`, `mirror_edesign.py`, and `scarab.py`, are replaced by one helper, `check_qiskit_version(context, required=True)`, checked against a tested *range* (`TESTED_QISKIT_RANGE = ((1, 4), (3,))`) instead of a single pin.
- That consolidation incidentally fixed real bugs the old pattern was causing: a warn-inside-`try`/bare-`except` that turned the promoted warning into a false "qiskit does not appear to be installed" `RuntimeError`; a `MissingDependencyWarning` misclassification in `subcircuit_selection.py` where a genuine version mismatch was reported as a missing dependency and execution silently continued; and a `NameError` fall-through in `internalgates.py` when qiskit is truly absent.
- `from_qiskit` now warns about discarded classical data only when the circuit actually has clbits — previously it fired on `len(circuit.cregs)`, so a pure pygsti→qiskit→pygsti round trip warned about discarding the empty `cr` register that `convert_to_qiskit` always attaches, even when nothing was measured.
- The plain-`UserWarning` `'skipping measure'` is now a `QiskitInteropWarning` with an actual message.
- `from_qiskit` gains `lossy={'warn', 'ignore', 'raise'}`; the mirror-edesign pipeline passes `lossy='ignore'` at call sites where the loss is intentional.
- `mirror_edesign`'s fullstack path no longer forwards `coupling_map` to `transpile()` alongside a backend — the warning claimed it was ignored, but an explicit `coupling_map` actually overrides the backend's map, so the old behavior silently used the wrong topology.
- New `test/unit/tools/test_qiskit_interop.py` exercises the warning paths directly.

**Qiskit 3.0-proofing**
- Removed the last uses of APIs slated for removal in qiskit 3.0: iterating a `CircuitInstruction` as a tuple (→ `.operation`/`.qubits`), `qubit._index` and `layout.initial_layout[idx]._register.name == 'ancilla'` (→ `circuit.find_bit(qubit).index` and `isinstance(..., AncillaQubit)`), and `circuit._qbit_argument_conversion(i)[0]` (→ the public, stable-since-1.0 `circuit.qubits[i]`).
- Test files: the deprecated `QFT` class (built on the also-removed `BlueprintCircuit`) is replaced with `QFTGate`.
- Considered and rejected: a global pytest filter promoting qiskit `DeprecationWarning`s to errors. Warning attribution follows `stacklevel`, so such a filter would promote *all* pygsti-attributed `DeprecationWarning`s, not just qiskit-related ones — too much blast radius on the full suite. Documented in the phase-2 commit message.

**`extras/ibmq` guard split + honest floors**
- `ibmqexperiment.py` imported `ConvertToMidCircuitMeasure` (added in `qiskit-ibm-runtime` 0.44) in the same `try`/`except` as the core runtime names. On any older runtime the whole import failed and `_Sampler` was set to `None`, disabling *all* IBMQ submission — even though nothing else needed the new pass. It's now guarded separately, with the assertion only in the code path that actually converts mid-circuit measurements (message names the real fix: upgrade runtime, or pass `use_ibm_mcm=False`).
- `pyproject.toml`'s `ibmq` extra goes from the stale, unbounded `qiskit>1, qiskit-ibm-runtime>=0.17.1` to `qiskit>=1.4,<3, qiskit-ibm-runtime>=0.40`, matching `TESTED_QISKIT_RANGE`.
- Validated: all 11 ibmq tests now pass on both qiskit 2.5.0/runtime 0.47 and qiskit 2.1.1/runtime 0.41.1 — the latter previously failed solely because of the coupled import.

**Coverage**
- `test/unit/protocols/test_scarab.py` (new): smoke tests for all three scarab benchmark wrappers (`lowlevel`/`fullstack`/`subcircuit_mirror_benchmark`), which are public API in `pygsti.protocols.scarab` but previously had zero coverage — these would have caught the phase-1 bare-except bug.
- `test_circuit.py`: a `convert_to_qiskit` argument matrix (`qubits_to_measure` in `None`/`'all'`/`'active'`/list form, oversized `num_qubits`, `ordered_data_indices` metadata, the invalid-option error path).
- `test_subcirc_selection.py`: `greedy_growth_subcirc_selection` coverage (direct call and via `sample_subcircuits(strategy='greedy')`), plus a `stochastic_2q_drops` test — see below. `subcircuit_selection.py` coverage goes from 42% to 80%.
- `extras/devices` gets no new tests, per plan: its calibration formats predate the current runtime API, and deprecation is proposed to maintainers instead of investing in coverage.

**CI**
- New `.github/workflows/qiskit-interop.yml`, weekly: a bare qiskit-1.4-floor matrix leg (runtime uninstalled), a runtime-0.40-floor leg, and a latest leg. Keeps `TESTED_QISKIT_RANGE` honest and should flag qiskit 3.0 breakage the week it ships rather than at user-report time.

### Reviewer attention

1. **New bug found, not fixed: `stochastic_2q_drops=True` is broken.** Writing the `greedy`/`stochastic` coverage in phase 4 (previously 0% covered) surfaced that `simple_weighted_subcirc_selection(..., stochastic_2q_drops=True)` re-adds dangling two-qubit gates whose support, by definition, includes at least one qubit outside the selected subset — and the subcircuit is then built with `line_labels=sorted(qubit_subset)`, so `Circuit.__init__` raises `ValueError` on essentially any connected circuit. The new test documents the intended behavior and is marked `@unittest.expectedFailure`. Fixing it needs a maintainer call: should retained dangling gates expand the subcircuit's line labels (changing its effective width), or should they be truncated to their in-subset qubits? Whoever picks a direction should also remove the `expectedFailure` marker.
2. **`ibmq` extra's dependency floor moved** from `qiskit>1` to `qiskit>=1.4,<3` and from `qiskit-ibm-runtime>=0.17.1` to `>=0.40`. This is a correction, not a new restriction — anything outside the old, unbounded range was already broken (that's how finding 5 was found), but it's technically a tightening of the declared floor that downstream pins might notice.
3. **No global `DeprecationWarning` promotion.** See the qiskit-3.0-proofing section above — flagging so it isn't independently proposed and then hit the same blast-radius problem.

### Testing

Cross-version validation, all with the strict `error::QiskitInteropWarning` filter, 141 passed + 2 xfailed on each:
- qiskit 2.5.0 + qiskit-ibm-runtime 0.47 (py313 conda env)
- qiskit 2.1.1 + qiskit-ibm-runtime 0.41.1
- qiskit 1.4.6 + qiskit-ibm-runtime 0.37.0
