### PR TITLE
Xfgst circuit lanes

### DIFF
--- a/pygsti/baseobjs/label.py
+++ b/pygsti/baseobjs/label.py
@@ -745,6 +745,8 @@ class LabelTup(Label, tuple):
         else:
             return super().concat(other)
 
+        if len(components) == 1:
+            return components[0]
         return LabelTupTup.init(components, warn_on_component_metadata=False)
 
     __hash__ = tuple.__hash__
@@ -1279,6 +1281,8 @@ class LabelTupTup(Label, tuple):
         else:
             return super().concat(other)
 
+        if len(components) == 1:
+            return components[0]
         return LabelTupTup.init(components, warn_on_component_metadata=False)
 
     __hash__ = tuple.__hash__

--- a/pygsti/circuits/__init__.py
+++ b/pygsti/circuits/__init__.py
@@ -21,3 +21,4 @@ from .gstcircuits import *
 # Unused: from rpecircuits import *
 
 from .subcircuit_selection import *
+from .split_circuits_into_lanes import *

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from cirq.circuits.circuit import Circuit as CirqCircuit
     from pygsti.baseobjs.label import ConcreteLabel
 
+import copy as _copy
 import itertools as _itertools
 import warnings as _warnings
 
@@ -622,13 +623,7 @@ class Circuit(object):
         self._name = name  # can be None
         #self._times = None  # for FUTURE expansion
         self.auxinfo = {}  # for FUTURE expansion / user metadata
-        if saved_aux:
-            self.saved_auxinfo = {
-                k: (v.copy() if isinstance(v, dict) else v)
-                for k, v in saved_aux.items()
-            }
-        else:
-            self.saved_auxinfo = {}
+        self.saved_auxinfo = _copy.deepcopy(saved_aux) if saved_aux else {}
         return self
 
     #pickle management functions

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -598,8 +598,9 @@ class Circuit(object):
         self._name = name  # can be None
         #self._times = None  # for FUTURE expansion
         self.auxinfo = {}  # for FUTURE expansion / user metadata
+        # `saved_auxinfo["lanes"]` is a cache used by pygsti.circuits.split_circuits_into_lanes.
+        # It is populated lazily (see Circuit._cache_tensor_lanes)
         self.saved_auxinfo = {}
-        self.saved_auxinfo["lanes"] = {tuple(line_labels): list(self._labels)}
 
     #Note: If editing _copy_init one should also check _bare_init in case changes must be propagated.
     #specialized codepath for copying
@@ -1351,7 +1352,9 @@ class Circuit(object):
 
         for i in layers:
             ret_layer = []
-            layer_lbl = self.layertup[i]
+            # Equivalent to `layer_lbl = self.layertup[i]`
+            raw_layer = self._labels[i]
+            layer_lbl = raw_layer if isinstance(raw_layer, _Label) else _Label(raw_layer)
 
             components = list(layer_lbl.components)
 
@@ -2548,9 +2551,9 @@ class Circuit(object):
         if len(overlap) > 0:
             raise ValueError(
                 "The line labels of `circuit` and this Circuit must be distinct, but overlap = %s!" % str(overlap))
-        if self._line_labels == '*':
+        if self._line_labels == ('*',):
             raise ValueError("The line labels of 'self', are underspecified and are currently the placeholder labels.")
-        if circuit._line_labels == '*':
+        if circuit._line_labels == ('*',):
             raise ValueError("The line labels of 'circuit', are underspecified and are currently the placeholder labels.")
 
         all_line_labels = set(self._line_labels + circuit._line_labels)
@@ -2648,23 +2651,42 @@ class Circuit(object):
         Store the tensor lanes in the circuit if appropriate.
         Note that this should only be called in the case that `sub_circuit_list`
         when tensored is equivalent to the current circuit.
+
+        This cache is only ever written to (or read from, see
+        `split_circuits_into_lanes.compute_subcircuits`) when the circuit is
+        static (read-only). Editable circuits can be mutated in-place (e.g.
+        via `__setitem__`, `replace_gatename_inplace`, `tensor_circuit_inplace`,
+        etc.) without going through `done_editing()` or
+        `map_state_space_labels_inplace` -- the only two places that invalidate
+        this cache -- so trusting/populating a cache on an editable circuit
+        could silently return stale results after such a mutation. Restricting
+        the cache to static circuits is safe because a static circuit's
+        `_labels`/`_line_labels` cannot be changed in place (every in-place
+        mutator asserts `not self._static` before touching them).
         """
+        if not self._static or len(self) == 0:
+            return self
 
-        if "lanes" in self.saved_auxinfo and len(self) > 0:
-            if len(self.saved_auxinfo["lanes"]) <= 1:
-                # We will update this because it is now believed that
-                # we are able to conduct the operation in cross talk free lanes.
-                qubits_used = set()
-                for qub_in_lane in lane_to_qubits.values():
-                    qubits_used = qubits_used.union(qub_in_lane)
+        # `saved_auxinfo["lanes"]` is populated lazily: if it hasn't been
+        # computed yet the key may simply be absent (or map to an empty/
+        # trivial single-lane dict), either of which we treat the same way as
+        # "not yet split into lanes".
+        current_lanes = self.saved_auxinfo.get("lanes")
+        if current_lanes is None or len(current_lanes) <= 1:
+            # We will update this because it is now believed that
+            # we are able to conduct the operation in cross talk free lanes.
+            qubits_used = set()
+            for qub_in_lane in lane_to_qubits.values():
+                qubits_used = qubits_used.union(qub_in_lane)
 
-                if len(qubits_used) != self.num_lines:
-                    # Do not update.
-                    return self
+            if len(qubits_used) != self.num_lines:
+                # Do not update.
+                return self
 
-                self.saved_auxinfo["lanes"] = {}  # Reset lanes info
-                for i, qubit_labels in lane_to_qubits.items():
-                    self.saved_auxinfo["lanes"][tuple(sorted(qubit_labels))] = sub_circuit_list[i]
+            new_lanes = {}
+            for i, qubit_labels in lane_to_qubits.items():
+                new_lanes[tuple(sorted(qubit_labels))] = sub_circuit_list[i]
+            self.saved_auxinfo["lanes"] = new_lanes
 
         return self
 

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2569,10 +2569,11 @@ class Circuit(object):
         else:
             new_line_labels = self._line_labels + circuit._line_labels
 
-        #Add circuit's labels into this circuit
+        #Add circuit's labels into this circuit.
         new_layers = []
         ind = 0
-        while ind < min(self.num_layers, circuit.num_layers):
+        common_len = min(len(self), len(circuit))
+        while ind < common_len:
             lbl = self.layer_label(ind)
             other_lbl = circuit.layer_label(ind)
 
@@ -2584,25 +2585,24 @@ class Circuit(object):
             if isinstance(other_lbl, _LabelStr):
                 other_lbl = _Label(other_lbl.name, circuit.line_labels)
 
-            lbl = lbl.concat(other_lbl)
-            new_layers.append(lbl)
+            new_layers.append(lbl.concat(other_lbl))
             ind += 1
 
-        # We need to pad with idle gates if the circuits are not the same length.
-        if len(self) < len(circuit):
-            while ind < len(circuit):
-                lbl = circuit.layer_label(ind)
+        # One circuit may be longer than the other; walk the remaining layers of
+        # whichever one is longer. If such a layer has *explicit* sslbls we must
+        # also list the other (shorter, now-exhausted) circuit's lines as idling
+        # explicitly, via `idle_gate_name` -- otherwise those lines would be missing
+        # from the layer entirely. If the layer's sslbls are implicit (None, meaning
+        # it already applies contextually to *all* lines) it needs no change: it will
+        # automatically extend to cover the newly-added lines once merged.
+        if len(self) != common_len or len(circuit) != common_len:
+            long_circuit, short_line_labels = (
+                (circuit, self._line_labels) if len(circuit) > common_len else (self, circuit._line_labels)
+            )
+            while ind < len(long_circuit):
+                lbl = long_circuit.layer_label(ind)
                 if lbl.sslbls is not None:
-                    idle_lbls = [_Label(idle_gate_name, line) for line in self._line_labels]
-                    for idle_lbl in idle_lbls:
-                        lbl = lbl.concat(idle_lbl)
-                new_layers.append(lbl)
-                ind += 1
-        else:
-            while ind < len(self):
-                lbl = self.layer_label(ind)
-                if lbl.sslbls is not None:
-                    idle_lbls = [_Label(idle_gate_name, line) for line in circuit._line_labels]
+                    idle_lbls = [_Label(idle_gate_name, line) for line in short_line_labels]
                     for idle_lbl in idle_lbls:
                         lbl = lbl.concat(idle_lbl)
                 new_layers.append(lbl)
@@ -2640,7 +2640,7 @@ class Circuit(object):
         if self._static: cpy.done_editing()
         return cpy
 
-    def _cache_tensor_lanes(self, sub_circuit_list: list[_Label],
+    def _cache_tensor_lanes(self, sub_circuit_list: list[Circuit],
                              lane_to_qubits: dict[int, tuple[int, ...]]) -> Circuit:
         """
         Store the tensor lanes in the circuit if appropriate.
@@ -2648,7 +2648,7 @@ class Circuit(object):
         when tensored is equivalent to the current circuit.
 
         This cache is only ever written to (or read from, see
-        `split_circuits_into_lanes.compute_subcircuits`) when the circuit is
+        `split_circuits_into_lanes.split_into_tensor_lanes`) when the circuit is
         static (read-only). Editable circuits can be mutated in-place (e.g.
         via `__setitem__`, `replace_gatename_inplace`, `tensor_circuit_inplace`,
         etc.) without going through `done_editing()` or
@@ -3633,6 +3633,68 @@ class Circuit(object):
             if line_lbl not in layer_lbl.sslbls:
                 components.append(_Label(idle_gate_name, line_lbl))
         return _Label(components)
+
+    def insert_implicit_idles_inplace(self, layers: Optional[Iterable[int]] = None,
+                                      idle_gate_name: Union[str, _Label] = 'Gi'):
+        """
+        Materialize implicit identity operations as explicit idle gates, in place.
+
+        For each targeted layer, every line that isn't already acted on by that
+        layer's gates has `idle_gate_name` inserted onto it (see
+        :meth:`layer_label_with_idles`).  This is useful whenever a layer must be
+        able to stand on its own with an explicit gate on every line -- for
+        example before tensoring circuits together, so that a padded/idling
+        layer becomes a real gate label instead of an implicit (`sslbls=None`)
+        layer that would otherwise be interpreted as acting on *all* lines once
+        new lines are added.
+
+        Parameters
+        ----------
+        layers : iterable of int, optional
+            The layer indices to materialize idles for.  If `None` (the
+            default), every layer of the circuit is updated.
+
+        idle_gate_name : str or Label, optional
+            The idle gate name to use.  Note that state space (qubit) labels
+            will be added to this name to form a :class:`Label`.
+
+        Returns
+        -------
+        None
+        """
+        assert(not self._static), "Cannot edit a read-only circuit!"
+        if layers is None:
+            layers = range(self.num_layers)
+        for j in layers:
+            padded_lbl = self.layer_label_with_idles(j, idle_gate_name)
+            self._clear_labels([j], self._line_labels)
+            self._labels[j].extend(_label_to_nested_lists_of_simple_labels(padded_lbl, None))
+
+    def insert_implicit_idles(self, layers: Optional[Iterable[int]] = None,
+                              idle_gate_name: Union[str, _Label] = 'Gi') -> Circuit:
+        """
+        Materialize implicit identity operations as explicit idle gates, returning a copy.
+
+        See :meth:`insert_implicit_idles_inplace` for details.
+
+        Parameters
+        ----------
+        layers : iterable of int, optional
+            The layer indices to materialize idles for.  If `None` (the
+            default), every layer of the circuit is updated.
+
+        idle_gate_name : str or Label, optional
+            The idle gate name to use.  Note that state space (qubit) labels
+            will be added to this name to form a :class:`Label`.
+
+        Returns
+        -------
+        Circuit
+        """
+        cpy = self.copy(editable=True)
+        cpy.insert_implicit_idles_inplace(layers, idle_gate_name)
+        if self._static: cpy.done_editing()
+        return cpy
 
     @property
     def num_layers(self):

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -2670,18 +2670,16 @@ class Circuit(object):
         if current_lanes is None or len(current_lanes) <= 1:
             # We will update this because it is now believed that
             # we are able to conduct the operation in cross talk free lanes.
-            qubits_used = set()
-            for qub_in_lane in lane_to_qubits.values():
-                qubits_used = qubits_used.union(qub_in_lane)
+            qubits_used = set().union(*lane_to_qubits.values())
 
             if len(qubits_used) != self.num_lines:
                 # Do not update.
                 return self
 
-            new_lanes = {}
-            for i, qubit_labels in lane_to_qubits.items():
-                new_lanes[tuple(sorted(qubit_labels))] = sub_circuit_list[i]
-            self.saved_auxinfo["lanes"] = new_lanes
+            self.saved_auxinfo["lanes"] = {
+                tuple(sorted(qubit_labels)): sub_circuit_list[i]
+                for i, qubit_labels in lane_to_qubits.items()
+            }
 
         return self
 
@@ -3666,9 +3664,7 @@ class Circuit(object):
         if layers is None:
             layers = range(self.num_layers)
         for j in layers:
-            padded_lbl = self.layer_label_with_idles(j, idle_gate_name)
-            self._clear_labels([j], self._line_labels)
-            self._labels[j].extend(_label_to_nested_lists_of_simple_labels(padded_lbl, None))
+            self[j] = self.layer_label_with_idles(j, idle_gate_name)
 
     def insert_implicit_idles(self, layers: Optional[Iterable[int]] = None,
                               idle_gate_name: Union[str, _Label] = 'Gi') -> Circuit:

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -621,7 +621,13 @@ class Circuit(object):
         self._name = name  # can be None
         #self._times = None  # for FUTURE expansion
         self.auxinfo = {}  # for FUTURE expansion / user metadata
