### PR TITLE
Fix trace-preservation check for bases starting with identity

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [0.10.3] - Unreleased
+### Fixed
+* Fixed the trace-preservation check for bases whose first element is the identity.
+
 ## [0.10.2] - 2026-07-30
 
 Bugfix release, plus a line search safeguard for the Levenberg-Marquardt optimizer.

--- a/pygsti/tools/optools.py
+++ b/pygsti/tools/optools.py
@@ -483,7 +483,7 @@ def is_trace_preserving(a: _np.ndarray, mx_basis: BasisLike='pp', tol=1e-8) -> b
     basis = _Basis.cast(mx_basis, dim=dim)
     if basis.first_element_is_identity:
         checkone = _np.isclose(a[0,0], 1.0, rtol=tol, atol=tol)
-        checktwo = _np.allclose(a[1:], 0.0, atol=tol)
+        checktwo = _np.allclose(a[0, 1:], 0.0, atol=tol)
         return checkone and checktwo
     # else, check that the adjoint of a is unital.
     I_mat = _np.eye(udim)


### PR DESCRIPTION
Hi PyGSTi team,

For bases whose first element is the identity, trace preservation requires the first row of the process matrix to be [1, 0, ..., 0].

The previous implementation checked a[1:] instead of a[0, 1:], causing trace-preserving process matrices to be misclassified and potentially selecting incorrect downstream computation paths.

I hope this fix is helpful.