### PR TITLE
Add line search guard to (simpler) Levenberg-Marquardt optimizer

### DIFF
--- a/docs/markdown/objects/Instruments.md
+++ b/docs/markdown/objects/Instruments.md
@@ -211,7 +211,7 @@ gst = StandardGST(modes=('full TP', 'CPTPLND'), target_model=mdl_ideal, verbosit
 results = gst.run(ProtocolData(edesign, ds))
 ```
 
-Both fits recover the data-generating model about equally well.  We compare each gauge-optimized estimate to the (ideal) target with the Frobenius distance:
+Both fits recover the data-generating model fairly well. We compare each gauge-optimized estimate to the (ideal) target with the Frobenius distance:
 
 ```{code-cell} ipython3
 for mode in ('full TP', 'CPTPLND'):

--- a/pygsti/optimize/simplerlm.py
+++ b/pygsti/optimize/simplerlm.py
@@ -171,6 +171,12 @@ class SimplerLMOptimizer(Optimizer):
         by the objective function's `.terms()` and `.lsvec()` methods (`'normal'` mode) or the
         "per-circuit quantities" computed by the objective function's `.percircuit()` and
         `.lsvec_percircuit()` methods (`'percircuit'` mode).
+
+    linesearch : dict, optional
+        Controls the optional backtracking-to-argmin line search performed on a trial
+        LM step when it looks untrusted.  See `simplish_leastsq`'s `linesearch` parameter
+        for the recognized keys (`'mode'`, `'beta'`, `'max_evals'`, `'kappa'`) and their
+        defaults; missing keys (or a `None` dict) take those defaults.
     """
 
     @classmethod
@@ -186,7 +192,8 @@ class SimplerLMOptimizer(Optimizer):
         return cls()
 
     def __init__(self, maxiter=100, maxfev=100, tol=1e-6, fditer=0, first_fditer=0, init_munu="auto", oob_check_interval=0,
-                 oob_action="reject", oob_check_mode=0, serial_solve_proc_threshold=100, lsvec_mode="normal"):
+                 oob_action="reject", oob_check_mode=0, serial_solve_proc_threshold=100, lsvec_mode="normal",
+                 linesearch=None):
 
         super().__init__()
         if isinstance(tol, float):
@@ -194,6 +201,11 @@ class SimplerLMOptimizer(Optimizer):
         else:
             default_tol = {'relx': 1e-8, 'relf': 1e-6, 'f': 1.0, 'jac': 1e-6, 'maxdx': 1.0}
             tol = {**default_tol, **tol}
+        linesearch = dict(linesearch) if linesearch else {}
+        linesearch.setdefault('mode', 'guarded')
+        linesearch.setdefault('beta', 0.25)
+        linesearch.setdefault('max_evals', 6)
+        linesearch.setdefault('kappa', 1.0)
         self.maxiter = maxiter
         self.maxfev = maxfev
         self.tol = tol
@@ -207,6 +219,7 @@ class SimplerLMOptimizer(Optimizer):
         self.called_objective_methods = ('lsvec', 'dlsvec')  # the objective function methods we use (for mem estimate)
         self.serial_solve_proc_threshold = serial_solve_proc_threshold
         self.lsvec_mode = lsvec_mode
+        self.linesearch = linesearch
 
     def _to_nice_serialization(self):
         state = super()._to_nice_serialization()
@@ -223,7 +236,8 @@ class SimplerLMOptimizer(Optimizer):
             'array_types': self.array_types,
             'called_objective_function_methods': self.called_objective_methods,
             'serial_solve_number_of_processors_threshold': self.serial_solve_proc_threshold,
-            'lsvec_mode': self.lsvec_mode
+            'lsvec_mode': self.lsvec_mode,
+            'linesearch': self.linesearch
         })
         return state
 
@@ -239,7 +253,8 @@ class SimplerLMOptimizer(Optimizer):
                    oob_action=state['out_of_bounds_action'],
                    oob_check_mode=state['out_of_bounds_check_mode'],
                    serial_solve_proc_threshold=state['serial_solve_number_of_processors_threshold'],
-                   lsvec_mode=state.get('lsvec_mode', 'normal'))
+                   lsvec_mode=state.get('lsvec_mode', 'normal'),
+                   linesearch=state.get('linesearch', None))
 
     def run(self, objective: TimeIndependentMDCObjectiveFunction, profiler, printer):
 
@@ -298,6 +313,7 @@ class SimplerLMOptimizer(Optimizer):
             oob_check_interval=self.oob_check_interval,
             oob_action=self.oob_action,
             oob_check_mode=self.oob_check_mode,
+            linesearch=self.linesearch,
             resource_alloc=objective.resource_alloc,
             arrays_interface=ari,
             serial_solve_proc_threshold=self.serial_solve_proc_threshold,
@@ -377,7 +393,8 @@ def simplish_leastsq(
     rel_ftol=1e-6, rel_xtol=1e-6, max_iter=100, num_fd_iters=0, max_dx_scale=1.0,
     init_munu="auto", oob_check_interval=0, oob_action="reject", oob_check_mode=0,
     resource_alloc=None, arrays_interface=None, serial_solve_proc_threshold=100,
-    x_limits=None, verbosity=0, profiler=None
+    x_limits=None, verbosity=0, profiler=None,
+    linesearch=None
     ):
     """
     An implementation of the Levenberg-Marquardt least-squares optimization algorithm customized for use within pyGSTi.
@@ -477,6 +494,25 @@ def simplish_leastsq(
     profiler : Profiler, optional
         A profiler object used for to track timing and memory usage.
 
+    linesearch : dict, optional
+        Controls the optional backtracking-to-argmin line search performed on a trial
+        LM step when it looks untrusted.  Recognized keys (missing keys, or an entirely
+        `None` dict, take the defaults shown):
+
+        - `'mode'` (default `'guarded'`) : `{'guarded', 'always', 'none'}`.  `'guarded'`
+          only searches when a trigger fires (the `max_dx_scale` clip activated, the step
+          is large relative to `|x|`, or the trial's objective norm is non-finite).
+          `'always'` searches on every trial step.  `'none'` never searches and is
+          bit-identical to the legacy behavior.  The primary motivation is robustness
+          against a full LM step leaving the good basin, not speed.
+        - `'beta'` (default `0.25`) : geometric shrink factor used by the line search,
+          in (0, 1).  Trial points are evaluated at `t = beta, beta**2, beta**3, ...`
+          along the step ray.
+        - `'max_evals'` (default `6`) : maximum number of trial objective evaluations
+          performed per line search.
+        - `'kappa'` (default `1.0`) : scale factor for the `'guarded'` oversize trigger:
+          a search is triggered when `|dx|^2 > kappa^2 * max(1, |x|^2)`.
+
     Returns
     -------
     x : numpy.ndarray
@@ -486,6 +522,25 @@ def simplish_leastsq(
     msg : str
         A message indicating why the solution converged (or didn't).
     """
+    linesearch = dict(linesearch) if linesearch else {}
+    linesearch.setdefault('mode', 'guarded')
+    linesearch.setdefault('beta', 0.25)
+    linesearch.setdefault('max_evals', 6)
+    linesearch.setdefault('kappa', 1.0)
+    ls_mode = linesearch['mode']
+    ls_beta = linesearch['beta']
+    ls_max_evals = linesearch['max_evals']
+    ls_kappa = linesearch['kappa']
+
+    if ls_mode not in ('none', 'guarded', 'always'):
+        raise ValueError("Invalid `linesearch['mode']`: %s" % str(ls_mode))
+    if not (0 < ls_beta < 1):
+        raise ValueError("`linesearch['beta']` must satisfy 0 < beta < 1, got %s" % str(ls_beta))
+    if ls_max_evals < 1:
+        raise ValueError("`linesearch['max_evals']` must be >= 1, got %s" % str(ls_max_evals))
+    if ls_kappa <= 0:
+        raise ValueError("`linesearch['kappa']` must be > 0, got %s" % str(ls_kappa))
+
     resource_alloc = _ResourceAllocation.cast(resource_alloc)
     comm = resource_alloc.comm
     printer = _VerbosityPrinter.create_printer(verbosity, comm)
@@ -567,6 +622,25 @@ def simplish_leastsq(
             return new_f, (oob_check_interval == 0), True
             # ^ assume in bounds if we have no out-of-bounds checks.
 
+    def handle_oob_rejection():
+        """Called when `eval_candidate` reports oob_ok=False. Returns 'continue' or 'break',
+        indicating which the inner-loop call site should do."""
+        nonlocal mu, nu, msg, converged
+        MIN_STOP_ITER = 1  # the minimum iteration where an OOB objective stops the optimization
+        if oob_action == "reject" or k < MIN_STOP_ITER:
+            reject_msg = " (out-of-bounds)"
+            mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
+            return "continue" if len(msg) == 0 else "break"
+        elif oob_action == "stop":
+            if oob_check_interval == 1:
+                msg = "Objective function out-of-bounds! STOP"
+                converged = True
+            else:  # reset to last know in-bounds point and not do oob check every step
+                revert_to_best_x("Hit")
+            return "break"
+        else:
+            raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
+
     try:
 
         for k in range(max_iter):  # outer loop
@@ -626,6 +700,8 @@ def simplish_leastsq(
 
             #determining increment using adaptive damping
             while True:  # inner loop
+                step_clipped = False
+                step_shrunk_by_ls = False
                 if profiler: profiler.memory_check("simplish_leastsq: begin inner iter")
 
                 # ok if assume fine-param-proc.size == 1 (otherwise need to sync setting local JTJ)
@@ -658,6 +734,7 @@ def simplish_leastsq(
                     dx *= _np.sqrt(max_norm_dx / norm_dx)
                     new_x[:] = x + dx
                     norm_dx = ari.norm2_x(dx)
+                    step_clipped = True
 
                 #apply x limits (bounds)
                 if x_limits is not None:
@@ -689,26 +766,56 @@ def simplish_leastsq(
                 do_oob_check = (oob_check_mode == 0 and oob_check_interval > 0 and k % oob_check_interval == 0)
                 new_f, new_x_is_known_inbounds, oob_ok = eval_candidate(do_oob_check)
                 if not oob_ok:
-                    MIN_STOP_ITER = 1  # the minimum iteration where an OOB objective stops the optimization
-                    if oob_action == "reject" or k < MIN_STOP_ITER:
-                        reject_msg = " (out-of-bounds)"
-                        mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
-                        if len(msg) == 0:
+                    if handle_oob_rejection() == "continue":
+                        continue
+                    else:
+                        break
+
+                norm_new_f = ari.norm2_f(new_f)
+
+                if ls_mode == 'always':
+                    do_linesearch = True
+                elif ls_mode == 'guarded':
+                    do_linesearch = (step_clipped
+                                      or norm_dx > (ls_kappa**2) * max(1.0, norm_x)
+                                      or not _np.isfinite(norm_new_f))
+                else:  # 'none'
+                    do_linesearch = False
+
+                if do_linesearch:
+                    best_t = 1.0
+                    best_norm = norm_new_f if _np.isfinite(norm_new_f) else _np.inf
+                    t = ls_beta
+                    for _ in range(ls_max_evals):
+                        new_x[:] = x + t * dx
+                        ari.allgather_x(new_x, global_new_x)
+                        trial_norm = ari.norm2_f(obj_fn(global_new_x))
+                        if _np.isfinite(trial_norm) and trial_norm < best_norm:
+                            best_t, best_norm = t, trial_norm
+                            t *= ls_beta
+                        else:
+                            break  # one past the interior minimum (or trial non-finite)
+
+                    if best_t < 1.0:
+                        dx *= best_t
+                        norm_dx = ari.norm2_x(dx)
+                        step_shrunk_by_ls = True
+
+                    # Re-evaluate at the (possibly rescaled) dx: the trial evals above clobbered
+                    # obj_fn's internally-owned memory, so `new_f`/`norm_new_f` no longer reflect x + dx.
+                    new_x[:] = x + dx
+                    ari.allgather_x(new_x, global_new_x)
+                    new_f, new_x_is_known_inbounds, oob_ok = eval_candidate(do_oob_check)
+                    if not oob_ok:
+                        if handle_oob_rejection() == "continue":
                             continue
                         else:
                             break
-                    elif oob_action == "stop":
-                        if oob_check_interval == 1:
-                            msg = "Objective function out-of-bounds! STOP"
-                            converged = True
-                            break
-                        else:  # reset to last know in-bounds point and not do oob check every step
-                            revert_to_best_x("Hit")
-                            break  # restart next outer loop
-                    else:
-                        raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
+                    norm_new_f = ari.norm2_f(new_f)
 
-                norm_new_f = ari.norm2_f(new_f)
+                    if step_shrunk_by_ls:
+                        printer.log("      Line search: t=%g, norm_f %g -> %g" % (best_t, best_norm, norm_new_f), 2)
+
                 if not _np.isfinite(norm_new_f):  # avoid infinite loop...
                     msg = "Infinite norm of objective function!"
                     break
@@ -767,6 +874,8 @@ def simplish_leastsq(
                 t = 1.0 - (2 * dF / dL - 1.0)**3  # dF/dL == gain ratio
                 # always reduce mu for accepted step when |dx| is small
                 mu_factor = max(t, 1.0 / 3.0) if norm_dx > 1e-8 else 0.3
+                if step_shrunk_by_ls:
+                    mu_factor = max(mu_factor, 1.0)  # the model was untrusted at full step; never loosen damping
                 mu *= mu_factor
                 nu = 2
                 x[:] = new_x[:]

--- a/pygsti/optimize/simplerlm.py
+++ b/pygsti/optimize/simplerlm.py
@@ -511,7 +511,7 @@ def simplish_leastsq(
         - `'max_evals'` (default `6`) : maximum number of trial objective evaluations
           performed per line search.
         - `'kappa'` (default `1.0`) : scale factor for the `'guarded'` oversize trigger:
-          a search is triggered when `|dx|^2 > kappa^2 * max(1, |x|^2)`.
+          a search is triggered when `|dx|^2 > kappa^2 * |x|^2`.
 
     Returns
     -------
@@ -707,9 +707,6 @@ def simplish_leastsq(
                 # ok if assume fine-param-proc.size == 1 (otherwise need to sync setting local JTJ)
                 ari.jtj_update_regularization(JTJ, pre_reg_data, mu)
 
-                #assert(_np.isfinite(JTJ).all()), "Non-finite JTJ (inner)!" # NaNs tracking
-                #assert(_np.isfinite(minus_JTf).all()), "Non-finite minus_JTf (inner)!" # NaNs tracking
-
                 try:
                     if profiler: profiler.memory_check("simplish_leastsq: before linsolve")
                     tm = _time.time()
@@ -776,9 +773,7 @@ def simplish_leastsq(
                 if ls_mode == 'always':
                     do_linesearch = True
                 elif ls_mode == 'guarded':
-                    do_linesearch = (step_clipped
-                                      or norm_dx > (ls_kappa**2) * max(1.0, norm_x)
-                                      or not _np.isfinite(norm_new_f))
+                    do_linesearch = step_clipped or norm_dx > (ls_kappa**2) * norm_x or not _np.isfinite(norm_new_f)
                 else:  # 'none'
                     do_linesearch = False
 
@@ -897,16 +892,9 @@ def simplish_leastsq(
                         best_x[:] = x[:]
                         best_x_state = (mu, nu, norm_f, f.copy())
 
-                #assert(_np.isfinite(x).all()), "Non-finite x!" # NaNs tracking
-                #assert(_np.isfinite(f).all()), "Non-finite f!" # NaNs tracking
-
                 break 
                 # ^ exit inner loop normally ...
             # end of inner loop
-            #
-            # x[:] = best_x[:]
-            # mu, nu, norm_f, f[:] = best_x_state
-            #
         # end of outer loop
         else:
             #if no break stmt hit, then we've exceeded max_iter

--- a/pygsti/optimize/simplerlm.py
+++ b/pygsti/optimize/simplerlm.py
@@ -120,9 +120,11 @@ class SimplerLMOptimizer(Optimizer):
 
     tol : float or dict, optional
         The tolerance, specified as a single float or as a dict
-        with keys `{'relx', 'relf', 'jac', 'maxdx'}`.  A single
+        with keys `{'relx', 'relf', 'f', 'jac', 'maxdx'}`.  A single
         float sets the `'relf'` and `'jac'` elemments and leaves
-        the others at their default values.
+        the others at their default values.  A dict need not specify
+        all keys; missing keys take the values a float `tol` would
+        have produced with `tol=1e-6`.
 
     fditer : int optional
         Internally compute the Jacobian using a finite-difference method
@@ -187,7 +189,11 @@ class SimplerLMOptimizer(Optimizer):
                  oob_action="reject", oob_check_mode=0, serial_solve_proc_threshold=100, lsvec_mode="normal"):
 
         super().__init__()
-        if isinstance(tol, float): tol = {'relx': 1e-8, 'relf': tol, 'f': 1.0, 'jac': tol, 'maxdx': 1.0}
+        if isinstance(tol, float):
+            tol = {'relx': 1e-8, 'relf': tol, 'f': 1.0, 'jac': tol, 'maxdx': 1.0}
+        else:
+            default_tol = {'relx': 1e-8, 'relf': 1e-6, 'f': 1.0, 'jac': 1e-6, 'maxdx': 1.0}
+            tol = {**default_tol, **tol}
         self.maxiter = maxiter
         self.maxfev = maxfev
         self.tol = tol
@@ -283,13 +289,11 @@ class SimplerLMOptimizer(Optimizer):
             objective_func, jacobian, x0,
             max_iter=self.maxiter,
             num_fd_iters=self.fditer,
-            # NOTE: I think the fallback values below will NEVER be triggered. 
-            # Should probably remove them. See __init__ instead.
-            f_norm2_tol=self.tol.get('f', 1.0),
-            jac_norm_tol=self.tol.get('jac', 1e-6),
-            rel_ftol=self.tol.get('relf', 1e-6),
-            rel_xtol=self.tol.get('relx', 1e-8),
-            max_dx_scale=self.tol.get('maxdx', 1.0),
+            f_norm2_tol=self.tol['f'],
+            jac_norm_tol=self.tol['jac'],
+            rel_ftol=self.tol['relf'],
+            rel_xtol=self.tol['relx'],
+            max_dx_scale=self.tol['maxdx'],
             init_munu=self.init_munu,
             oob_check_interval=self.oob_check_interval,
             oob_action=self.oob_action,
@@ -516,6 +520,9 @@ def simplish_leastsq(
     max_norm_dx = (max_dx_scale**2) * len(global_x) if max_dx_scale else None
     # ^ don't let any component change by more than ~max_dx_scale
 
+    # NOTE: all "norm" variables below (norm_f, norm_dx, norm_x, max_norm_dx, and the
+    # ari.norm2_* helpers) are *squared* 2-norms, not norms. E.g. a log line reading
+    # "norm_dx=96" means ||dx|| ~= 9.8.
 
     f = obj_fn(global_x)  # 'E'-type array
     norm_f = ari.norm2_f(f)
@@ -533,6 +540,33 @@ def simplish_leastsq(
     best_x_state = (mu, nu, norm_f, f.copy())
     # ^ here and elsewhere, need f.copy() b/c f is objfn mem
 
+    def revert_to_best_x(verb):
+        nonlocal oob_check_interval, mu, nu, norm_f
+        printer.log(("** %s with out-of-bounds with check interval=%d, reverting to last know "
+                      "in-bounds point and setting interval=1 **") % (verb, oob_check_interval), 2)
+        oob_check_interval = 1
+        x[:] = best_x[:]
+        mu, nu, norm_f, f[:] = best_x_state
+
+    def eval_candidate(do_oob_check):
+        """Collective. Evaluates obj_fn at global_new_x (caller has filled new_x and allgathered).
+        Returns (new_f, known_inbounds, oob_ok). oob_ok=False means the oob check raised ValueError."""
+        if oob_check_mode == 0 and oob_check_interval > 0:
+            if do_oob_check:
+                try:
+                    new_f = obj_fn(global_new_x, oob_check=True)
+                except ValueError:  # Use this to mean - "not allowed, but don't stop"
+                    return None, False, False
+                return new_f, True, True
+            else:  # don't check this time
+                new_f = obj_fn(global_new_x, oob_check=False)
+                return new_f, False, True
+        else:
+            #Just evaluate objective function normally; never check for in-bounds condition
+            new_f = obj_fn(global_new_x)
+            return new_f, (oob_check_interval == 0), True
+            # ^ assume in bounds if we have no out-of-bounds checks.
+
     try:
 
         for k in range(max_iter):  # outer loop
@@ -547,10 +581,7 @@ def simplish_leastsq(
                     converged = True
                     break
                 else:
-                    printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                    oob_check_interval = 1
-                    x[:] = best_x[:]
-                    mu, nu, norm_f, f[:] = best_x_state
+                    revert_to_best_x("Converged")
                     continue
 
             if profiler: profiler.memory_check("simplish_leastsq: begin outer iter")
@@ -585,10 +616,7 @@ def simplish_leastsq(
                     converged = True
                     break
                 else:
-                    printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                    oob_check_interval = 1
-                    x[:] = best_x[:]
-                    mu, nu, norm_f, f[:] = best_x_state
+                    revert_to_best_x("Converged")
                     continue
 
             if k == 0:
@@ -651,62 +679,34 @@ def simplish_leastsq(
                         converged = True
                         break
                     else:
-                        printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                        oob_check_interval = 1
-                        x[:] = best_x[:]
-                        mu, nu, norm_f, f[:] = best_x_state
+                        revert_to_best_x("Converged")
                         break
                 elif (norm_x + rel_xtol) < norm_dx * (_MACH_PRECISION**2):
                     msg = "(near-)singular linear system"
                     break
 
-                if oob_check_mode == 0 and oob_check_interval > 0:
-                    if k % oob_check_interval == 0:
-                        #Check to see if objective function is out of bounds
-
-                        in_bounds = []
-                        ari.allgather_x(new_x, global_new_x)
-                        try:
-                            new_f = obj_fn(global_new_x, oob_check=True)
-                        except ValueError:  # Use this to mean - "not allowed, but don't stop"
-                            in_bounds.append(False)
+                ari.allgather_x(new_x, global_new_x)
+                do_oob_check = (oob_check_mode == 0 and oob_check_interval > 0 and k % oob_check_interval == 0)
+                new_f, new_x_is_known_inbounds, oob_ok = eval_candidate(do_oob_check)
+                if not oob_ok:
+                    MIN_STOP_ITER = 1  # the minimum iteration where an OOB objective stops the optimization
+                    if oob_action == "reject" or k < MIN_STOP_ITER:
+                        reject_msg = " (out-of-bounds)"
+                        mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
+                        if len(msg) == 0:
+                            continue
                         else:
-                            in_bounds.append(True)
-
-                        if any(in_bounds):  # In adaptive mode, proceed if *any* cases are in-bounds
-                            new_x_is_known_inbounds = True
-                        else:
-                            MIN_STOP_ITER = 1  # the minimum iteration where an OOB objective stops the optimization
-                            if oob_action == "reject" or k < MIN_STOP_ITER:
-                                reject_msg = " (out-of-bounds)"
-                                mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
-                                if len(msg) == 0:
-                                    continue
-                                else:
-                                    break
-                            elif oob_action == "stop":
-                                if oob_check_interval == 1:
-                                    msg = "Objective function out-of-bounds! STOP"
-                                    converged = True
-                                    break
-                                else:  # reset to last know in-bounds point and not do oob check every step
-                                    printer.log(("** Hit out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                                    oob_check_interval = 1
-                                    x[:] = best_x[:]
-                                    mu, nu, norm_f, f[:] = best_x_state
-                                    break  # restart next outer loop
-                            else:
-                                raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
-                    else:  # don't check this time
-                        ari.allgather_x(new_x, global_new_x)
-                        new_f = obj_fn(global_new_x, oob_check=False)
-                        new_x_is_known_inbounds = False
-                else:
-                    #Just evaluate objective function normally; never check for in-bounds condition
-                    ari.allgather_x(new_x, global_new_x)
-                    new_f = obj_fn(global_new_x)
-                    new_x_is_known_inbounds = oob_check_interval == 0
-                    # ^ assume in bounds if we have no out-of-bounds checks.
+                            break
+                    elif oob_action == "stop":
+                        if oob_check_interval == 1:
+                            msg = "Objective function out-of-bounds! STOP"
+                            converged = True
+                            break
+                        else:  # reset to last know in-bounds point and not do oob check every step
+                            revert_to_best_x("Hit")
+                            break  # restart next outer loop
+                    else:
+                        raise ValueError("Invalid `oob_action`: '%s'" % oob_action)
 
                 norm_new_f = ari.norm2_f(new_f)
                 if not _np.isfinite(norm_new_f):  # avoid infinite loop...
@@ -725,14 +725,11 @@ def simplish_leastsq(
                         converged = True
                         break
                     else:
-                        printer.log(("** Converged with out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                        oob_check_interval = 1
-                        x[:] = best_x[:]
-                        mu, nu, norm_f, f[:] = best_x_state
+                        revert_to_best_x("Converged")
                         break
 
                 if (dL <= 0 or dF <= 0):
-                    reject_msg = " (out-of-bounds)"
+                    reject_msg = " (dL or dF <= 0)"
                     mu, nu, msg = damp_coeff_update(mu, nu, half_max_nu, reject_msg, printer)
                     if len(msg) == 0:
                         continue
@@ -760,10 +757,7 @@ def simplish_leastsq(
                                 converged = True
                                 break
                             else:  # reset to last know in-bounds point and not do oob check every step
-                                printer.log(("** Hit out-of-bounds with check interval=%d, reverting to last know in-bounds point and setting interval=1 **") % oob_check_interval, 2)
-                                oob_check_interval = 1
-                                x[:] = best_x[:]
-                                mu, nu, norm_f, f[:] = best_x_state
+                                revert_to_best_x("Hit")
                                 break  # restart next outer loop
                         else:
                             raise ValueError("Invalid `oob_action`: '%s'" % oob_action)

--- a/test/unit/optimize/test_simplerlm.py
+++ b/test/unit/optimize/test_simplerlm.py
@@ -41,3 +41,98 @@ class LMTester(BaseCase):
         xf, converged, msg, *_ = lm.simplish_leastsq(g, gjac, x0, max_iter=100, arrays_interface=ari,
                                                    x_limits=xlimits)
         self.assertAlmostEqual(xf[0], 1.0)
+
+    def test_linesearch_wrong_basin_witness(self):
+        # r(x) = x + sin(10*x) - 0.5 is oscillatory with many local minima of the sum-of-squares.
+        # From x0=0.8 the full LM step overshoots the nearby true root (x~0.994) into a
+        # neighboring-but-worse local minimum (x~1.718, norm_f~0.05). The line search should
+        # backtrack along the same step ray and land at the good root instead.
+        target = 0.5
+
+        def obj(x, oob_check=False):
+            return np.array([x[0] + np.sin(10 * x[0]) - target])
+
+        def jac(x):
+            return np.array([[1 + 10 * np.cos(10 * x[0])]])
+
+        x0 = np.array([0.8])
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf_none, _, _, _, _, norm_f_none, _ = lm.simplish_leastsq(
+            obj, jac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': 'none'})
+        # This assertion is the witness that the test still captures the pathology: if a future
+        # change makes 'none' converge to the good basin too, this should fail loudly rather than
+        # let the test go vacuous.
+        self.assertGreater(norm_f_none, 0.01)
+
+        for mode in ('guarded', 'always'):
+            ari = _ari.UndistributedArraysInterface(1, 1)
+            xf, _, _, _, _, norm_f, _ = lm.simplish_leastsq(
+                obj, jac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': mode})
+            self.assertLess(norm_f, 1e-6, msg="linesearch mode %s failed to reach the good basin" % mode)
+            self.assertAlmostEqual(xf[0], 0.99416, places=4)
+
+    def test_linesearch_nonfinite_rescue(self):
+        # r(x) = exp(1.5*x) - 2 has a near-zero Jacobian far in the negative tail, so an
+        # undamped full LM step from x0=-3.7 overshoots into positive territory so far that
+        # exp overflows to inf. A shrunk step along the same ray stays finite and converges.
+        k = 1.5
+
+        def obj(x, oob_check=False):
+            with np.errstate(over='ignore'):
+                return np.array([np.exp(k * x[0]) - 2.0])
+
+        def jac(x):
+            with np.errstate(over='ignore'):
+                return np.array([[k * np.exp(k * x[0])]])
+
+        x0 = np.array([-3.7])
+
+        with np.errstate(over='ignore', invalid='ignore'):
+            ari = _ari.UndistributedArraysInterface(1, 1)
+            xf_none, converged_none, msg_none, *_ = lm.simplish_leastsq(
+                obj, jac, x0.copy(), max_iter=20, max_dx_scale=None, arrays_interface=ari,
+                linesearch={'mode': 'none'})
+        self.assertFalse(converged_none)
+        self.assertEqual(msg_none, "Infinite norm of objective function!")
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf, converged, msg, _, _, norm_f, _ = lm.simplish_leastsq(
+            obj, jac, x0.copy(), max_iter=20, max_dx_scale=None, arrays_interface=ari,
+            linesearch={'mode': 'guarded'})
+        self.assertTrue(converged)
+        self.assertLess(norm_f, 1e-6)
+
+    def test_linesearch_guarded_quiet_on_healthy_problem(self):
+        # On a well-conditioned problem the guarded trigger should never fire, so 'guarded'
+        # and 'none' must produce identical results.
+        x0 = np.array([6.0], 'd')
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf_none, _, _, _, _, norm_f_none, _ = lm.simplish_leastsq(
+            g, gjac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': 'none'})
+
+        ari = _ari.UndistributedArraysInterface(1, 1)
+        xf_guarded, _, _, _, _, norm_f_guarded, _ = lm.simplish_leastsq(
+            g, gjac, x0.copy(), max_iter=100, arrays_interface=ari, linesearch={'mode': 'guarded'})
+
+        self.assertEqual(norm_f_none, norm_f_guarded)
+        np.testing.assert_array_equal(xf_none, xf_guarded)
+
+    def test_simplerlm_optimizer_linesearch_serialization_roundtrip(self):
+        opt = lm.SimplerLMOptimizer(linesearch={'mode': 'always', 'beta': 0.5, 'max_evals': 3, 'kappa': 2.0})
+        state = opt._to_nice_serialization()
+        opt2 = lm.SimplerLMOptimizer._from_nice_serialization(state)
+        self.assertEqual(opt2.linesearch, {'mode': 'always', 'beta': 0.5, 'max_evals': 3, 'kappa': 2.0})
+
+        # A state dict without the 'linesearch' key (as produced by code predating this feature)
+        # should deserialize to the defaults rather than raising a KeyError.
+        del state['linesearch']
+        opt3 = lm.SimplerLMOptimizer._from_nice_serialization(state)
+        self.assertEqual(opt3.linesearch, {'mode': 'guarded', 'beta': 0.25, 'max_evals': 6, 'kappa': 1.0})
+
+    def test_tol_normalization(self):
+        # A partial `tol` dict should have its missing keys filled with the values a float
+        # tol=1e-6 would have produced, so that `run()`'s direct indexing never KeyErrors.
+        opt = lm.SimplerLMOptimizer(tol={'relf': 1e-5})
+        self.assertEqual(opt.tol, {'relx': 1e-8, 'relf': 1e-5, 'f': 1.0, 'jac': 1e-6, 'maxdx': 1.0})


### PR DESCRIPTION
This PR changes pygsti/optimizers/simplerlm.py.

**Main change**

Adds enumerative line search for the LM optimizer after computing its search direction. We need this because there are times when the norm of the search direction is huge, and existing step-size decision making leads us to jump to a wrong basin. We have to use enumerative search (rather than something fancier) because the 1-dimensional line search problem is likely to have spurious local minima.

The line search is only triggered if the norm of the search direction is sufficiently large relative to the current iterate. The meaning of "sufficient" can be set by a line search parameter. All told there are four parameters controlling line search, packed in a dict.

**Secondary change**

Introduced helper functions to make the inner loop of `simplerlm.py::simplish_leastsq` more readable. The helpers use the `nonlocal` keyword to capture outer-scope variables so that inner-scope assignment writes back to the outer-scope.

**Motivation**

After these changes the Instruments example will actually make sense. (It currently has the optimizer crap out on the CPTPLND parameterization.) It should fix most instances where people had to set small step sizes to avoid wrong-basin problems.