-        self.saved_auxinfo = saved_aux if saved_aux else dict()
+        if saved_aux:
+            self.saved_auxinfo = {
+                k: (v.copy() if isinstance(v, dict) else v)
+                for k, v in saved_aux.items()
+            }
+        else:
+            self.saved_auxinfo = {}
         return self
 
     #pickle management functions

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -1347,19 +1347,7 @@ class Circuit(object):
             ret_layer = []
             layer_lbl = self.layertup[i]
 
-            if lines is None:  # Add idles only when lines is None
-                if layer_lbl.sslbls is None:
-                    if not layer_lbl.components:
-                        components = [_Label('I', line) for line in self._line_labels]
-                    else:
-                        components = [layer_lbl]
-                else:
-                    components = list(layer_lbl.components)
-                    for line in self._line_labels:
-                        if line not in layer_lbl.sslbls:
-                            components.append(_Label('I', line))
-            else:
-                components = list(layer_lbl.components)
+            components = list(layer_lbl.components)
 
             for l in components:
                 sslbls = get_sslbls(l)
@@ -2491,7 +2479,7 @@ class Circuit(object):
         assert(not self._static), "Cannot edit a read-only circuit!"
         self.insert_circuit_inplace(circuit, 0)
 
-    def tensor_circuit_inplace(self, circuit: Circuit, line_order: Union[None, List[Union[str, int]], Tuple[Union[str, int], ...]]=None):
+    def tensor_circuit_inplace(self, circuit: Circuit, line_order: Union[None, List[Union[str, int]], Tuple[Union[str, int], ...]]=None, idle_gate_name: Union[str, _Label]='Gi'):
         """
         The tensor product of this circuit and `circuit`.
 
@@ -2599,17 +2587,27 @@ class Circuit(object):
         # We need to pad with idle gates if the circuits are not the same length.
         if len(self) < len(circuit):
             while ind < len(circuit):
-                new_layers.append(circuit.layer_label(ind))
+                lbl = circuit.layer_label(ind)
+                if lbl.sslbls is not None:
+                    idle_lbls = [_Label(idle_gate_name, line) for line in self._line_labels]
+                    for idle_lbl in idle_lbls:
+                        lbl = lbl.concat(idle_lbl)
+                new_layers.append(lbl)
                 ind += 1
         else:
             while ind < len(self):
-                new_layers.append(self.layer_label(ind))
+                lbl = self.layer_label(ind)
+                if lbl.sslbls is not None:
+                    idle_lbls = [_Label(idle_gate_name, line) for line in circuit._line_labels]
+                    for idle_lbl in idle_lbls:
+                        lbl = lbl.concat(idle_lbl)
+                new_layers.append(lbl)
                 ind += 1
 
         self._labels = new_layers
         self._line_labels = new_line_labels  # essentially just reorders labels if needed
 
-    def tensor_circuit(self, circuit: Circuit, line_order: Union[None, List[Union[str, int]], Tuple[Union[str, int], ...]]=None) -> Circuit:
+    def tensor_circuit(self, circuit: Circuit, line_order: Union[None, List[Union[str, int]], Tuple[Union[str, int], ...]]=None, idle_gate_name: Union[str, _Label]='Gi') -> Circuit:
         """
         The tensor product of this circuit and `circuit`, returning a copy.
 
@@ -2634,7 +2632,7 @@ class Circuit(object):
         """
 
         cpy = self.copy(editable=True)
-        cpy.tensor_circuit_inplace(circuit, line_order)
+        cpy.tensor_circuit_inplace(circuit, line_order, idle_gate_name)
         if self._static: cpy.done_editing()
         return cpy
 

--- a/pygsti/circuits/circuit.py
+++ b/pygsti/circuits/circuit.py
@@ -23,7 +23,7 @@ import itertools as _itertools
 import warnings as _warnings
 
 import numpy as _np
-from pygsti.baseobjs.label import Label as _Label, CircuitLabel as _CircuitLabel, LabelTupTup as _LabelTupTup
+from pygsti.baseobjs.label import Label as _Label, CircuitLabel as _CircuitLabel, LabelTupTup as _LabelTupTup, LabelStr as _LabelStr
 from pygsti.baseobjs import outcomelabeldict as _ld, _compatibility as _compat
 from pygsti.tools import internalgates as _itgs
 from pygsti.tools import slicetools as _slct
@@ -598,11 +598,13 @@ class Circuit(object):
         self._name = name  # can be None
         #self._times = None  # for FUTURE expansion
         self.auxinfo = {}  # for FUTURE expansion / user metadata
+        self.saved_auxinfo = {}
+        self.saved_auxinfo["lanes"] = {tuple(line_labels): list(self._labels)}
 
     #Note: If editing _copy_init one should also check _bare_init in case changes must be propagated.
     #specialized codepath for copying
     def _copy_init(self, labels, line_labels, editable, name='', stringrep=None, occurrence=None,
-                compilable_layer_indices_tup=(), hashable_tup=None, precomp_hash=None):
+                compilable_layer_indices_tup=(), hashable_tup=None, precomp_hash=None, saved_aux: Optional[dict[str, dict]]=None):
         self._labels = labels
         self._line_labels = line_labels
         self._occurrence_id = occurrence
@@ -619,7 +621,7 @@ class Circuit(object):
         self._name = name  # can be None
         #self._times = None  # for FUTURE expansion
         self.auxinfo = {}  # for FUTURE expansion / user metadata
-
+        self.saved_auxinfo = saved_aux if saved_aux else dict()
         return self
 
     #pickle management functions
@@ -1123,13 +1125,13 @@ class Circuit(object):
                 editable_labels =[[lbl] if lbl.IS_SIMPLE else list(lbl.components) for lbl in self._labels]
                 return ret._copy_init(editable_labels, self._line_labels, editable,
                                       self._name, self._str, self._occurrence_id,
-                                      self._compilable_layer_indices_tup)
+                                      self._compilable_layer_indices_tup, saved_aux=self.saved_auxinfo)
             else:
                 #copy the editable labels (avoiding shallow copy issues)
                 editable_labels = [sublist.copy() for sublist in self._labels]
                 return ret._copy_init(editable_labels, self._line_labels, editable,
                                       self._name, self._str, self._occurrence_id,
-                                      self._compilable_layer_indices_tup)
+                                      self._compilable_layer_indices_tup, saved_aux=self.saved_auxinfo)
         else: #create static copy
             if self._static:
                 #if presently static leverage precomputed hashable_tup and hash.
@@ -1138,14 +1140,14 @@ class Circuit(object):
                 return ret._copy_init(self._labels, self._line_labels, editable,
                                       self._name, self._str, self._occurrence_id,
                                       self._compilable_layer_indices_tup,
-                                      self._hashable_tup, self._hash)
+                                      self._hashable_tup, self._hash, saved_aux=self.saved_auxinfo)
             else:
                 static_labels = _sort_layer_labels(self._labels)
                 hashable_tup = self._tup_copy(static_labels)
                 return ret._copy_init(static_labels, self._line_labels,
                                       editable, self._name, self._str, self._occurrence_id,
                                       self._compilable_layer_indices_tup,
-                                      hashable_tup, hash(hashable_tup))
+                                      hashable_tup, hash(hashable_tup), saved_aux=self.saved_auxinfo)
     
     def sort_layer_labels_inplace(self):
         """
@@ -1343,13 +1345,26 @@ class Circuit(object):
 
         for i in layers:
             ret_layer = []
-            for l in self._layer_components(i):  # loop over labels in this layer
+            layer_lbl = self.layertup[i]
+
+            if lines is None:  # Add idles only when lines is None
+                if layer_lbl.sslbls is None:
+                    if not layer_lbl.components:
+                        components = [_Label('I', line) for line in self._line_labels]
+                    else:
+                        components = [layer_lbl]
+                else:
+                    components = list(layer_lbl.components)
+                    for line in self._line_labels:
+                        if line not in layer_lbl.sslbls:
+                            components.append(_Label('I', line))
+            else:
+                components = list(layer_lbl.components)
+
+            for l in components:
                 sslbls = get_sslbls(l)
                 if sslbls is None:
-                    ## add in special case of identity layer
-                    #if (isinstance(l,_Label) and l.name == self.identity): # ~ is_identity_layer(l)
-                    #    ret_layer.append(l); continue
-                    sslbls = set(self._line_labels)  # otherwise, treat None sslbs as *all* labels
+                    sslbls = set(self._line_labels)
                 else:
                     sslbls = set(sslbls)
                 if (strict and sslbls.issubset(lines)) or \
@@ -2539,6 +2554,10 @@ class Circuit(object):
         if len(overlap) > 0:
             raise ValueError(
                 "The line labels of `circuit` and this Circuit must be distinct, but overlap = %s!" % str(overlap))
+        if self._line_labels == '*':
+            raise ValueError("The line labels of 'self', are underspecified and are currently the placeholder labels.")
+        if circuit._line_labels == '*':
+            raise ValueError("The line labels of 'circuit', are underspecified and are currently the placeholder labels.")
 
         all_line_labels = set(self._line_labels + circuit._line_labels)
         if line_order is not None:
@@ -2559,7 +2578,35 @@ class Circuit(object):
             new_line_labels = self._line_labels + circuit._line_labels
 
         #Add circuit's labels into this circuit
-        self.insert_labels_as_lines_inplace(circuit._labels, line_labels=circuit.line_labels)
+        new_layers = []
+        ind = 0
+        while ind < min(self.num_layers, circuit.num_layers):
+            lbl = self.layer_label(ind)
+            other_lbl = circuit.layer_label(ind)
+
+            # Convert to LabelTup-esque formats.
+            if isinstance(lbl, _LabelStr):
+                # These lbls have no qubits associated with them because of reasons.
+                # So we will assume that each line in the circuit of each has that gate applied.
+                lbl = _Label(lbl.name, self.line_labels)
+            if isinstance(other_lbl, _LabelStr):
+                other_lbl = _Label(other_lbl.name, circuit.line_labels)
+
+            lbl = lbl.concat(other_lbl)
+            new_layers.append(lbl)
+            ind += 1
+
+        # We need to pad with idle gates if the circuits are not the same length.
+        if len(self) < len(circuit):
+            while ind < len(circuit):
+                new_layers.append(circuit.layer_label(ind))
+                ind += 1
+        else:
+            while ind < len(self):
+                new_layers.append(self.layer_label(ind))
+                ind += 1
+
+        self._labels = new_layers
         self._line_labels = new_line_labels  # essentially just reorders labels if needed
 
     def tensor_circuit(self, circuit: Circuit, line_order: Union[None, List[Union[str, int]], Tuple[Union[str, int], ...]]=None) -> Circuit:
@@ -2585,10 +2632,37 @@ class Circuit(object):
         -------
         Circuit
         """
+
         cpy = self.copy(editable=True)
         cpy.tensor_circuit_inplace(circuit, line_order)
         if self._static: cpy.done_editing()
         return cpy
+
+    def _cache_tensor_lanes(self, sub_circuit_list: list[_Label],
+                             lane_to_qubits: dict[int, tuple[int, ...]]) -> Circuit:
+        """
+        Store the tensor lanes in the circuit if appropriate.
+        Note that this should only be called in the case that `sub_circuit_list`
+        when tensored is equivalent to the current circuit.
+        """
+
+        if "lanes" in self.saved_auxinfo and len(self) > 0:
+            if len(self.saved_auxinfo["lanes"]) <= 1:
+                # We will update this because it is now believed that
+                # we are able to conduct the operation in cross talk free lanes.
+                qubits_used = set()
+                for qub_in_lane in lane_to_qubits.values():
+                    qubits_used = qubits_used.union(qub_in_lane)
+
+                if len(qubits_used) != self.num_lines:
+                    # Do not update.
+                    return self
+
+                self.saved_auxinfo["lanes"] = {}  # Reset lanes info
+                for i, qubit_labels in lane_to_qubits.items():
+                    self.saved_auxinfo["lanes"][tuple(sorted(qubit_labels))] = sub_circuit_list[i]
+
+        return self
 
     def replace_layer_with_circuit_inplace(self, circuit: Circuit, j):
         """
@@ -3012,6 +3086,7 @@ class Circuit(object):
                 newobj = [map_sslbls(sub) for sub in obj]
             return newobj
         self._labels = map_sslbls(self._labels)
+        self.saved_auxinfo['lanes'] = {}
 
     def map_state_space_labels(self, mapper) -> Circuit:
         """
@@ -5100,6 +5175,8 @@ class Circuit(object):
         self._str = self.str
         # ^ the accessor on the right-hand side sees that self._str
         #   is None, and so returns a value computed from scratch.
+        if 'lanes' in self.saved_auxinfo:
+            self.saved_auxinfo['lanes'] = {}
         return
 
 

--- a/pygsti/circuits/split_circuits_into_lanes.py
+++ b/pygsti/circuits/split_circuits_into_lanes.py
@@ -1,4 +1,4 @@
-import numpy as _np
+import networkx as _nx
 
 from typing import Sequence, Dict, Tuple, Optional, Set, Union
 from pygsti.circuits import Circuit as Circuit
@@ -34,120 +34,108 @@ def _map_label_state_space_labels(lbl, sslbl_map):
 
     return lbl.map_state_space_labels(sslbl_map)
 
-def compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit: Circuit) -> tuple[dict[int, int],
-                                                                                             dict[int, tuple[int]]]:
+
+def compute_qubit_lane_mappings_for_circuit(circuit: Circuit) -> tuple[dict[int, int],
+                                                                       dict[int, set[int]]]:
     """
+    Partition `circuit`'s lines ("qubits") into lanes: maximal groups of lines that
+    are connected to each other via multi-line gates, and so cannot be simulated
+    independently of one another.  Lines that never appear together in a multi-line
+    gate end up in different lanes.
+
     Parameters:
     ------------
     circuit: Circuit - the circuit to compute qubit to lanes mapping for
 
     Returns
     --------
