### PR TITLE
Fix ExpErrorgenOp.to_dense to return a unitary when a Hilbert space is requested

### DIFF
--- a/pygsti/modelmembers/operations/experrorgenop.py
+++ b/pygsti/modelmembers/operations/experrorgenop.py
@@ -33,6 +33,7 @@ from pygsti.modelmembers.errorgencontainer import ErrorGeneratorContainer as _Er
 from pygsti.modelmembers.torchable import Torchable as _Torchable
 from pygsti.baseobjs.polynomial import Polynomial as _Polynomial
 from pygsti.baseobjs import _compatibility as _compat
+from pygsti.tools import optools as _ot
 from pygsti import SpaceT
 
 IMAG_TOL = 1e-7  # tolerance for imaginary part being considered zero
@@ -184,17 +185,44 @@ class ExpErrorgenOp(_LinearOperator, _Torchable, _ErrorGeneratorContainer):
         """
         Return this operation as a dense matrix.
 
+        Parameters
+        ----------
+        on_space : {'minimal', 'Hilbert', 'HilbertSchmidt'}
+            The space that the returned dense operation acts upon.  For unitary matrices use
+            `'Hilbert'`; for superoperator matrices use `'HilbertSchmidt'`.  `'minimal'` means
+            that `'Hilbert'` is used if possible given this operator's evolution type, and
+            otherwise `'HilbertSchmidt'` is used.
+
         Returns
         -------
         numpy.ndarray
+
+        Raises
+        ------
+        ValueError
+            If a Hilbert-space (unitary) matrix is requested but this operation does not act
+            unitarily -- i.e. its error generator contains non-Hamiltonian terms.
         """
         if self._rep_type == 'dense':
             # Then self._rep contains a dense version already
-            return self._rep.base  # copy() unnecessary since we set to readonly
-
+            superop = self._rep.base  # copy() unnecessary since we set to readonly
         else:
-            # Construct a dense version from scratch (more time consuming)
-            return _spl.expm(self.errorgen.to_dense(on_space))
+            # Construct a dense version from scratch (more time consuming). Ask the error
+            # generator for a superoperator regardless of `on_space`: an error generator is
+            # never itself unitary (it is the argument of the exponential, not the result), so
+            # LindbladErrorgen.to_dense rejects on_space='Hilbert' outright. Any cast down to a
+            # unitary has to happen after exponentiating, which is what we do below.
+            superop = _spl.expm(self.errorgen.to_dense('HilbertSchmidt'))
+
+        # Attempt to cast down to a unitary, if requested.
+        if on_space == 'Hilbert' or (on_space == 'minimal' and self.evotype.minimal_space == 'Hilbert'):
+            try:
+                return _ot.superop_to_unitary(superop, self.errorgen.matrix_basis, True)
+            except ValueError as e:
+                raise ValueError("Could not convert to unitary. Check that only Hamiltonian "
+                                 "errors are provided.") from e
+
+        return superop
 
     def stateless_data(self, real_dtype: _torch.dtype, device: _torch.Device):
         assert isinstance(self.errorgen, _Torchable)

--- a/test/unit/modelmembers/test_operation.py
+++ b/test/unit/modelmembers/test_operation.py
@@ -716,3 +716,55 @@ class DepolarizeOpTester(BaseCase):
         v = (rho.T @ dop.to_dense() @ rho).item()
         u = float(v)
         self.assertAlmostEqual(u, 0.98)
+
+
+class ExpErrorgenOpToDenseHilbertTester(BaseCase):
+    """`ExpErrorgenOp.to_dense` must return a unitary when a Hilbert space is requested.
+
+    An error generator is never itself unitary -- it is the argument of the exponential, not
+    the result -- so `LindbladErrorgen.to_dense` rejects ``on_space='Hilbert'`` outright. The
+    cast down to a unitary therefore has to happen in `ExpErrorgenOp.to_dense`, after
+    exponentiating.
+    """
+
+    @staticmethod
+    def _exp_errorgen(elementary_errorgens, evotype):
+        errgen = op.LindbladErrorgen.from_elementary_errorgens(
+            elementary_errorgens, evotype=evotype, state_space=1)
+        return op.ExpErrorgenOp(errgen)
+
+    def test_hilbert_evotype_returns_unitary(self):
+        # 'statevec' has minimal_space == 'Hilbert', so both 'minimal' and 'Hilbert' must give
+        # back a 2x2 unitary rather than a 4x4 superoperator.
+        expop = self._exp_errorgen({('H', 'X'): 0.1}, 'statevec')
+        self.assertEqual(expop.evotype.minimal_space, 'Hilbert')
+
+        for on_space in ('minimal', 'Hilbert'):
+            mx = expop.to_dense(on_space)
+            self.assertEqual(mx.shape, (2, 2))
+            self.assertArraysAlmostEqual(mx.conj().T @ mx, np.identity(2))
+
+        # pyGSTi's H generator is H_P[rho] = -i[P, rho], so exp(0.1 * H_X) is the unitary
+        # exp(-0.1i X) = cos(0.1) I - i sin(0.1) X.
+        expected = np.array([[np.cos(0.1), -1j * np.sin(0.1)],
+                             [-1j * np.sin(0.1), np.cos(0.1)]])
+        self.assertArraysAlmostEqual(expop.to_dense('Hilbert'), expected)
+
+    def test_explicit_hilbert_schmidt_still_returns_superop(self):
+        expop = self._exp_errorgen({('H', 'X'): 0.1}, 'statevec')
+        self.assertEqual(expop.to_dense('HilbertSchmidt').shape, (4, 4))
+
+    def test_hilbert_schmidt_evotype_unaffected(self):
+        # 'densitymx' has minimal_space == 'HilbertSchmidt'; 'minimal' must stay a superoperator.
+        expop = self._exp_errorgen({('H', 'X'): 0.1}, 'densitymx')
+        self.assertEqual(expop.evotype.minimal_space, 'HilbertSchmidt')
+        self.assertEqual(expop.to_dense().shape, (4, 4))
+        self.assertEqual(expop.to_dense('minimal').shape, (4, 4))
+
+    def test_non_unitary_errorgen_raises_informative_error(self):
+        # A stochastic error generator does not exponentiate to a unitary, so asking for one
+        # must raise a helpful ValueError rather than an opaque failure.
+        expop = self._exp_errorgen({('S', 'X'): 0.1}, 'densitymx')
+        with self.assertRaises(ValueError) as ctx:
+            expop.to_dense('Hilbert')
+        self.assertIn('Could not convert to unitary', str(ctx.exception))