-    Dictionary mapping qubit number to lane number in the circuit.
+    A tuple `(qubit_to_lane, lane_to_qubits)`:
+      - `qubit_to_lane` maps each of `circuit`'s line labels to the index of the
+        lane it belongs to.
+      - `lane_to_qubits` maps each lane index to the set of line labels in
+        that lane.
     """
-
-    qubits_to_potentially_entangled_others = {i: set((i,)) for i in circuit.line_labels}
-    num_layers = circuit.num_layers
-    for layer_ind in range(num_layers):
-        layer = circuit.layer(layer_ind)
-        for op in layer:
+    # Build a graph whose nodes are this circuit's lines, with an edge between
+    # any two lines that ever appear together in the same (multi-line) gate.
+    # A lane is then just a connected component of this graph -- every line
+    # starts out in its own singleton component (so that lines untouched by
+    # any multi-line gate still end up in their own lane).
+    graph = _nx.Graph()
+    graph.add_nodes_from(circuit.line_labels)
+    for layer_ind in range(circuit.num_layers):
+        for op in circuit.layer(layer_ind):
             qubits_used = op.qubits
-            for qb in qubits_used:
-                qubits_to_potentially_entangled_others[qb].update(set(qubits_used))
+            graph.add_edges_from(
+                (qubits_used[0], other) for other in qubits_used[1:]
+            )
 
-    lanes = {}
-    lan_num = 0
-    visited: dict[int, int] = {}
+    lane_to_qubits = {
+        lane_num: component
+        for lane_num, component in enumerate(_nx.connected_components(graph))
+    }
+    qubit_to_lane = {
+        qubit: lane_num
+        for lane_num, qubits in lane_to_qubits.items()
+        for qubit in qubits
+    }
 
-    def reachable_nodes(starting_point: int,
-                        graph_qubits_to_neighbors: dict[int, set[int]],
-                        visited: dict[int, set[int]]):
-        """
-        Find which nodes are reachable from this starting point.
-        """
-        if starting_point in visited:
-            return visited[starting_point]
-        else:
-            assert starting_point in graph_qubits_to_neighbors
-            visited[starting_point] = graph_qubits_to_neighbors[starting_point]
-            output = set(visited[starting_point])
-            for child in graph_qubits_to_neighbors[starting_point]:
-                if child != starting_point:
-                    output.update(output, reachable_nodes(child, graph_qubits_to_neighbors, visited))
-            visited[starting_point] = output
-            return output
-
-    available_starting_points = list(sorted(qubits_to_potentially_entangled_others.keys()))
-    while available_starting_points:
-        sp = available_starting_points[0]
-        nodes = reachable_nodes(sp, qubits_to_potentially_entangled_others, visited)
-        for node in nodes:
-            available_starting_points.remove(node)
-        lanes[lan_num] = nodes
-        lan_num += 1
-
-    def compute_qubits_to_lanes(lanes_to_qubits: dict[int, set[int]]) -> dict[int, int]:
-        """
-        Determine a mapping from qubit to the lane it is in for this specific circuit.
-        """
-        out = {}
-        for key, val in lanes_to_qubits.items():
-            for qb in val:
-                out[qb] = key
-        return out
-
-    return compute_qubits_to_lanes(lanes), lanes
+    return qubit_to_lane, lane_to_qubits
 
 
-def compute_subcircuits(circuit: Circuit,
-                        qubit_to_lanes: Optional[dict[int, int]] = None,
-                        lane_to_qubits: Optional[dict[int, tuple[int, ...]]] = None,
-                        cache_lanes_in_circuit: bool = False,
-                        idle_gate_name: Union[str, Label]="Gi") -> list[list[LabelTupTup]]:
+def split_into_tensor_lanes(circuit: Circuit,
+                            qubit_to_lanes: Optional[dict[int, int]] = None,
+                            lane_to_qubits: Optional[dict[int, tuple[int, ...]]] = None,
+                            cache_lanes_in_circuit: bool = False,
+                            idle_gate_name: Union[str, Label] = "Gi") -> list[Circuit]:
     """
-    Split a circuit into multiple subcircuits which do not talk across lanes.
+    Split a circuit into multiple subcircuits ("lanes") which do not talk across lanes.
 
-    Returns a list of those subcircuits in the format of a list of layers.
+    Note: this is distinct from the notion of a "subcircuit" elsewhere in `Circuit`
+    (a repeated block of layers represented by a :class:`CircuitLabel`) -- here,
+    a lane's "subcircuit" is a full-depth `Circuit` restricted to a subset of lines.
+
+    Returns a list of `Circuit` objects, one per lane, indexed to match
+    `lane_to_qubits`.  Each lane's circuit is built by deleting all of the other
+    lanes' lines from a copy of `circuit` (see :meth:`Circuit.delete_lines`),
+    which also validates that no gate actually straddles two different lanes.
     """
 
     if qubit_to_lanes is None or lane_to_qubits is None:
-        qubit_to_lanes, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
+        qubit_to_lanes, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(circuit)
 
     # The lanes cache is only trustworthy for *static* (read-only) circuits:
     if circuit._static and "lanes" in circuit.saved_auxinfo:
         # Check if the lane info matches and I can just return that set up.
         if len(lane_to_qubits) == len(circuit.saved_auxinfo["lanes"]):
             # We may have this already in cache.
-
-            lanes_to_gates = [[] for _ in range(len(lane_to_qubits))]
+            lane_circuits = [None] * len(lane_to_qubits)
             for i, key in lane_to_qubits.items():
                 if tuple(sorted(key)) in circuit.saved_auxinfo["lanes"]:
-                    lanes_to_gates[i] = circuit.saved_auxinfo["lanes"][tuple(sorted(key))]
-
+                    lane_circuits[i] = circuit.saved_auxinfo["lanes"][tuple(sorted(key))]
                 else:
                     raise ValueError(f"lbl cache miss: {key} in circuit {circuit}")
-            return lanes_to_gates
+            return lane_circuits
 
-    lanes_to_gates = [[] for _ in range(len(lane_to_qubits))]
-
-    num_layers = circuit.num_layers
-    for layer_ind in range(num_layers):
-        layer = circuit.layer_with_idles(layer_ind, idle_gate_name)
-        lane_groups = [[] for _ in range(len(lane_to_qubits))]
-        for op in layer:
-            qubits_used = op.qubits
-            lane = qubit_to_lanes[qubits_used[0]]
-            lane_groups[lane].append(op)
-
-        for lane, group in enumerate(lane_groups):
-            # Sort the operations in each lane group by their first qubit for deterministic output
-            sorted_group = sorted(group, key=lambda x: x.qubits[0])
-            lanes_to_gates[lane].append(Label(tuple(sorted_group))) # Go through the label factory.
+    lane_circuits: list[Circuit] = [None] * len(lane_to_qubits)
+    for lane, lane_qubits in lane_to_qubits.items():
+        other_qubits = [q for q in circuit.line_labels if q not in lane_qubits]
+        lane_circuit = circuit.copy(editable=True)
+        # delete_lines gives us straddler-detection for free: if a gate spans
+        # this lane and another one, the qubit-to-lane partition computed above
+        # was wrong, and we want that surfaced as an error rather than silently
+        # dropping/mangling the offending gate.
+        lane_circuit.delete_lines(other_qubits, delete_straddlers=False)
+        # Materialize this lane's own implicit idles into explicit
+        # `idle_gate_name` gates, so each lane's layer explicitly lists every
+        # line in that lane (matching the historical behavior of this function).
+        lane_circuit.insert_implicit_idles_inplace(idle_gate_name=idle_gate_name)
+        lane_circuit.done_editing()
+        lane_circuits[lane] = lane_circuit
 
     if cache_lanes_in_circuit:
-        circuit = circuit._cache_tensor_lanes(lanes_to_gates, lane_to_qubits)
+        circuit = circuit._cache_tensor_lanes(lane_circuits, lane_to_qubits)
 
-    return lanes_to_gates
+    return lane_circuits
 
 
 def batch_tensor(
@@ -261,5 +249,5 @@ def batch_tensor(
 
     c = c.reorder_lines(global_line_order)
     c.saved_auxinfo["lanes"] = {}
-    compute_subcircuits(c, cache_lanes_in_circuit=True)
+    split_into_tensor_lanes(c, cache_lanes_in_circuit=True)
     return c

--- a/pygsti/circuits/split_circuits_into_lanes.py
+++ b/pygsti/circuits/split_circuits_into_lanes.py
@@ -113,7 +113,8 @@ def compute_subcircuits(circuit: Circuit,
     if qubit_to_lanes is None or lane_to_qubits is None:
         qubit_to_lanes, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
 
-    if "lanes" in circuit.saved_auxinfo:
+    # The lanes cache is only trustworthy for *static* (read-only) circuits:
+    if circuit._static and "lanes" in circuit.saved_auxinfo:
         # Check if the lane info matches and I can just return that set up.
         if len(lane_to_qubits) == len(circuit.saved_auxinfo["lanes"]):
             # We may have this already in cache.

--- a/pygsti/circuits/split_circuits_into_lanes.py
+++ b/pygsti/circuits/split_circuits_into_lanes.py
@@ -2,37 +2,7 @@ import networkx as _nx
 
 from typing import Sequence, Dict, Tuple, Optional, Set, Union
 from pygsti.circuits import Circuit as Circuit
-from pygsti.baseobjs.label import Label, LabelTup, LabelTupTup
-
-
-def _map_label_state_space_labels(lbl, sslbl_map):
-    """
-    Map the state-space labels inside a Label, including LabelTupTup members.
-
-    This is used after applying a layer_mapper value, so we do not rely on
-    Circuit.map_state_space_labels_inplace to correctly descend into newly
-    created compound/parallel labels.
-    """
-
-    if lbl == Label(()):
-        return lbl
-
-    if isinstance(lbl, LabelTupTup):
-        return Label(tuple(
-            _map_label_state_space_labels(member, sslbl_map)
-            for member in lbl
-        ))
-
-    if isinstance(lbl, LabelTup):
-        return lbl.map_state_space_labels(sslbl_map)
-
-    if isinstance(lbl, tuple):
-        return tuple(
-            _map_label_state_space_labels(member, sslbl_map)
-            for member in lbl
-        )
-
-    return lbl.map_state_space_labels(sslbl_map)
+from pygsti.baseobjs.label import Label
 
 
 def compute_qubit_lane_mappings_for_circuit(circuit: Circuit) -> tuple[dict[int, int],
@@ -82,6 +52,31 @@ def compute_qubit_lane_mappings_for_circuit(circuit: Circuit) -> tuple[dict[int,
     return qubit_to_lane, lane_to_qubits
 
 
+def _lookup_cached_lanes(circuit: Circuit,
+                         lane_to_qubits: dict[int, tuple[int, ...]]) -> Optional[list[Circuit]]:
+    """
+    Return the cached lane circuits for `circuit`, if a matching cache is available.
+
+    The lanes cache is only trustworthy for *static* (read-only) circuits, and only
+    when its size matches the (freshly computed) `lane_to_qubits` partition -- otherwise
+    `None` is returned so the caller falls back to (re)computing the lanes.
+    """
+    if not (circuit._static and "lanes" in circuit.saved_auxinfo):
+        return None
+    cached_lanes = circuit.saved_auxinfo["lanes"]
+    if len(lane_to_qubits) != len(cached_lanes):
+        return None
+
+    # We may have this already in cache.
+    lane_circuits = [None] * len(lane_to_qubits)
+    for i, key in lane_to_qubits.items():
+        sorted_key = tuple(sorted(key))
+        if sorted_key not in cached_lanes:
+            raise ValueError(f"lbl cache miss: {key} in circuit {circuit}")
+        lane_circuits[i] = cached_lanes[sorted_key]
+    return lane_circuits
+
+
 def split_into_tensor_lanes(circuit: Circuit,
                             qubit_to_lanes: Optional[dict[int, int]] = None,
                             lane_to_qubits: Optional[dict[int, tuple[int, ...]]] = None,
@@ -103,18 +98,9 @@ def split_into_tensor_lanes(circuit: Circuit,
     if qubit_to_lanes is None or lane_to_qubits is None:
         qubit_to_lanes, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(circuit)
 
-    # The lanes cache is only trustworthy for *static* (read-only) circuits:
-    if circuit._static and "lanes" in circuit.saved_auxinfo:
-        # Check if the lane info matches and I can just return that set up.
-        if len(lane_to_qubits) == len(circuit.saved_auxinfo["lanes"]):
-            # We may have this already in cache.
-            lane_circuits = [None] * len(lane_to_qubits)
-            for i, key in lane_to_qubits.items():
-                if tuple(sorted(key)) in circuit.saved_auxinfo["lanes"]:
-                    lane_circuits[i] = circuit.saved_auxinfo["lanes"][tuple(sorted(key))]
-                else:
-                    raise ValueError(f"lbl cache miss: {key} in circuit {circuit}")
-            return lane_circuits
+    cached_lane_circuits = _lookup_cached_lanes(circuit, lane_to_qubits)
+    if cached_lane_circuits is not None:
+        return cached_lane_circuits
 
     lane_circuits: list[Circuit] = [None] * len(lane_to_qubits)
     for lane, lane_qubits in lane_to_qubits.items():
@@ -136,6 +122,28 @@ def split_into_tensor_lanes(circuit: Circuit,
         circuit = circuit._cache_tensor_lanes(lane_circuits, lane_to_qubits)
 
     return lane_circuits
+
+
+def _prepare_target_circuit(source: Circuit, target_line_labels: Tuple[Union[int, str], ...],
+                            max_len: int, layer_mappers: Dict[int, Dict]) -> Circuit:
+    """
+    Pad `source` to `max_len` layers, apply the appropriate `layer_mappers` entry to
+    each (local) layer label, and relabel its lines to `target_line_labels`.
+
+    Returns a brand-new `Circuit` (built via the public `Circuit` constructor) with
+    `target_line_labels` as its lines -- `source` itself is left untouched.
+    """
+    padded = source.copy(editable=True)
+    padded._append_idling_layers_inplace(max_len - len(padded))
+    padded.done_editing()
+
+    sslbl_map = dict(zip(padded.line_labels, target_line_labels))
+    mapper = layer_mappers[padded.num_lines]
+    new_layers = [
+        mapper[layer_lbl].map_state_space_labels(sslbl_map)
+        for layer_lbl in padded.layertup
+    ]
+    return Circuit(new_layers, line_labels=target_line_labels, editable=False)
 
 
 def batch_tensor(
@@ -185,66 +193,9 @@ def batch_tensor(
     if global_line_order is None:
         global_line_order = tuple(sorted(list(s)))
 
-    c = circuits[0].copy(editable=True)
-    c._append_idling_layers_inplace(max_cir_len - len(c))
-
-    local_num_lines = c.num_lines
-    local_labels = list(c._labels)
-    sslbl_map = {
-        k: v
-        for k, v in zip(c.line_labels, target_lines[0])
-    }
-
-    # First remap the circuit line labels. We will overwrite the operation labels
-    # immediately afterward, so we do not care how this maps the old local labels.
-    c.map_state_space_labels_inplace(sslbl_map)
-
-    # Now rebuild operation labels from the saved local labels, explicitly mapping
-    # any LabelTupTup members.
-    # Note: Circuit._labels stores layers as raw Python lists internally (e.g.
-    # [] for an empty/idle layer, [Label(...)] for a single-gate layer).
-    # Normalise them to Label objects before the mapper lookup.
-    def _to_label(ell):
-        if isinstance(ell, list):
-            return Label(tuple(ell))
-        return ell
-
-    c._static = False
-    c._labels = [
-        _map_label_state_space_labels(
-            layer_mappers[local_num_lines][_to_label(ell)],
-            sslbl_map,
-        )
-        for ell in local_labels
-    ]
-
-    c.done_editing()
+    c = _prepare_target_circuit(circuits[0], target_lines[0], max_cir_len, layer_mappers)
     for i, c2 in enumerate(circuits[1:]):
-        c2 = c2.copy(editable=True)
-        c2._append_idling_layers_inplace(max_cir_len - len(c2))
-
-        local_num_lines = c2.num_lines
-        local_labels = list(c2._labels)
-        sslbl_map = {
-            k: v
-            for k, v in zip(c2.line_labels, target_lines[i + 1])
-        }
-
-        # Remap line labels first.
-        c2.map_state_space_labels_inplace(sslbl_map)
-
-        # Then rebuild labels from the original local labels, explicitly remapping
-        # LabelTupTup members.
-        c2._static = False
-        c2._labels = [
-            _map_label_state_space_labels(
-                layer_mappers[local_num_lines][_to_label(ell)],
-                sslbl_map,
-            )
-            for ell in local_labels
-        ]
-
-        c2.done_editing()
+        c2 = _prepare_target_circuit(c2, target_lines[i + 1], max_cir_len, layer_mappers)
         c = c.tensor_circuit(c2)
 
     c = c.reorder_lines(global_line_order)

--- a/pygsti/circuits/split_circuits_into_lanes.py
+++ b/pygsti/circuits/split_circuits_into_lanes.py
@@ -167,7 +167,8 @@ def batch_tensor(
     Tensor together a sequence of Circuits padding smaller circuits to the length of the largest circuit
     with noisy idles.
     """
-    assert len(circuits) > 0
+    if len(circuits) < 2:
+        raise ValueError("batch_tensor requires at least two circuits to tensor together.")
     if __debug__:
         for num_lines in layer_mappers:
             if Label(()) in layer_mappers[num_lines]:
@@ -184,7 +185,7 @@ def batch_tensor(
             max_cir_len = max(max_cir_len, len(c))
     else:
         total_lines = sum([c.num_lines for c in circuits])
-        max_cir_len = max(*[len(c) for c in circuits])
+        max_cir_len = max([len(c) for c in circuits])
 
     s: Set[int] = set()
     for c, t in zip(circuits, target_lines):

--- a/pygsti/circuits/split_circuits_into_lanes.py
+++ b/pygsti/circuits/split_circuits_into_lanes.py
@@ -1,0 +1,263 @@
+import numpy as _np
+
+from typing import Sequence, Dict, Tuple, Optional, Set, Union
+from pygsti.circuits import Circuit as Circuit
+from pygsti.baseobjs.label import Label, LabelTup, LabelTupTup
+
+
+def _map_label_state_space_labels(lbl, sslbl_map):
+    """
+    Map the state-space labels inside a Label, including LabelTupTup members.
+
+    This is used after applying a layer_mapper value, so we do not rely on
+    Circuit.map_state_space_labels_inplace to correctly descend into newly
+    created compound/parallel labels.
+    """
+
+    if lbl == Label(()):
+        return lbl
+
+    if isinstance(lbl, LabelTupTup):
+        return Label(tuple(
+            _map_label_state_space_labels(member, sslbl_map)
+            for member in lbl
+        ))
+
+    if isinstance(lbl, LabelTup):
+        return lbl.map_state_space_labels(sslbl_map)
+
+    if isinstance(lbl, tuple):
+        return tuple(
+            _map_label_state_space_labels(member, sslbl_map)
+            for member in lbl
+        )
+
+    return lbl.map_state_space_labels(sslbl_map)
+
+def compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit: Circuit) -> tuple[dict[int, int],
+                                                                                             dict[int, tuple[int]]]:
+    """
+    Parameters:
+    ------------
+    circuit: Circuit - the circuit to compute qubit to lanes mapping for
+
+    Returns
+    --------
+    Dictionary mapping qubit number to lane number in the circuit.
+    """
+
+    qubits_to_potentially_entangled_others = {i: set((i,)) for i in circuit.line_labels}
+    num_layers = circuit.num_layers
+    for layer_ind in range(num_layers):
+        layer = circuit.layer(layer_ind)
+        for op in layer:
+            qubits_used = op.qubits
+            for qb in qubits_used:
+                qubits_to_potentially_entangled_others[qb].update(set(qubits_used))
+
+    lanes = {}
+    lan_num = 0
+    visited: dict[int, int] = {}
+
+    def reachable_nodes(starting_point: int,
+                        graph_qubits_to_neighbors: dict[int, set[int]],
+                        visited: dict[int, set[int]]):
+        """
+        Find which nodes are reachable from this starting point.
+        """
+        if starting_point in visited:
+            return visited[starting_point]
+        else:
+            assert starting_point in graph_qubits_to_neighbors
+            visited[starting_point] = graph_qubits_to_neighbors[starting_point]
+            output = set(visited[starting_point])
+            for child in graph_qubits_to_neighbors[starting_point]:
+                if child != starting_point:
+                    output.update(output, reachable_nodes(child, graph_qubits_to_neighbors, visited))
+            visited[starting_point] = output
+            return output
+
+    available_starting_points = list(sorted(qubits_to_potentially_entangled_others.keys()))
+    while available_starting_points:
+        sp = available_starting_points[0]
+        nodes = reachable_nodes(sp, qubits_to_potentially_entangled_others, visited)
+        for node in nodes:
+            available_starting_points.remove(node)
+        lanes[lan_num] = nodes
+        lan_num += 1
+
+    def compute_qubits_to_lanes(lanes_to_qubits: dict[int, set[int]]) -> dict[int, int]:
+        """
+        Determine a mapping from qubit to the lane it is in for this specific circuit.
+        """
+        out = {}
+        for key, val in lanes_to_qubits.items():
+            for qb in val:
+                out[qb] = key
+        return out
+
+    return compute_qubits_to_lanes(lanes), lanes
+
+
+def compute_subcircuits(circuit: Circuit,
+                        qubit_to_lanes: Optional[dict[int, int]] = None,
+                        lane_to_qubits: Optional[dict[int, tuple[int, ...]]] = None,
+                        cache_lanes_in_circuit: bool = False,
+                        idle_gate_name: Union[str, Label]="Gi") -> list[list[LabelTupTup]]:
+    """
+    Split a circuit into multiple subcircuits which do not talk across lanes.
+
+    Returns a list of those subcircuits in the format of a list of layers.
+    """
+
+    if qubit_to_lanes is None or lane_to_qubits is None:
+        qubit_to_lanes, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
+
+    if "lanes" in circuit.saved_auxinfo:
+        # Check if the lane info matches and I can just return that set up.
+        if len(lane_to_qubits) == len(circuit.saved_auxinfo["lanes"]):
+            # We may have this already in cache.
+
+            lanes_to_gates = [[] for _ in range(len(lane_to_qubits))]
+            for i, key in lane_to_qubits.items():
+                if tuple(sorted(key)) in circuit.saved_auxinfo["lanes"]:
+                    lanes_to_gates[i] = circuit.saved_auxinfo["lanes"][tuple(sorted(key))]
+
+                else:
+                    raise ValueError(f"lbl cache miss: {key} in circuit {circuit}")
+            return lanes_to_gates
+
+    lanes_to_gates = [[] for _ in range(len(lane_to_qubits))]
+
+    num_layers = circuit.num_layers
+    for layer_ind in range(num_layers):
+        layer = circuit.layer_with_idles(layer_ind, idle_gate_name)
+        lane_groups = [[] for _ in range(len(lane_to_qubits))]
+        for op in layer:
+            qubits_used = op.qubits
+            lane = qubit_to_lanes[qubits_used[0]]
+            lane_groups[lane].append(op)
+
+        for lane, group in enumerate(lane_groups):
+            # Sort the operations in each lane group by their first qubit for deterministic output
+            sorted_group = sorted(group, key=lambda x: x.qubits[0])
+            lanes_to_gates[lane].append(Label(tuple(sorted_group))) # Go through the label factory.
+
+    if cache_lanes_in_circuit:
+        circuit = circuit._cache_tensor_lanes(lanes_to_gates, lane_to_qubits)
+
+    return lanes_to_gates
+
+
+def batch_tensor(
+    circuits: Sequence[Circuit],
+    layer_mappers: Dict[int, Dict],
+    global_line_order: Optional[Tuple[Union[int, str], ...]] = None,
+    target_lines: Optional[Sequence[Tuple[Union[int, str], ...]]] = None
+) -> Circuit:
+    """
+    `circuits`: Sequence of `Circuit` the circuits you want to tensor together.
+    `layer_mappers`: dictionary of lane size to a dictionary of `Label` to `Label`.
+        Need to ensure that you have something that maps from () -> Idle gate.
+        Else you may get spurious "COMPOUND" gates.
+    'target_lines' : Optional sequence of state space labels used by each circuit.
+    `global_line_order`: The final order of the state space labels (used if one wants to make it
+        not just arange(total_lines))
+
+    Tensor together a sequence of Circuits padding smaller circuits to the length of the largest circuit
+    with noisy idles.
+    """
+    assert len(circuits) > 0
+    if __debug__:
+        for num_lines in layer_mappers:
+            if Label(()) in layer_mappers[num_lines]:
+                assert layer_mappers[num_lines][Label(())] != Label(())
+
+    if target_lines is None:
+        target_lines = []
+        total_lines = 0
+        max_cir_len = 0
+        for c in circuits:
+            # We are just going to build the target_lines as arange(num_lines)
+            target_lines.append(tuple(range(total_lines, total_lines + c.num_lines)))
+            total_lines += c.num_lines
+            max_cir_len = max(max_cir_len, len(c))
+    else:
+        total_lines = sum([c.num_lines for c in circuits])
+        max_cir_len = max(*[len(c) for c in circuits])
+
+    s: Set[int] = set()
+    for c, t in zip(circuits, target_lines):
+        assert not s.intersection(t)
+        assert len(t) == c.num_lines
+        s.update(t)
+
+    if global_line_order is None:
+        global_line_order = tuple(sorted(list(s)))
+
+    c = circuits[0].copy(editable=True)
+    c._append_idling_layers_inplace(max_cir_len - len(c))
+
+    local_num_lines = c.num_lines
+    local_labels = list(c._labels)
+    sslbl_map = {
+        k: v
+        for k, v in zip(c.line_labels, target_lines[0])
+    }
+
+    # First remap the circuit line labels. We will overwrite the operation labels
+    # immediately afterward, so we do not care how this maps the old local labels.
+    c.map_state_space_labels_inplace(sslbl_map)
+
+    # Now rebuild operation labels from the saved local labels, explicitly mapping
+    # any LabelTupTup members.
+    # Note: Circuit._labels stores layers as raw Python lists internally (e.g.
+    # [] for an empty/idle layer, [Label(...)] for a single-gate layer).
+    # Normalise them to Label objects before the mapper lookup.
+    def _to_label(ell):
+        if isinstance(ell, list):
+            return Label(tuple(ell))
+        return ell
+
+    c._static = False
+    c._labels = [
+        _map_label_state_space_labels(
+            layer_mappers[local_num_lines][_to_label(ell)],
+            sslbl_map,
+        )
+        for ell in local_labels
+    ]
+
+    c.done_editing()
+    for i, c2 in enumerate(circuits[1:]):
+        c2 = c2.copy(editable=True)
+        c2._append_idling_layers_inplace(max_cir_len - len(c2))
+
+        local_num_lines = c2.num_lines
+        local_labels = list(c2._labels)
+        sslbl_map = {
+            k: v
+            for k, v in zip(c2.line_labels, target_lines[i + 1])
+        }
+
+        # Remap line labels first.
+        c2.map_state_space_labels_inplace(sslbl_map)
+
+        # Then rebuild labels from the original local labels, explicitly remapping
+        # LabelTupTup members.
+        c2._static = False
+        c2._labels = [
+            _map_label_state_space_labels(
+                layer_mappers[local_num_lines][_to_label(ell)],
+                sslbl_map,
+            )
+            for ell in local_labels
+        ]
+
+        c2.done_editing()
+        c = c.tensor_circuit(c2)
+
+    c = c.reorder_lines(global_line_order)
+    c.saved_auxinfo["lanes"] = {}
+    compute_subcircuits(c, cache_lanes_in_circuit=True)
+    return c

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -1278,6 +1278,32 @@ class CircuitBugfixRegressionTester(BaseCase):
         c.done_editing()
         self.assertEqual(c.saved_auxinfo["lanes"], {})
 