### PR DESCRIPTION
### Summary

`ExpErrorgenOp.to_dense(on_space='Hilbert')` — and `to_dense()` on any evotype whose `minimal_space` is `'Hilbert'` (e.g. `'statevec'`) — is contractually supposed to return a unitary. On `develop` it does not:

```python
from pygsti.modelmembers.operations import LindbladErrorgen, ExpErrorgenOp

eg = LindbladErrorgen.from_elementary_errorgens({('H','X'): 0.1}, evotype='statevec', state_space=1)
op = ExpErrorgenOp(eg)

op.evotype.minimal_space   # 'Hilbert'
op.to_dense().shape        # (4, 4)  <- a superoperator, not a 2x2 unitary
op.to_dense('Hilbert')     # bare AssertionError from inside LindbladErrorgen.to_dense
```

The `to_dense()` case is the worse of the two: it silently returns an object of the wrong space and shape rather than failing.

### Root cause

The cast down to a unitary is attempted in the wrong class, and currently in neither. An error generator is never itself unitary — it is the argument of the exponential, not the result — so `LindbladErrorgen.to_dense` correctly refuses `on_space='Hilbert'`:

```python
assert(on_space in ('minimal', 'HilbertSchmidt'))
```

But `ExpErrorgenOp.to_dense` forwarded its `on_space` straight through to the error generator and returned `expm(...)` unchanged, so the only place that could legitimately produce a unitary — *after* exponentiating — never tried to.

### The fix

- Ask the error generator for a `'HilbertSchmidt'` superoperator explicitly, instead of forwarding `on_space` and tripping the assert above.
- After exponentiating, cast down via `optools.superop_to_unitary` when a Hilbert space was requested, re-raising its `ValueError` with an actionable message when the operation isn't unitary (i.e. the error generator has non-Hamiltonian terms).
- Document `on_space` and add a `Raises` clause; the docstring previously described neither.

### Provenance — this is not new work

This is commit 0bdbb2830 by @sserita, *"Convert ExpErrorgenOp, not LindbladErrorgen, to unitary"* (Jul 2024), which moved this capability out of `LindbladErrorgen` into `ExpErrorgenOp`. That commit is an ancestor of the `feature-ml-*` branches only — **not** of `develop`, `beta`, or `master`:

```
$ git branch -r --contains 0bdbb2830
  origin/feature-ml-errorgenprop-refactor
  origin/feature-ml-rewrite
  origin/feature-ml-rewrite-noah
  origin/noah-feature-ml
```

So `develop` received neither half of that move. I found it riding along inside the QPANN PR (#835) and am extracting it here, with tests and a docstring added, so it can be reviewed on its own merits rather than as unrelated scope inside a large feature PR. Deleting it from #835 in the same pass.

### Correctness check

pyGSTi's Hamiltonian generator is `H_P[ρ] = -i[P, ρ]`, so `exp(0.1 · H_X)` must equal `exp(-0.1i·X) = cos(0.1)·I − i·sin(0.1)·X`. The returned 2×2 matrix matches to numerical precision.

### Tests

Adds `ExpErrorgenOpToDenseHilbertTester` to `test/unit/modelmembers/test_operation.py`:

| test | asserts |
|---|---|
| `test_hilbert_evotype_returns_unitary` | `'minimal'` and `'Hilbert'` both give a 2×2 unitary, matching the closed form above |
| `test_explicit_hilbert_schmidt_still_returns_superop` | `'HilbertSchmidt'` still returns the 4×4 superoperator |
| `test_hilbert_schmidt_evotype_unaffected` | `'densitymx'` (`minimal_space == 'HilbertSchmidt'`) is untouched |
| `test_non_unitary_errorgen_raises_informative_error` | a stochastic generator raises the informative `ValueError` |

The first and last were confirmed to fail against the unfixed code.

### Verification

- `test/unit/modelmembers` — 734 passed
- `test/unit/objects` + `test/unit/tools` — 1452 passed
- full `test/unit` with CI's own `-m "not slow"` filter — the only failure is `test_gst.py::GateSetTomographyTester::test_run_with_no_gaugeoptsuite`, which I confirmed **fails identically on a pristine `develop` worktree** and is unrelated to this change.
- `flake8 --config=.flake8-critical` — clean.