+    def test_copy_does_not_share_saved_auxinfo(self):
+        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        c1 = circuit.Circuit("Gx:0Gy:1", line_labels=(0, 1), editable=True)
+        c1.done_editing()
+
+        c2 = c1.copy(editable=True)
+        self.assertIsNot(c1.saved_auxinfo, c2.saved_auxinfo)
+
+        # Mutate c2 so that it is different from c1
+        c2[0] = Label('Gz', 1)
+        c2.done_editing()
+
+        # Cache lanes for c2
+        q2l_c2, l2q_c2 = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c2)
+        compute_subcircuits(c2, q2l_c2, l2q_c2, cache_lanes_in_circuit=True)
+
+        # Confirm c1's lanes cache did not get contaminated
+        # (It should still be empty or contain the original Gx/Gy representation, NOT Gz)
+        self.assertNotIn((1,), c1.saved_auxinfo.get("lanes", {}))
+
+        # Calling compute_subcircuits on c1 should produce correct results representing Gx/Gy
+        q2l_c1, l2q_c1 = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c1)
+        subs_c1 = compute_subcircuits(c1, q2l_c1, l2q_c1)
+        self.assertIn(Label('Gx', 0), subs_c1[0])
+        self.assertNotIn(Label('Gz', 1), subs_c1[1])
+
     def test_batch_tensor_populates_cache(self):
         from pygsti.circuits.split_circuits_into_lanes import batch_tensor
         c1 = circuit.Circuit("Gx:0", line_labels=(0,))

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -1131,6 +1131,31 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c.line_labels, (0, 1))
         self.assertEqual(c.depth, 3)
 
+    def test_tensor_circuit_tail_padding_with_idles_ok(self):
+        c1 = circuit.Circuit("Gx:0", line_labels=(0,), editable=True)
+        c2 = circuit.Circuit("Gy:1Gy:1Gy:1", line_labels=(1,), editable=True)
+        c1.tensor_circuit_inplace(c2, idle_gate_name='Gi')
+        c1.done_editing()
+        self.assertEqual(c1.depth, 3)
+        self.assertEqual(c1.line_labels, (0, 1))
+        # Layer 0: Gx:0, Gy:1 (concatenated)
+        # Layer 1: Gy:1, Gi:0 (padded with explicit Gi:0)
+        # Layer 2: Gy:1, Gi:0 (padded with explicit Gi:0)
+        self.assertEqual(c1[0], Label([('Gx', 0), ('Gy', 1)]))
+        self.assertEqual(c1[1], Label([('Gi', 0), ('Gy', 1)]))
+        self.assertEqual(c1[2], Label([('Gi', 0), ('Gy', 1)]))
+
+        # Also test with self being longer than incoming circuit
+        c1_long = circuit.Circuit("Gy:1Gy:1Gy:1", line_labels=(1,), editable=True)
+        c2_short = circuit.Circuit("Gx:0", line_labels=(0,), editable=True)
+        c1_long.tensor_circuit_inplace(c2_short, idle_gate_name='Gi')
+        c1_long.done_editing()
+        self.assertEqual(c1_long.depth, 3)
+        self.assertEqual(c1_long.line_labels, (1, 0))
+        self.assertEqual(c1_long[0], Label([('Gx', 0), ('Gy', 1)]))
+        self.assertEqual(c1_long[1], Label([('Gi', 0), ('Gy', 1)]))
+        self.assertEqual(c1_long[2], Label([('Gi', 0), ('Gy', 1)]))
+
     def test_extract_labels_nonstrict_filters_and_line_labels(self):
         # regression test for issue #756: the non-strict membership test was
         # always true (so no filtering happened) and the result's line labels

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -1208,3 +1208,76 @@ class CircuitBugfixRegressionTester(BaseCase):
         with self.assertWarns(UserWarning) as cm:
             c.replace_gatename_inplace('Gx', 123)
         self.assertIn('new_gatename', str(cm.warning))
+
+    def test_mutation_clears_lanes_cache(self):
+        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)", editable=True)
+        # First build/cache lanes
+        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        self.assertIn("lanes", c.saved_auxinfo)
+        self.assertNotEqual(c.saved_auxinfo["lanes"], {})
+
+        # Mutate the circuit
+        c.replace_gatename_with_idle_inplace("Gx")
+        # finalization (done_editing) must clear lanes cache to {}
+        c.done_editing()
+        self.assertEqual(c.saved_auxinfo["lanes"], {})
+
+        # Verify that we can successfully compute subcircuits and cache again
+        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        self.assertNotEqual(c.saved_auxinfo["lanes"], {})
+
+    def test_rebuild_lanes_cache_when_empty(self):
+        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)")
+        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        self.assertIn("lanes", c.saved_auxinfo)
+
+        # Manually clear to empty (simulate post-mutation/done_editing empty state)
+        c.saved_auxinfo["lanes"] = {}
+        # compute_subcircuits should notice empty cache, fall back to compute, and successfully cache again
+        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        self.assertNotEqual(c.saved_auxinfo["lanes"], {})
+
+    def test_map_state_space_labels_clears_lanes_cache(self):
+        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)", editable=True)
+        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        self.assertNotEqual(c.saved_auxinfo["lanes"], {})
+
+        c.map_state_space_labels_inplace({0: 10, 1: 11})
+        c.done_editing()
+        self.assertEqual(c.saved_auxinfo["lanes"], {})
+
+    def test_batch_tensor_populates_cache(self):
+        from pygsti.circuits.split_circuits_into_lanes import batch_tensor
+        c1 = circuit.Circuit("Gx:0", line_labels=(0,))
+        c2 = circuit.Circuit("Gy:0", line_labels=(0,))
+        idle_label = Label(())
+        labels_in_circuits = [Label('Gx', (0,)), Label('Gy', (0,)), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d}
+
+        # batch_tensor should return a static circuit with a non-empty, fully populated lanes cache
+        tensored_c = batch_tensor([c1, c2], layer_mappers, target_lines=((0,), (1,)))
+        self.assertIn("lanes", tensored_c.saved_auxinfo)
+        self.assertNotEqual(tensored_c.saved_auxinfo["lanes"], {})
+        # Verify that we can query compute_subcircuits without recomputing or "lbl cache miss"
+        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(tensored_c)
+        # Should execute successfully using cache
+        compute_subcircuits(tensored_c, q2l, l2q)
+
+        # Ensure that the manually built lanes cache in tensored_c is identical to a freshly computed one
+        c_no_cache = tensored_c.copy()
+        c_no_cache.saved_auxinfo = {}
+        fresh_sub_cirs = compute_subcircuits(c_no_cache, q2l, l2q)
+        # Check matching structures
+        self.assertEqual(len(tensored_c.saved_auxinfo["lanes"]), len(l2q))
+        for lane_idx, key in l2q.items():
+            self.assertEqual(tensored_c.saved_auxinfo["lanes"][tuple(sorted(key))], fresh_sub_cirs[lane_idx])

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -1156,6 +1156,22 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c1_long[1], Label([('Gi', 0), ('Gy', 1)]))
         self.assertEqual(c1_long[2], Label([('Gi', 0), ('Gy', 1)]))
 
+    def test_tensor_circuit_rejects_placeholder_line_labels(self):
+        # regression test: `self._line_labels == '*'` never matches because
+        # `_line_labels` is stored as the tuple `('*',)`, not the bare string
+        # '*', so this guard against tensoring underspecified circuits was
+        # dead code.
+        c1 = circuit.Circuit([[]])  # placeholder ('*',) line labels
+        self.assertEqual(c1.line_labels, ('*',))
+        c2 = circuit.Circuit("Gy:0", line_labels=(0,))
+        with self.assertRaises(ValueError):
+            c1.tensor_circuit(c2)
+
+        c3 = circuit.Circuit("Gx:0", line_labels=(0,))
+        c4 = circuit.Circuit([[]])  # placeholder ('*',) line labels
+        with self.assertRaises(ValueError):
+            c3.tensor_circuit(c4)
+
     def test_extract_labels_nonstrict_filters_and_line_labels(self):
         # regression test for issue #756: the non-strict membership test was
         # always true (so no filtering happened) and the result's line labels
@@ -1236,14 +1252,16 @@ class CircuitBugfixRegressionTester(BaseCase):
 
     def test_mutation_clears_lanes_cache(self):
         from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
-        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)", editable=True)
+        # The lanes cache is only trusted/populated for static (read-only) circuits.
+        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)")
         # First build/cache lanes
         q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
         compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertIn("lanes", c.saved_auxinfo)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
 
-        # Mutate the circuit
+        # Mutate the circuit via an editable copy
+        c = c.copy(editable=True)
         c.replace_gatename_with_idle_inplace("Gx")
         # finalization (done_editing) must clear lanes cache to {}
         c.done_editing()
@@ -1253,6 +1271,28 @@ class CircuitBugfixRegressionTester(BaseCase):
         q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
         compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
+
+    def test_editable_circuit_does_not_use_or_populate_lanes_cache(self):
+        # Regression test: editable circuits can be mutated in-place without going
+        # through done_editing()/map_state_space_labels_inplace (the only two places
+        # that invalidate the lanes cache), so the cache must never be trusted for,
+        # or populated on, an editable circuit -- otherwise a subsequent in-place
+        # mutation could cause compute_subcircuits to silently return stale results.
+        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        c = circuit.Circuit("Gx:0Gy:1", line_labels=(0, 1), editable=True)
+        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+
+        out1 = compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        self.assertIn(Label('Gx', 0), out1[0])
+        # No cache should have been written since the circuit is editable.
+        self.assertEqual(c.saved_auxinfo.get("lanes", {}), {})
+
+        # Mutate in place (no done_editing() call) and confirm the *fresh* content
+        # is reflected, not stale cached content.
+        c[0] = Label('Gz', 0)
+        out2 = compute_subcircuits(c, q2l, l2q)
+        self.assertIn(Label('Gz', 0), out2[0])
+        self.assertNotIn(Label('Gx', 0), out2[0])
 
     def test_rebuild_lanes_cache_when_empty(self):
         from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
@@ -1269,11 +1309,12 @@ class CircuitBugfixRegressionTester(BaseCase):
 
     def test_map_state_space_labels_clears_lanes_cache(self):
         from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
-        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)", editable=True)
+        c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)")
         q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
         compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
 
+        c = c.copy(editable=True)
         c.map_state_space_labels_inplace({0: 10, 1: 11})
         c.done_editing()
         self.assertEqual(c.saved_auxinfo["lanes"], {})

--- a/test/unit/circuits/test_circuit.py
+++ b/test/unit/circuits/test_circuit.py
@@ -442,6 +442,29 @@ class CircuitMethodTester(BaseCase):
         self.c.tensor_circuit_inplace(c2)
         self.assertEqual(self.c.depth, max(self.c.depth, c2.depth))
 
+    def test_insert_implicit_idles_inplace_all_layers(self):
+        c = circuit.Circuit([('Gx', 0), Label(())], line_labels=(0, 1), editable=True)
+        c.insert_implicit_idles_inplace(idle_gate_name='Gi')
+        c.done_editing()
+        self.assertEqual(c[0], Label([('Gx', 0), ('Gi', 1)]))
+        self.assertEqual(c[1], Label([('Gi', 0), ('Gi', 1)]))
+
+    def test_insert_implicit_idles_inplace_selected_layers(self):
+        c = circuit.Circuit([('Gx', 0), Label(()), Label(())], line_labels=(0, 1), editable=True)
+        # Only materialize idles on layer 1; layers 0 and 2 should be untouched.
+        c.insert_implicit_idles_inplace(layers=[1], idle_gate_name='Gi')
+        c.done_editing()
+        self.assertEqual(c[0], Label(('Gx', 0)))
+        self.assertEqual(c[1], Label([('Gi', 0), ('Gi', 1)]))
+        self.assertEqual(c[2], Label(()))
+
+    def test_insert_implicit_idles_noninplace_returns_copy(self):
+        c = circuit.Circuit([('Gx', 0)], line_labels=(0, 1))
+        padded = c.insert_implicit_idles(idle_gate_name='Gi')
+        # original circuit is untouched
+        self.assertEqual(c[0], Label(('Gx', 0)))
+        self.assertEqual(padded[0], Label([('Gx', 0), ('Gi', 1)]))
+
     def test_replace_gatename_inplace(self):
         # Test changing a gate name
         self.c.replace_gatename_inplace('Gx', 'Gz')
@@ -1251,12 +1274,12 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertIn('new_gatename', str(cm.warning))
 
     def test_mutation_clears_lanes_cache(self):
-        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        from pygsti.circuits.split_circuits_into_lanes import split_into_tensor_lanes, compute_qubit_lane_mappings_for_circuit
         # The lanes cache is only trusted/populated for static (read-only) circuits.
         c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)")
         # First build/cache lanes
-        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
-        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        q2l, l2q = compute_qubit_lane_mappings_for_circuit(c)
+        split_into_tensor_lanes(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertIn("lanes", c.saved_auxinfo)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
 
@@ -1268,8 +1291,8 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c.saved_auxinfo["lanes"], {})
 
         # Verify that we can successfully compute subcircuits and cache again
-        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
-        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        q2l, l2q = compute_qubit_lane_mappings_for_circuit(c)
+        split_into_tensor_lanes(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
 
     def test_editable_circuit_does_not_use_or_populate_lanes_cache(self):
@@ -1277,12 +1300,12 @@ class CircuitBugfixRegressionTester(BaseCase):
         # through done_editing()/map_state_space_labels_inplace (the only two places
         # that invalidate the lanes cache), so the cache must never be trusted for,
         # or populated on, an editable circuit -- otherwise a subsequent in-place
-        # mutation could cause compute_subcircuits to silently return stale results.
-        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        # mutation could cause split_into_tensor_lanes to silently return stale results.
+        from pygsti.circuits.split_circuits_into_lanes import split_into_tensor_lanes, compute_qubit_lane_mappings_for_circuit
         c = circuit.Circuit("Gx:0Gy:1", line_labels=(0, 1), editable=True)
-        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+        q2l, l2q = compute_qubit_lane_mappings_for_circuit(c)
 
-        out1 = compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        out1 = split_into_tensor_lanes(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertIn(Label('Gx', 0), out1[0])
         # No cache should have been written since the circuit is editable.
         self.assertEqual(c.saved_auxinfo.get("lanes", {}), {})
@@ -1290,28 +1313,28 @@ class CircuitBugfixRegressionTester(BaseCase):
         # Mutate in place (no done_editing() call) and confirm the *fresh* content
         # is reflected, not stale cached content.
         c[0] = Label('Gz', 0)
-        out2 = compute_subcircuits(c, q2l, l2q)
+        out2 = split_into_tensor_lanes(c, q2l, l2q)
         self.assertIn(Label('Gz', 0), out2[0])
         self.assertNotIn(Label('Gx', 0), out2[0])
 
     def test_rebuild_lanes_cache_when_empty(self):
-        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        from pygsti.circuits.split_circuits_into_lanes import split_into_tensor_lanes, compute_qubit_lane_mappings_for_circuit
         c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)")
-        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
-        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        q2l, l2q = compute_qubit_lane_mappings_for_circuit(c)
+        split_into_tensor_lanes(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertIn("lanes", c.saved_auxinfo)
 
         # Manually clear to empty (simulate post-mutation/done_editing empty state)
         c.saved_auxinfo["lanes"] = {}
-        # compute_subcircuits should notice empty cache, fall back to compute, and successfully cache again
-        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        # split_into_tensor_lanes should notice empty cache, fall back to compute, and successfully cache again
+        split_into_tensor_lanes(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
 
     def test_map_state_space_labels_clears_lanes_cache(self):
-        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        from pygsti.circuits.split_circuits_into_lanes import split_into_tensor_lanes, compute_qubit_lane_mappings_for_circuit
         c = circuit.Circuit("[Gx:0][Gy:1]@(0,1)")
-        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
-        compute_subcircuits(c, q2l, l2q, cache_lanes_in_circuit=True)
+        q2l, l2q = compute_qubit_lane_mappings_for_circuit(c)
+        split_into_tensor_lanes(c, q2l, l2q, cache_lanes_in_circuit=True)
         self.assertNotEqual(c.saved_auxinfo["lanes"], {})
 
         c = c.copy(editable=True)
@@ -1320,7 +1343,7 @@ class CircuitBugfixRegressionTester(BaseCase):
         self.assertEqual(c.saved_auxinfo["lanes"], {})
 
     def test_copy_does_not_share_saved_auxinfo(self):
-        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
+        from pygsti.circuits.split_circuits_into_lanes import split_into_tensor_lanes, compute_qubit_lane_mappings_for_circuit
         c1 = circuit.Circuit("Gx:0Gy:1", line_labels=(0, 1), editable=True)
         c1.done_editing()
 
@@ -1332,16 +1355,16 @@ class CircuitBugfixRegressionTester(BaseCase):
         c2.done_editing()
 
         # Cache lanes for c2
-        q2l_c2, l2q_c2 = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c2)
-        compute_subcircuits(c2, q2l_c2, l2q_c2, cache_lanes_in_circuit=True)
+        q2l_c2, l2q_c2 = compute_qubit_lane_mappings_for_circuit(c2)
+        split_into_tensor_lanes(c2, q2l_c2, l2q_c2, cache_lanes_in_circuit=True)
 
         # Confirm c1's lanes cache did not get contaminated
         # (It should still be empty or contain the original Gx/Gy representation, NOT Gz)
         self.assertNotIn((1,), c1.saved_auxinfo.get("lanes", {}))
 
-        # Calling compute_subcircuits on c1 should produce correct results representing Gx/Gy
-        q2l_c1, l2q_c1 = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c1)
-        subs_c1 = compute_subcircuits(c1, q2l_c1, l2q_c1)
+        # Calling split_into_tensor_lanes on c1 should produce correct results representing Gx/Gy
+        q2l_c1, l2q_c1 = compute_qubit_lane_mappings_for_circuit(c1)
+        subs_c1 = split_into_tensor_lanes(c1, q2l_c1, l2q_c1)
         self.assertIn(Label('Gx', 0), subs_c1[0])
         self.assertNotIn(Label('Gz', 1), subs_c1[1])
 
@@ -1359,16 +1382,16 @@ class CircuitBugfixRegressionTester(BaseCase):
         tensored_c = batch_tensor([c1, c2], layer_mappers, target_lines=((0,), (1,)))
         self.assertIn("lanes", tensored_c.saved_auxinfo)
         self.assertNotEqual(tensored_c.saved_auxinfo["lanes"], {})
-        # Verify that we can query compute_subcircuits without recomputing or "lbl cache miss"
-        from pygsti.circuits.split_circuits_into_lanes import compute_subcircuits, compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit
-        q2l, l2q = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(tensored_c)
+        # Verify that we can query split_into_tensor_lanes without recomputing or "lbl cache miss"
+        from pygsti.circuits.split_circuits_into_lanes import split_into_tensor_lanes, compute_qubit_lane_mappings_for_circuit
+        q2l, l2q = compute_qubit_lane_mappings_for_circuit(tensored_c)
         # Should execute successfully using cache
-        compute_subcircuits(tensored_c, q2l, l2q)
+        split_into_tensor_lanes(tensored_c, q2l, l2q)
 
         # Ensure that the manually built lanes cache in tensored_c is identical to a freshly computed one
         c_no_cache = tensored_c.copy()
         c_no_cache.saved_auxinfo = {}
-        fresh_sub_cirs = compute_subcircuits(c_no_cache, q2l, l2q)
+        fresh_sub_cirs = split_into_tensor_lanes(c_no_cache, q2l, l2q)
         # Check matching structures
         self.assertEqual(len(tensored_c.saved_auxinfo["lanes"]), len(l2q))
         for lane_idx, key in l2q.items():

--- a/test/unit/circuits/test_circuit_splitting.py
+++ b/test/unit/circuits/test_circuit_splitting.py
@@ -107,10 +107,11 @@ class CircuitSplittingTester(BaseCase):
         circuit = build_circuit_with_multiple_qubit_gates_with_designated_lanes(num_qubits, depth, lane_eps, gates_to_num_used)
         qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
 
-        self.assertIn("lanes", circuit.saved_auxinfo)
-        self.assertEqual(list(circuit.saved_auxinfo["lanes"].keys()), [(0, 1, 2, 3, 4, 5)])
+        # The lanes cache is populated lazily, so nothing is cached yet.
+        self.assertNotIn("lanes", circuit.saved_auxinfo)
 
         sub_cirs = compute_subcircuits(circuit, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
+        self.assertIn("lanes", circuit.saved_auxinfo)
         self.assertEqual(len(circuit.saved_auxinfo["lanes"].keys()), len(sub_cirs))
 
     def test_subcircuits_split_cache_miss(self):

--- a/test/unit/circuits/test_circuit_splitting.py
+++ b/test/unit/circuits/test_circuit_splitting.py
@@ -165,6 +165,16 @@ class CircuitSplittingTester(BaseCase):
                 self.assertIn(qu, qubit_to_lane)
                 self.assertEqual(lane, qubit_to_lane[qu])
 
+    def test_batch_tensor_single_circuit(self):
+        c1 = _Circuit("Gx:0", line_labels=(0,))
+        idle_label = Label(())
+        labels_in_circuits = [Label('Gx', (0,)), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d}
+        with self.assertRaises(ValueError):
+            batch_tensor([c1], layer_mappers, target_lines=((0,),))
+
     def test_batch_tensor_diff_lengths(self):
         c1 = _Circuit("Gx:0", line_labels=(0,))
         c2 = _Circuit("Gy:0Gz:0", line_labels=(0,))
@@ -181,9 +191,9 @@ class CircuitSplittingTester(BaseCase):
         expected_c = c1.tensor_circuit(c2.map_state_space_labels({0:1}))
 
         # manually construct the expected circuit
-        self.assertNotEqual(tensored_c, expected_c) # explicit idles.
+        self.assertEqual(tensored_c, expected_c) # now equal due to explicit idle padding
         self.assertEqual(tensored_c[0], expected_c[0])
-        self.assertEqual(tensored_c[1][1], expected_c[1])
+        self.assertEqual(tensored_c[1], expected_c[1])
 
     def test_batch_tensor_reorder(self):
         c1 = _Circuit("Gx:0", line_labels=(0,))

--- a/test/unit/circuits/test_circuit_splitting.py
+++ b/test/unit/circuits/test_circuit_splitting.py
@@ -196,6 +196,47 @@ class CircuitSplittingTester(BaseCase):
         self.assertEqual(tensored_c[0], expected_c[0])
         self.assertEqual(tensored_c[1], expected_c[1])
 
+    def test_batch_tensor_diff_lengths_first_circuit_longer(self):
+        # Regression test / complement to test_batch_tensor_diff_lengths: here the
+        # -- every circuit is independently padded up to the overall max length,
+        # regardless of its position in `circuits`.
+        c1 = _Circuit("Gy:0Gz:0", line_labels=(0,))
+        c2 = _Circuit("Gx:0", line_labels=(0,))
+
+        idle_label = Label(())  # empty label is the idle
+        labels_in_circuits = [Label('Gx', (0,)), Label('Gy', (0,)), Label("Gz", 0), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d}
+
+        tensored_c = batch_tensor([c1, c2], layer_mappers)
+        expected_c = c1.tensor_circuit(c2.map_state_space_labels({0: 1}))
+
+        self.assertEqual(tensored_c, expected_c)
+        self.assertEqual(tensored_c[0], expected_c[0])
+        self.assertEqual(tensored_c[1], expected_c[1])
+
+    def test_batch_tensor_diff_lengths_middle_circuit_longest(self):
+        # Regression test / complement to test_batch_tensor_diff_lengths: here the
+        # -- every circuit is independently padded up to the overall max length,
+        # regardless of its position in `circuits`.
+        c1 = _Circuit("Gx:0", line_labels=(0,))
+        c2 = _Circuit("Gy:0Gy:0Gy:0", line_labels=(0,))
+        c3 = _Circuit("Gz:0Gz:0", line_labels=(0,))
+
+        idle_label = Label(())
+        labels_in_circuits = [Label('Gx', (0,)), Label('Gy', (0,)), Label("Gz", 0), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d, 3: map_d}
+
+        tensored_c = batch_tensor([c1, c2, c3], layer_mappers)
+        self.assertEqual(tensored_c.num_layers, 3)
+        self.assertEqual(tensored_c.num_lines, 3)
+        self.assertEqual(tensored_c[0], Label([('Gx', 0), ('Gy', 1), ('Gz', 2)]))
+        self.assertEqual(tensored_c[1], Label([('Gi', 0), ('Gy', 1), ('Gz', 2)]))
+        self.assertEqual(tensored_c[2], Label([('Gi', 0), ('Gy', 1), ('Gi', 2)]))
+
     def test_batch_tensor_reorder(self):
         c1 = _Circuit("Gx:0", line_labels=(0,))
         c2 = _Circuit("Gy:0", line_labels=(0,))

--- a/test/unit/circuits/test_circuit_splitting.py
+++ b/test/unit/circuits/test_circuit_splitting.py
@@ -216,6 +216,50 @@ class CircuitSplittingTester(BaseCase):
         self.assertEqual(tensored_c[0][1], Label(("Gy", "Q1")))
         self.assertEqual(tensored_c[0][0], Label(("Gx", "Q0")))
 
+    def test_batch_tensor_reorder_with_multiqubit_gate(self):
+        # Three circuits, one of which contains a 2-qubit gate, tensored together with
+        # non-contiguous/non-default target_lines and a global_line_order that is neither
+        # the default sorted order nor a simple reversal.
+        c1 = _Circuit([Label('Gcnot', (0, 1))], line_labels=(0, 1))
+        c2 = _Circuit("Gy:0", line_labels=(0,))
+        c3 = _Circuit("Gz:0", line_labels=(0,))
+
+        circuits = [c1, c2, c3]
+
+        idle_label = Label(())  # empty label is the idle
+        labels_in_circuits = [
+            Label('Gcnot', (0, 1)), Label('Gy', (0,)), Label('Gz', (0,)), idle_label
+        ]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d}
+
+        # c1 uses two target lines, c2 and c3 each use one.
+        target_lines = (('Q0', 'Q2'), ('Q1',), ('Q3',))
+        # Neither sorted(('Q0','Q1','Q2','Q3')) nor its reverse.
+        global_line_order = ('Q3', 'Q0', 'Q1', 'Q2')
+
+        tensored_c = batch_tensor(
+            circuits, layer_mappers,
+            global_line_order=global_line_order,
+            target_lines=target_lines
+        )
+
+        self.assertEqual(tensored_c.line_labels, global_line_order)
+
+        expected_c = _Circuit(
+            [Label([('Gcnot', 'Q0', 'Q2'), ('Gy', 'Q1'), ('Gz', 'Q3')])],
+            line_labels=['Q3', 'Q0', 'Q1', 'Q2']
+        )
+        self.assertEqual(tensored_c, expected_c)
+
+        # Confirm the 2-qubit gate still acts on its correct (remapped) target lines,
+        # not on some other pair introduced by the reordering.
+        layer = tensored_c[0]
+        cnot_ops = [op for op in layer if op.name == 'Gcnot']
+        self.assertEqual(len(cnot_ops), 1)
+        self.assertEqual(set(cnot_ops[0].qubits), {'Q0', 'Q2'})
+
     def test_batch_tensor_string_labels(self):
         c1 = _Circuit("Gx:0", line_labels=(0,))
         c2 = _Circuit("Gy:0", line_labels=(0,))

--- a/test/unit/circuits/test_circuit_splitting.py
+++ b/test/unit/circuits/test_circuit_splitting.py
@@ -1,8 +1,8 @@
 from pygsti.circuits.circuit import Circuit as _Circuit
 from pygsti.baseobjs.label import Label
 from pygsti.circuits.split_circuits_into_lanes import (
-    compute_subcircuits,
-    compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit,
+    split_into_tensor_lanes,
+    compute_qubit_lane_mappings_for_circuit,
     batch_tensor
 )
 import numpy as np
@@ -91,7 +91,7 @@ class CircuitSplittingTester(BaseCase):
         qubits_to_lanes = {0: 0}
         lane_to_qubits = {0: (0,)}
 
-        attempt = compute_subcircuits(original, qubits_to_lanes, lane_to_qubits)
+        attempt = split_into_tensor_lanes(original, qubits_to_lanes, lane_to_qubits)
         self.assertEqual(original, _Circuit(attempt[0], line_labels=[0]))
 
     def test_subcircuits_split_can_be_cached(self):
@@ -105,21 +105,21 @@ class CircuitSplittingTester(BaseCase):
 
         # This is a random circuit so the lanes may not be perfect.
         circuit = build_circuit_with_multiple_qubit_gates_with_designated_lanes(num_qubits, depth, lane_eps, gates_to_num_used)
-        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
+        qubit_to_lane, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(circuit)
 
         # The lanes cache is populated lazily, so nothing is cached yet.
         self.assertNotIn("lanes", circuit.saved_auxinfo)
 
-        sub_cirs = compute_subcircuits(circuit, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
+        sub_cirs = split_into_tensor_lanes(circuit, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
         self.assertIn("lanes", circuit.saved_auxinfo)
         self.assertEqual(len(circuit.saved_auxinfo["lanes"].keys()), len(sub_cirs))
 
     def test_subcircuits_split_cache_miss(self):
         c = _Circuit([('Gx', 0), ('Gy', 1)], line_labels=[0, 1])
-        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+        qubit_to_lane, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(c)
 
         # Cache the lanes in the circuit.
-        sub_cirs = compute_subcircuits(c, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
+        sub_cirs = split_into_tensor_lanes(c, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
         self.assertIn("lanes", c.saved_auxinfo)
 
         # Create a copy and map state space labels, which will result in cleared lanes cache on done_editing.
@@ -137,7 +137,7 @@ class CircuitSplittingTester(BaseCase):
         # Manually inject a stale key to verify that "lbl cache miss" check works when a mismatching key is present.
         c_mapped.saved_auxinfo["lanes"] = {(0,): None, (1,): None}
         with self.assertRaisesRegex(ValueError, "lbl cache miss"):
-            compute_subcircuits(c_mapped, qubit_to_lane_mapped, lane_to_qubits_mapped)
+            split_into_tensor_lanes(c_mapped, qubit_to_lane_mapped, lane_to_qubits_mapped)
 
     def test_find_qubit_to_lane_splitting(self):
         gates_to_num_used = {"X": 1, "Y": 1, "Z": 1, "CNOT": 2, "CZ": 2}
@@ -152,7 +152,7 @@ class CircuitSplittingTester(BaseCase):
         # This is a random circuit so the lanes may not be perfect.
         circuit = build_circuit_with_multiple_qubit_gates_with_designated_lanes(num_qubits, depth, lane_eps, gates_to_num_used)
 
-        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
+        qubit_to_lane, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(circuit)
 
         self.assertEqual(len(qubit_to_lane), num_qubits)
         self.assertGreaterEqual(len(lane_to_qubits), minimum_num_lanes)
@@ -318,7 +318,7 @@ class CircuitSplittingTester(BaseCase):
             [Label('Gx', 0), Label('Gy', 1), Label('Gz', 2)]
         ], line_labels=[0, 1, 2])
 
-        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c_interleaved)
+        qubit_to_lane, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(c_interleaved)
 
         # Confirm the lane structure is interleaved.
         # Lane 0 should be {0, 2} and Lane 1 should be {1}.
@@ -326,7 +326,7 @@ class CircuitSplittingTester(BaseCase):
         self.assertEqual(lane_to_qubits[1], {1})
 
         # Compute the subcircuits.
-        sub_cirs = compute_subcircuits(c_interleaved, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
+        sub_cirs = split_into_tensor_lanes(c_interleaved, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
 
         # Expected: Each subcircuit has exactly 2 layers (since the input circuit has 2 layers).
         # The lane-keyed grouping fix ensures that Lane 0's subcircuit second layer is not
@@ -342,7 +342,7 @@ class CircuitSplittingTester(BaseCase):
             [Label('Gx', 0), Label('Gy', 1), Label('Gz', 2)]
         ], line_labels=[0, 1, 2])
 
-        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c_contiguous)
+        qubit_to_lane, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(c_contiguous)
 
         # Confirm the lane structure is contiguous.
         # Lane 0 should be {0, 1} and Lane 1 should be {2}.
@@ -350,7 +350,7 @@ class CircuitSplittingTester(BaseCase):
         self.assertEqual(lane_to_qubits[1], {2})
 
         # Compute the subcircuits.
-        sub_cirs = compute_subcircuits(c_contiguous, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
+        sub_cirs = split_into_tensor_lanes(c_contiguous, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
 
         # For contiguous lanes, sorting by qubit index works perfectly.
         # So each subcircuit should correctly have exactly 2 layers (depth 2).
@@ -370,13 +370,13 @@ class CircuitSplittingTester(BaseCase):
             [Label('Gcnot', (0, 3))]
         ], line_labels=[0, 1, 2, 3])
 
-        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c_deep)
+        qubit_to_lane, lane_to_qubits = compute_qubit_lane_mappings_for_circuit(c_deep)
 
         self.assertEqual(lane_to_qubits[0], {0, 3})
         self.assertEqual(lane_to_qubits[1], {1})
         self.assertEqual(lane_to_qubits[2], {2})
 
-        sub_cirs = compute_subcircuits(c_deep, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
+        sub_cirs = split_into_tensor_lanes(c_deep, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
 
         # The subcircuit for every single lane must contain exactly 5 layers (equal to input circuit layers),
         # demonstrating that our fix perfectly preserves the one-layer-per-layer invariant under interleaving.

--- a/test/unit/circuits/test_circuit_splitting.py
+++ b/test/unit/circuits/test_circuit_splitting.py
@@ -1,0 +1,330 @@
+from pygsti.circuits.circuit import Circuit as _Circuit
+from pygsti.baseobjs.label import Label
+from pygsti.circuits.split_circuits_into_lanes import (
+    compute_subcircuits,
+    compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit,
+    batch_tensor
+)
+import numpy as np
+import pytest
+from ..util import BaseCase
+
+
+def build_circuit(num_qubits: int, depth_L: int, allowed_gates: set[str]) -> _Circuit:
+    """
+    Build a random circuit of depth L which operates on num_qubits and has the allowed
+    single qubit gates specified in allowed gates.
+    """
+    my_circuit = []
+    for _ in range(depth_L):
+        layer = []
+        for qnum in range(num_qubits):
+            gate = str(np.random.choice(allowed_gates))
+            layer.append((gate, qnum))
+        my_circuit.append(layer)
+    return _Circuit(my_circuit, line_labels=[i for i in range(num_qubits)])
+
+
+def build_circuit_with_multiple_qubit_gates_with_designated_lanes(
+                                num_qubits: int,
+                                depth_L: int,
+                                lane_end_points: list[int],
+                                gates_to_qubits_used: dict[str, int]) -> _Circuit:
+    """
+    Builds a circuit with a known lane structure.
+    Any two + qubit lanes can be split into smaller lanes if none of the gates
+    chosen for that lane actually operate on two or more qubits.
+    """
+
+    assert lane_end_points[-1] <= num_qubits # if < then we have a lane from there to num_qubits.
+    assert lane_end_points[0] > 0
+    assert np.all(np.diff(lane_end_points) > 0) # then it is sorted in increasing order.
+
+    if lane_end_points[-1] < num_qubits:
+        lane_end_points.append(num_qubits)
+
+    my_circuit = []
+    n_qs_to_gates_avail = {}
+    for key, val in gates_to_qubits_used.items():
+        if val in n_qs_to_gates_avail:
+            n_qs_to_gates_avail[val].append(key)
+        else:
+            n_qs_to_gates_avail[val] = [key]
+
+    for _ in range(depth_L):
+        layer = []
+        start_point = 0
+
+        for lane_ep in lane_end_points:
+            num_used: int = 0
+            while num_used < (lane_ep - start_point):
+                navail = (lane_ep - start_point) - num_used
+                nchosen = 0
+                if navail >= max(n_qs_to_gates_avail):
+                    # we can use any gate
+                    nchosen = np.random.randint(1, max(n_qs_to_gates_avail) + 1)
+                else:
+                    # we need to first choose how many to use.
+                    nchosen = np.random.randint(1, navail + 1)
+                gate = str(np.random.choice(n_qs_to_gates_avail[nchosen]))
+                tmp = list(np.random.permutation(nchosen) + num_used + start_point) # Increase to offset.
+                perm_of_qubits_used = [int(tmp[ind]) for ind in range(len(tmp))]
+                if gate == "Gcustom":
+                    layer.append(Label(gate, *perm_of_qubits_used, args=(np.random.random(4)*4*np.pi)))
+                else:
+                    layer.append((gate, *perm_of_qubits_used))
+                num_used += nchosen
+
+            if num_used > (lane_ep - start_point) + 1:
+                print(num_used, f"lane ({start_point}, {lane_ep})")
+                raise AssertionError("lane barrier is broken")
+            
+            start_point = lane_ep
+        my_circuit.append(layer)
+    return _Circuit(my_circuit, line_labels=[i for i in range(num_qubits)])
+
+
+class CircuitSplittingTester(BaseCase):
+    def test_subcircuits_splits_can_create_empty_sub_circuit(self):
+        original = _Circuit([], line_labels=[0])
+
+        qubits_to_lanes = {0: 0}
+        lane_to_qubits = {0: (0,)}
+
+        attempt = compute_subcircuits(original, qubits_to_lanes, lane_to_qubits)
+        self.assertEqual(original, _Circuit(attempt[0], line_labels=[0]))
+
+    def test_subcircuits_split_can_be_cached(self):
+        gates_to_num_used = {"X": 1, "Y": 1, "Z": 1, "CNOT": 2, "CZ": 2}
+
+        depth = 10
+        num_qubits = 6
+
+        lane_eps = [1, 2, 4, 5]
+        # So expected lane dist is (0, ), (1), (2,3), (4,), (5,)
+
+        # This is a random circuit so the lanes may not be perfect.
+        circuit = build_circuit_with_multiple_qubit_gates_with_designated_lanes(num_qubits, depth, lane_eps, gates_to_num_used)
+        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
+
+        self.assertIn("lanes", circuit.saved_auxinfo)
+        self.assertEqual(list(circuit.saved_auxinfo["lanes"].keys()), [(0, 1, 2, 3, 4, 5)])
+
+        sub_cirs = compute_subcircuits(circuit, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
+        self.assertEqual(len(circuit.saved_auxinfo["lanes"].keys()), len(sub_cirs))
+
+    def test_subcircuits_split_cache_miss(self):
+        c = _Circuit([('Gx', 0), ('Gy', 1)], line_labels=[0, 1])
+        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c)
+
+        # Cache the lanes in the circuit.
+        sub_cirs = compute_subcircuits(c, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=True)
+        self.assertIn("lanes", c.saved_auxinfo)
+
+        # Create a copy and map state space labels, which will result in cleared lanes cache on done_editing.
+        c_mapped = c.copy(editable=True)
+        c_mapped.map_state_space_labels_inplace({0: 10, 1: 11})
+        c_mapped.done_editing()
+
+        # The cache should be empty (invalidated) after done_editing
+        self.assertEqual(c_mapped.saved_auxinfo["lanes"], {})
+
+        # Now, manually define lane mapping for the mapped circuit.
+        qubit_to_lane_mapped = {10: 0, 11: 1}
+        lane_to_qubits_mapped = {0: (10,), 1: (11,)}
+
+        # Manually inject a stale key to verify that "lbl cache miss" check works when a mismatching key is present.
+        c_mapped.saved_auxinfo["lanes"] = {(0,): None, (1,): None}
+        with self.assertRaisesRegex(ValueError, "lbl cache miss"):
+            compute_subcircuits(c_mapped, qubit_to_lane_mapped, lane_to_qubits_mapped)
+
+    def test_find_qubit_to_lane_splitting(self):
+        gates_to_num_used = {"X": 1, "Y": 1, "Z": 1, "CNOT": 2, "CZ": 2}
+
+        depth = 10
+        num_qubits = 6
+
+        lane_eps = [1, 2, 4, 5]
+        # So expected lane dist is (0, ), (1), (2,3), (4,), (5,)
+        minimum_num_lanes = 5
+
+        # This is a random circuit so the lanes may not be perfect.
+        circuit = build_circuit_with_multiple_qubit_gates_with_designated_lanes(num_qubits, depth, lane_eps, gates_to_num_used)
+
+        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(circuit)
+
+        self.assertEqual(len(qubit_to_lane), num_qubits)
+        self.assertGreaterEqual(len(lane_to_qubits), minimum_num_lanes)
+        self.assertLessEqual(len(lane_to_qubits), num_qubits)
+
+        for qubit in qubit_to_lane:
+            self.assertIn(qubit_to_lane[qubit], lane_to_qubits)
+
+        for lane in lane_to_qubits:
+            for qu in lane_to_qubits[lane]:
+                self.assertIn(qu, qubit_to_lane)
+                self.assertEqual(lane, qubit_to_lane[qu])
+
+    def test_batch_tensor_diff_lengths(self):
+        c1 = _Circuit("Gx:0", line_labels=(0,))
+        c2 = _Circuit("Gy:0Gz:0", line_labels=(0,))
+
+        idle_label = Label(()) # empty label is the idle
+        labels_in_circuits = [Label('Gx', (0,)), Label('Gy', (0,)), Label("Gz", 0), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d}
+
+        # Call batch_tensor
+        tensored_c = batch_tensor([c1, c2], layer_mappers)
+
+        expected_c = c1.tensor_circuit(c2.map_state_space_labels({0:1}))
+
+        # manually construct the expected circuit
+        self.assertNotEqual(tensored_c, expected_c) # explicit idles.
+        self.assertEqual(tensored_c[0], expected_c[0])
+        self.assertEqual(tensored_c[1][1], expected_c[1])
+
+    def test_batch_tensor_reorder(self):
+        c1 = _Circuit("Gx:0", line_labels=(0,))
+        c2 = _Circuit("Gy:0", line_labels=(0,))
+        idle_label = Label(()) # empty label is the idle
+        labels_in_circuits = [Label('Gx', (0,)), Label('Gy', (0,)), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d}
+
+        # Call batch_tensor
+        tensored_c = batch_tensor([c1, c2], layer_mappers, global_line_order=('Q1', 'Q0'), target_lines=(('Q0',), ('Q1',)))
+        expected_c = _Circuit([Label([('Gx', 'Q0'), ('Gy', 'Q1')])], line_labels=['Q1', 'Q0'])
+
+        self.assertEqual(tensored_c, expected_c)
+        self.assertEqual(tensored_c.line_labels, ("Q1", "Q0"))
+        # We store them still in the canonically ordered form.
+        # However, we will print them in the order specified by line labels.
+        self.assertEqual(tensored_c[0][1], Label(("Gy", "Q1")))
+        self.assertEqual(tensored_c[0][0], Label(("Gx", "Q0")))
+
+    def test_batch_tensor_string_labels(self):
+        c1 = _Circuit("Gx:0", line_labels=(0,))
+        c2 = _Circuit("Gy:0", line_labels=(0,))
+        idle_label = Label(()) # empty label is the idle
+        labels_in_circuits = [Label('Gx', (0,)), Label('Gy', (0,)), idle_label]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        layer_mappers = {1: map_d, 2: map_d}
+
+        # Call batch_tensor
+        tensored_c = batch_tensor([c1, c2], layer_mappers, target_lines=(('Q0',), ('Q1',)))
+        expected_c = _Circuit([Label([('Gx', 'Q0'), ('Gy', 'Q1')])], line_labels=['Q0', 'Q1'])
+
+        self.assertEqual(tensored_c, expected_c)
+
+    def test_batch_tensor_5_circuits_with_2q_gate(self):
+        c1 = _Circuit("Gx:0", line_labels=(0,))
+        c2 = _Circuit("Gy:0", line_labels=(0,))
+        c3 = _Circuit([Label("Gcnot", (0, 1))], line_labels=(0, 1))
+        c4 = _Circuit("Gz:0", line_labels=(0,))
+        c5 = _Circuit("Gh:0", line_labels=(0,))
+
+        circuits = [c1, c2, c3, c4, c5]
+
+        idle_label = Label(())  # empty label is the idle
+        labels_in_circuits = [
+            Label('Gx', (0,)), Label('Gy', (0,)), Label('Gz', (0,)), Label('Gh', (0,)),
+            idle_label
+        ]
+        map_d = {l: l for l in labels_in_circuits}
+        map_d[idle_label] = Label("Gi", 0)
+        map_2d = {k: v for k,v in map_d.items()}
+        map_2d[Label('Gcnot', (0, 1))] = Label('Gcnot', (0, 1))
+        
+        layer_mappers = {1: map_d, 2: map_2d}
+
+        tensored_c = batch_tensor(circuits, layer_mappers)
+
+        expected_c = _Circuit([
+            Label([
+                ('Gx', 0),
+                ('Gy', 1),
+                ('Gcnot', 2, 3),
+                ('Gz', 4),
+                ('Gh', 5)
+            ])
+        ])
+
+        self.assertEqual(tensored_c, expected_c)
+
+    def test_subcircuits_interleaved_lanes_depth(self):
+        # Create a circuit where Lane 0 contains non-contiguous qubits {0, 2}
+        # and Lane 1 contains qubit {1}.
+        c_interleaved = _Circuit([
+            [Label('Gcnot', (0, 2))],
+            [Label('Gx', 0), Label('Gy', 1), Label('Gz', 2)]
+        ], line_labels=[0, 1, 2])
+
+        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c_interleaved)
+
+        # Confirm the lane structure is interleaved.
+        # Lane 0 should be {0, 2} and Lane 1 should be {1}.
+        self.assertEqual(lane_to_qubits[0], {0, 2})
+        self.assertEqual(lane_to_qubits[1], {1})
+
+        # Compute the subcircuits.
+        sub_cirs = compute_subcircuits(c_interleaved, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
+
+        # Expected: Each subcircuit has exactly 2 layers (since the input circuit has 2 layers).
+        # The lane-keyed grouping fix ensures that Lane 0's subcircuit second layer is not
+        # split into two layers, preserving the correct depth of 2.
+        self.assertEqual(len(sub_cirs[0]), 2, f"Lane 0 subcircuit depth inflated to {len(sub_cirs[0])}!")
+        self.assertEqual(len(sub_cirs[1]), 2)
+
+    def test_subcircuits_contiguous_lanes_depth(self):
+        # Control case: Create a circuit where Lane 0 contains contiguous qubits {0, 1}
+        # and Lane 1 contains qubit {2}.
+        c_contiguous = _Circuit([
+            [Label('Gcnot', (0, 1))],
+            [Label('Gx', 0), Label('Gy', 1), Label('Gz', 2)]
+        ], line_labels=[0, 1, 2])
+
+        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c_contiguous)
+
+        # Confirm the lane structure is contiguous.
+        # Lane 0 should be {0, 1} and Lane 1 should be {2}.
+        self.assertEqual(lane_to_qubits[0], {0, 1})
+        self.assertEqual(lane_to_qubits[1], {2})
+
+        # Compute the subcircuits.
+        sub_cirs = compute_subcircuits(c_contiguous, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
+
+        # For contiguous lanes, sorting by qubit index works perfectly.
+        # So each subcircuit should correctly have exactly 2 layers (depth 2).
+        self.assertEqual(len(sub_cirs[0]), 2)
+        self.assertEqual(len(sub_cirs[1]), 2)
+
+    def test_subcircuits_multi_layer_interleaved_lanes(self):
+        # Additional multi-layer interleaved regression test to confirm the one-layer-per-layer-per-lane invariant
+        # holds across arbitrary depths.
+        # Here we have 4 qubits: Lane 0 = {0, 3}, Lane 1 = {1}, Lane 2 = {2} (interleaved)
+        # Deep multi-layer circuit:
+        c_deep = _Circuit([
+            [Label('Gcnot', (0, 3))],
+            [Label('Gx', 0), Label('Gy', 1), Label('Gz', 2), Label('Gh', 3)],
+            [Label('Gy', 1), Label('Gz', 2)],
+            [Label('Gx', 0), Label('Gh', 3)],
+            [Label('Gcnot', (0, 3))]
+        ], line_labels=[0, 1, 2, 3])
+
+        qubit_to_lane, lane_to_qubits = compute_qubit_to_lane_and_lane_to_qubits_mappings_for_circuit(c_deep)
+
+        self.assertEqual(lane_to_qubits[0], {0, 3})
+        self.assertEqual(lane_to_qubits[1], {1})
+        self.assertEqual(lane_to_qubits[2], {2})
+
+        sub_cirs = compute_subcircuits(c_deep, qubit_to_lane, lane_to_qubits, cache_lanes_in_circuit=False)
+
+        # The subcircuit for every single lane must contain exactly 5 layers (equal to input circuit layers),
+        # demonstrating that our fix perfectly preserves the one-layer-per-layer invariant under interleaving.
+        self.assertEqual(len(sub_cirs[0]), 5)
+        self.assertEqual(len(sub_cirs[1]), 5)
+        self.assertEqual(len(sub_cirs[2]), 5)

--- a/test/unit/objects/test_label.py
+++ b/test/unit/objects/test_label.py
@@ -1237,3 +1237,17 @@ class LabelConcateTester(BaseCase):
             for result in (cl1.concat(other), other.concat(cl1)):
                 self.assertIsInstance(result, LabelTupTup)
                 self.assertFalse(has_circuitlabel(result))
+
+    def test_concat_unwraps_single_component(self):
+        # Concatenation resulting in 1 component should return the component itself (LabelTup/LabelTupWithTime)
+        # instead of wrapping it in a LabelTupTup.
+        l1 = L(('Gx', 0))
+        empty = LabelTupTup.init(())
+        res1 = l1.concat(empty)
+        self.assertIsInstance(res1, LabelTup)
+        self.assertEqual(res1, l1)
+
+        res2 = empty.concat(l1)
+        self.assertIsInstance(res2, LabelTup)
+        self.assertEqual(res2, l1)
+

--- a/test/unit/protocols/test_protocols.py
+++ b/test/unit/protocols/test_protocols.py
@@ -161,7 +161,10 @@ class ExperimentDesignTester(BaseCase):
             edesign.write(root)
             loaded_edesign = type(edesign).from_dir(root)
             # TODO: We don't have good edesign equality
-            self.assertEqual(set(edesign.all_circuits_needing_data), set(loaded_edesign.all_circuits_needing_data))
+            self.assertEqual(
+                set([c.serialize() for c in edesign.all_circuits_needing_data]),
+                set([c.serialize() for c in loaded_edesign.all_circuits_needing_data])
+            )
             self.assertEqual(edesign.auxfile_types, loaded_edesign.auxfile_types)
             self.assertEqual(edesign._vals.keys(), loaded_edesign._vals.keys())
 
@@ -174,7 +177,10 @@ class ExperimentDesignTester(BaseCase):
                 edesign.write(root2)
                 loaded_edesign = type(edesign).from_dir(root2)
                 # TODO: We don't have good edesign equality
-                self.assertEqual(set(edesign.all_circuits_needing_data), set(loaded_edesign.all_circuits_needing_data))
+                self.assertEqual(
+                    set([c.serialize() for c in edesign.all_circuits_needing_data]),
+                    set([c.serialize() for c in loaded_edesign.all_circuits_needing_data])
+                )
                 self.assertEqual(edesign.auxfile_types, loaded_edesign.auxfile_types)
                 self.assertEqual(edesign._vals.keys(), loaded_edesign._vals.keys())
                 self.assertTrue((root2 / 'edesign' / 'all_circuits_needing_data.txt').exists())

--- a/test/unit/protocols/test_protocols.py
+++ b/test/unit/protocols/test_protocols.py
@@ -162,8 +162,8 @@ class ExperimentDesignTester(BaseCase):
             loaded_edesign = type(edesign).from_dir(root)
             # TODO: We don't have good edesign equality
             self.assertEqual(
-                set([c for c in edesign.all_circuits_needing_data]),
-                set([c for c in loaded_edesign.all_circuits_needing_data])
+                set(edesign.all_circuits_needing_data),
+                set(loaded_edesign.all_circuits_needing_data)
             )
             self.assertEqual(edesign.auxfile_types, loaded_edesign.auxfile_types)
             self.assertEqual(edesign._vals.keys(), loaded_edesign._vals.keys())
@@ -178,8 +178,8 @@ class ExperimentDesignTester(BaseCase):
                 loaded_edesign = type(edesign).from_dir(root2)
                 # TODO: We don't have good edesign equality
                 self.assertEqual(
-                    set([c for c in edesign.all_circuits_needing_data]),
-                    set([c for c in loaded_edesign.all_circuits_needing_data])
+                    set(edesign.all_circuits_needing_data),
+                    set(loaded_edesign.all_circuits_needing_data)
                 )
                 self.assertEqual(edesign.auxfile_types, loaded_edesign.auxfile_types)
                 self.assertEqual(edesign._vals.keys(), loaded_edesign._vals.keys())

--- a/test/unit/protocols/test_protocols.py
+++ b/test/unit/protocols/test_protocols.py
@@ -162,8 +162,8 @@ class ExperimentDesignTester(BaseCase):
             loaded_edesign = type(edesign).from_dir(root)
             # TODO: We don't have good edesign equality
             self.assertEqual(
-                set([c.serialize() for c in edesign.all_circuits_needing_data]),
-                set([c.serialize() for c in loaded_edesign.all_circuits_needing_data])
+                set([c for c in edesign.all_circuits_needing_data]),
+                set([c for c in loaded_edesign.all_circuits_needing_data])
             )
             self.assertEqual(edesign.auxfile_types, loaded_edesign.auxfile_types)
             self.assertEqual(edesign._vals.keys(), loaded_edesign._vals.keys())
@@ -178,8 +178,8 @@ class ExperimentDesignTester(BaseCase):
                 loaded_edesign = type(edesign).from_dir(root2)
                 # TODO: We don't have good edesign equality
                 self.assertEqual(
-                    set([c.serialize() for c in edesign.all_circuits_needing_data]),
-                    set([c.serialize() for c in loaded_edesign.all_circuits_needing_data])
+                    set([c for c in edesign.all_circuits_needing_data]),
+                    set([c for c in loaded_edesign.all_circuits_needing_data])
                 )
                 self.assertEqual(edesign.auxfile_types, loaded_edesign.auxfile_types)
                 self.assertEqual(edesign._vals.keys(), loaded_edesign._vals.keys())


### PR DESCRIPTION
Split off from PR #735

This PR focuses on the ability to lane circuits. It is not dependent on #848.

A circuit can be split into lanes, which are sets of non-interacting qubits. Once we have those lanes, we can potentially simulate the circuit more quickly depending on the error model.

The current way to build a circuit with a known lane structure is to use the function `batch_tensor`, which requires two or more circuits (it will raise an error if given only one). Note that the lane structure will not be generated until you either build the circuit with `batch_tensor` or call `compute_subcircuits(circuit, cache_lanes_in_circuit=True)`. This cache is only used for static (read-only) circuits, so it cannot go stale from an in-place edit; converting a circuit back to editable and calling `done_editing()` clears the cache. A future PR may update the cache based upon the action done to the circuit, but that is not available at this time.

When calling `compute_subcircuits`, the caller does not need to specify the lane partition (`qubit_to_lanes`/`lane_to_qubits`); if omitted, it will be automatically detected from the circuit. However, if the partition is already known, passing it in explicitly avoids the detection step and will be faster.

Each circuit's lane cache is independent: copying a circuit deep-copies `saved_auxinfo`, so mutating one circuit's cache cannot corrupt another's.

This PR is purely standalone infrastructure in `pygsti/circuits/` (`split_circuits_into_lanes.py` plus supporting cache hooks in `Circuit`). It is not yet wired into any forward simulator, protocol, or layout code — that integration is left for a future PR.

Tests are in `test/unit/circuits/test_circuit_splitting.py` and cover: basic lane splitting and caching, cache invalidation/miss detection, automatic lane detection, `batch_tensor` with mismatched-depth circuits, custom line ordering (including multi-qubit gates and string labels), the single-circuit error case, and regression cases for non-contiguous/interleaved lanes.